### PR TITLE
feat: add docker-compose for local development

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,13 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/codeq-server ./cmd/server"
+  bin = "tmp/codeq-server"
+  delay = 500
+  exclude_dir = ["tmp", "vendor", "node_modules", "deploy", "docs", "wiki", "examples", "sdks"]
+  include_ext = ["go"]
+
+[log]
+  time = true
+

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Local development defaults for docker-compose.
+#
+# Copy to .env if you want to customize values locally.
+
+CODEQ_PORT=8080
+KVROCKS_PORT=6666
+
+# Used by the seed container to call the API.
+CODEQ_PRODUCER_TOKEN=dev-token
+
+# Local/dev auth: static bearer tokens (see pkg/auth/static).
+PRODUCER_AUTH_PROVIDER=static
+PRODUCER_AUTH_CONFIG={"token":"dev-token","subject":"producer-dev","email":"dev@codeq.local","raw":{"role":"ADMIN"}}
+
+WORKER_AUTH_PROVIDER=static
+WORKER_AUTH_CONFIG={"token":"dev-token","subject":"worker-dev","scopes":["codeq:claim","codeq:heartbeat","codeq:abandon","codeq:nack","codeq:result","codeq:subscribe"],"eventTypes":["*"]}
+
+# Optional observability stack (docker compose --profile obs up -d)
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+GRAFANA_USER=admin
+GRAFANA_PASS=admin
+JAEGER_UI_PORT=16686
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ go.work.sum
 .idea
 .env
 .DS_Store
+tmp/
+.artifacts/
 
 # npm installer output (native binaries downloaded at install time)
 npm/native/

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/jwks"   // Register default JWKS auth provider
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/static" // Register static token auth provider (dev/local)
+	"github.com/osvaldoandrade/codeq/pkg/config"
+
+	"github.com/osvaldoandrade/codeq/pkg/app"
+)
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	cfgPath := getenv("CODEQ_CONFIG_PATH", "")
+
+	cfg, err := config.LoadConfigOptional(cfgPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "[ERROR] load config:", err)
+		os.Exit(1)
+	}
+	if err := cfg.Validate(); err != nil {
+		fmt.Fprintln(os.Stderr, "[ERROR] invalid config:", err)
+		os.Exit(1)
+	}
+
+	application, err := app.NewApplication(cfg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "[ERROR] init app:", err)
+		os.Exit(1)
+	}
+	app.SetupMappings(application)
+
+	addr := fmt.Sprintf(":%d", cfg.Port)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           application.Engine,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			fmt.Fprintln(os.Stderr, "[ERROR] http server:", err)
+			os.Exit(1)
+		}
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(ctx)
+}

--- a/deploy/docker-compose/local-dev/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/docker-compose/local-dev/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: codeq
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: true
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+

--- a/deploy/docker-compose/local-dev/grafana/provisioning/datasources/datasources.yml
+++ b/deploy/docker-compose/local-dev/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+

--- a/deploy/docker-compose/local-dev/prometheus.yml
+++ b/deploy/docker-compose/local-dev/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["prometheus:9090"]
+
+  - job_name: "codeq"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["codeq:8080"]
+

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  codeq:
+    volumes:
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+      - ./.artifacts:/app/.artifacts
+    command: ["sh", "-c", "go mod download && go install github.com/air-verse/air@latest && air -c .air.toml"]
+
+volumes:
+  go-mod-cache:
+  go-build-cache:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,102 @@
+version: "3.8"
+
+services:
+  kvrocks:
+    image: apache/kvrocks:latest
+    ports:
+      - "${KVROCKS_PORT:-6666}:6666"
+    volumes:
+      - kvrocks-data:/var/lib/kvrocks
+    restart: unless-stopped
+
+  codeq:
+    image: golang:1.23
+    working_dir: /app
+    volumes:
+      - ./:/app
+    ports:
+      - "${CODEQ_PORT:-8080}:8080"
+    environment:
+      - PORT=8080
+      - REDIS_ADDR=kvrocks:6666
+      - REDIS_PASSWORD=
+      - ENV=dev
+      - LOG_LEVEL=debug
+      - LOG_FORMAT=text
+      - LOCAL_ARTIFACTS_DIR=/app/.artifacts
+      - PRODUCER_AUTH_PROVIDER=${PRODUCER_AUTH_PROVIDER:-static}
+      - PRODUCER_AUTH_CONFIG=${PRODUCER_AUTH_CONFIG:-{"token":"dev-token","subject":"producer-dev","email":"dev@codeq.local","raw":{"role":"ADMIN"}}}
+      - WORKER_AUTH_PROVIDER=${WORKER_AUTH_PROVIDER:-static}
+      - WORKER_AUTH_CONFIG=${WORKER_AUTH_CONFIG:-{"token":"dev-token","subject":"worker-dev","scopes":["codeq:claim","codeq:heartbeat","codeq:abandon","codeq:nack","codeq:result","codeq:subscribe"],"eventTypes":["*"]}}
+    depends_on:
+      - kvrocks
+    command: ["sh", "-c", "go run ./cmd/server"]
+    restart: unless-stopped
+
+  seed:
+    image: curlimages/curl:8.6.0
+    depends_on:
+      - codeq
+    environment:
+      - CODEQ_BASE_URL=http://codeq:8080
+      - CODEQ_PRODUCER_TOKEN=${CODEQ_PRODUCER_TOKEN:-dev-token}
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        echo "[seed] waiting for codeq..."
+        until curl -sf "$${CODEQ_BASE_URL}/metrics" >/dev/null; do sleep 1; done
+        echo "[seed] creating example tasks..."
+        curl -sf -X POST "$${CODEQ_BASE_URL}/v1/codeq/tasks" \
+          -H "Authorization: Bearer $${CODEQ_PRODUCER_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -d '{"command":"GENERATE_MASTER","payload":{"seed":true,"n":1},"priority":0,"idempotencyKey":"seed-gm-1"}' >/dev/null
+        curl -sf -X POST "$${CODEQ_BASE_URL}/v1/codeq/tasks" \
+          -H "Authorization: Bearer $${CODEQ_PRODUCER_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -d '{"command":"GENERATE_MASTER","payload":{"seed":true,"n":2},"priority":0,"idempotencyKey":"seed-gm-2"}' >/dev/null
+        curl -sf -X POST "$${CODEQ_BASE_URL}/v1/codeq/tasks" \
+          -H "Authorization: Bearer $${CODEQ_PRODUCER_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -d '{"command":"GENERATE_CREATIVE","payload":{"seed":true,"n":1},"priority":0,"idempotencyKey":"seed-gc-1"}' >/dev/null
+        echo "[seed] done"
+    restart: "no"
+
+  prometheus:
+    profiles: ["obs"]
+    image: prom/prometheus:v2.49.1
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    volumes:
+      - ./deploy/docker-compose/local-dev/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      - codeq
+    restart: unless-stopped
+
+  grafana:
+    profiles: ["obs"]
+    image: grafana/grafana:10.3.1
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASS:-admin}
+    volumes:
+      - ./deploy/docker-compose/local-dev/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./docs/grafana:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  jaeger:
+    profiles: ["obs"]
+    image: jaegertracing/all-in-one:1.55
+    ports:
+      - "${JAEGER_UI_PORT:-16686}:16686"
+      - "4317:4317"
+      - "4318:4318"
+    restart: unless-stopped
+
+volumes:
+  kvrocks-data:

--- a/docs/15-local-development.md
+++ b/docs/15-local-development.md
@@ -1,0 +1,82 @@
+# Local Development (docker-compose)
+
+This guide sets up a full local environment for codeQ development using Docker Compose:
+
+- KVRocks (Redis-compatible)
+- codeQ API server (runs from source, with hot reload)
+- Optional: Prometheus + Grafana + Jaeger (`--profile obs`)
+
+## Quick Start
+
+1. Create your local env file (optional):
+
+````bash
+cp .env.example .env
+````
+
+2. Start everything:
+
+````bash
+docker compose up -d
+````
+
+3. Verify:
+
+````bash
+curl -sSf http://localhost:8080/metrics | head
+````
+
+4. Watch logs:
+
+````bash
+docker compose logs -f codeq
+````
+
+5. Stop:
+
+````bash
+docker compose down
+````
+
+## Hot Reload
+
+`docker-compose.override.yml` runs the API server via `air` using `.air.toml`.
+Any change under `./internal`, `./pkg`, `./cmd`, etc should trigger a rebuild/restart.
+
+## Seeded Example Tasks
+
+The `seed` service creates a few tasks on startup (idempotent via `idempotencyKey`).
+
+Check queue stats (uses the static dev token by default):
+
+````bash
+TOKEN="${CODEQ_PRODUCER_TOKEN:-dev-token}"
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8080/v1/codeq/admin/queues | jq .
+````
+
+## Run Tests Inside the Container
+
+````bash
+docker compose exec codeq go test ./...
+````
+
+## Optional Observability Stack (Prometheus + Grafana + Jaeger)
+
+Start with the `obs` profile:
+
+````bash
+docker compose --profile obs up -d
+````
+
+Then open:
+
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3000` (default user/pass: `admin` / `admin`)
+- Jaeger UI: `http://localhost:16686`
+
+Grafana auto-provisions:
+
+- Prometheus datasource (`http://prometheus:9090`)
+- Dashboard JSON from `docs/grafana/codeq-dashboard.json`
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This specification defines codeQ, a reactive scheduling and completion system bu
 
 13. `docs/13-examples.md` - Usage examples and common patterns
 14. `docs/14-configuration.md` - Configuration reference
+15. `docs/15-local-development.md` - Local development with docker-compose
 15. `docs/15-cli-reference.md` - Complete CLI command reference
 
 ### Technical Reference (Information-Oriented)

--- a/pkg/auth/static/validator.go
+++ b/pkg/auth/static/validator.go
@@ -1,0 +1,92 @@
+package static
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/osvaldoandrade/codeq/pkg/auth"
+)
+
+type validatorConfig struct {
+	// Token is the exact bearer token value expected by this validator.
+	Token string `json:"token"`
+
+	// Subject is returned as claims.Subject.
+	Subject string `json:"subject,omitempty"`
+
+	// Email is returned as claims.Email (producer auth).
+	Email string `json:"email,omitempty"`
+
+	// Scopes is returned as claims.Scopes (worker auth scope checks).
+	Scopes []string `json:"scopes,omitempty"`
+
+	// EventTypes is returned as claims.EventTypes (worker claim authorization).
+	EventTypes []string `json:"eventTypes,omitempty"`
+
+	// Raw is returned as claims.Raw (used for role-based checks, etc).
+	Raw map[string]any `json:"raw,omitempty"`
+}
+
+type validator struct {
+	cfg validatorConfig
+}
+
+func NewValidatorFromJSON(raw json.RawMessage) (auth.Validator, error) {
+	raw = json.RawMessage(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 {
+		return nil, errors.New("static auth: missing config")
+	}
+
+	var cfg validatorConfig
+	// Allow config to be either:
+	// - JSON object: {"token":"...","subject":"..."}
+	// - JSON string: "token-value"
+	if raw[0] == '"' {
+		if err := json.Unmarshal(raw, &cfg.Token); err != nil {
+			return nil, fmtError("static auth: invalid config", err)
+		}
+	} else {
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return nil, fmtError("static auth: invalid config", err)
+		}
+	}
+
+	cfg.Token = strings.TrimSpace(cfg.Token)
+	if cfg.Token == "" {
+		return nil, errors.New("static auth: token is required")
+	}
+	cfg.Subject = strings.TrimSpace(cfg.Subject)
+	if cfg.Subject == "" {
+		cfg.Subject = "static"
+	}
+	if cfg.Raw == nil {
+		cfg.Raw = map[string]any{}
+	}
+
+	return &validator{cfg: cfg}, nil
+}
+
+func (v *validator) Validate(token string) (*auth.Claims, error) {
+	if strings.TrimSpace(token) != v.cfg.Token {
+		return nil, errors.New("invalid token")
+	}
+	return &auth.Claims{
+		Subject:    v.cfg.Subject,
+		Email:      v.cfg.Email,
+		Scopes:     v.cfg.Scopes,
+		EventTypes: v.cfg.EventTypes,
+		Raw:        v.cfg.Raw,
+	}, nil
+}
+
+func init() {
+	auth.RegisterProvider("static", NewValidatorFromJSON)
+}
+
+func fmtError(msg string, err error) error {
+	if err == nil {
+		return errors.New(msg)
+	}
+	return errors.New(msg + ": " + err.Error())
+}

--- a/pkg/auth/static/validator_test.go
+++ b/pkg/auth/static/validator_test.go
@@ -1,0 +1,46 @@
+package static
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStaticValidator(t *testing.T) {
+	raw := json.RawMessage(`{"token":"t-1","subject":"s-1","email":"e@local","scopes":["codeq:claim"],"eventTypes":["*"],"raw":{"role":"ADMIN"}}`)
+	v, err := NewValidatorFromJSON(raw)
+	if err != nil {
+		t.Fatalf("NewValidatorFromJSON: %v", err)
+	}
+
+	claims, err := v.Validate("t-1")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims.Subject != "s-1" {
+		t.Fatalf("expected subject s-1, got %q", claims.Subject)
+	}
+	if claims.Email != "e@local" {
+		t.Fatalf("expected email e@local, got %q", claims.Email)
+	}
+	if !claims.HasScope("codeq:claim") {
+		t.Fatalf("expected scope present")
+	}
+	if len(claims.EventTypes) != 1 || claims.EventTypes[0] != "*" {
+		t.Fatalf("expected wildcard eventTypes, got %v", claims.EventTypes)
+	}
+
+	if _, err := v.Validate("wrong"); err == nil {
+		t.Fatalf("expected validation error for wrong token")
+	}
+}
+
+func TestStaticValidator_StringConfig(t *testing.T) {
+	raw := json.RawMessage(`"t-2"`)
+	v, err := NewValidatorFromJSON(raw)
+	if err != nil {
+		t.Fatalf("NewValidatorFromJSON: %v", err)
+	}
+	if _, err := v.Validate("t-2"); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #34

## What
- Adds a local API server entrypoint at `cmd/server` so the codeQ API can run directly from this repo.
- Adds root `docker-compose.yml` + `docker-compose.override.yml` for local dev (KVRocks + codeQ).
- Enables hot reload via `air` (`.air.toml`) when using the default override.
- Seeds a few example tasks on startup (idempotent via `idempotencyKey`).
- Optional observability stack via `--profile obs` (Prometheus + Grafana + Jaeger) with Grafana auto-provisioning the example dashboard from `docs/grafana/codeq-dashboard.json`.

## How To Use
```bash
docker compose up -d
docker compose --profile obs up -d
docker compose exec codeq go test ./...
```

Docs: `docs/15-local-development.md`
