### PR TITLE
perf: speed up admin cleanup with DLQ SET + task location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ BREAKING CHANGES
+
+#### DLQ Data Structure Change
+
+The DLQ queue has been changed from a Redis LIST to a SET to achieve O(1) removal performance during admin cleanup.
+
+**What changed:**
+- `codeq:q:<command>:dlq` is now a SET (previously LIST)
+- DLQ enqueue uses `SADD` (previously `LPUSH`)
+- DLQ depth uses `SCARD` (previously `LLEN`)
+- DLQ cleanup uses `SREM` O(1) (previously `LREM` O(N))
+
+**Migration required:**
+- **Recommended**: Drain DLQ before upgrading
+- **Alternative**: Convert existing LIST → SET during freeze window (rename list to a temp key, then `SADD` members)
+
+### Performance Improvements
+
+- **Faster admin cleanup**: tasks now track an optional `lastKnownLocation` to avoid unnecessary O(N) list scans during `CleanupExpired`.
+
 ## [1.1.0] - 2026-02-15
 
 ### ⚠️ BREAKING CHANGES

--- a/docs/07-storage-kvrocks.md
+++ b/docs/07-storage-kvrocks.md
@@ -12,7 +12,7 @@ All keys are prefixed with `codeq:`.
 - `codeq:q:<command>:<tenantID>:pending:<priority>` (list)
 - `codeq:q:<command>:<tenantID>:inprog` (set)
 - `codeq:q:<command>:<tenantID>:delayed` (ZSET)
-- `codeq:q:<command>:<tenantID>:dlq` (list)
+- `codeq:q:<command>:<tenantID>:dlq` (set)
 - `codeq:lease:<id>` (string)
 - `codeq:idempo:<key>` (string)
 - `codeq:subs:<event>` (ZSET): webhook subscriptions with TTL score
@@ -29,8 +29,8 @@ The tenant ID segment is omitted for backward compatibility when `tenantID` is e
 ## Command usage
 
 - Hash: `HSET`, `HGET`, `HDEL`
-- Lists: `LPUSH`, `RPOP`, `LLEN`, `LREM` (pending + dlq)
-- Sets: `SADD`, `SREM`, `SCARD`, `SRANDMEMBER` (in-progress tracking)
+- Lists: `LPUSH`, `RPOP`, `LLEN`, `LREM` (pending)
+- Sets: `SADD`, `SREM`, `SCARD`, `SRANDMEMBER` (in-progress tracking + DLQ)
 - ZSET: `ZADD`, `ZRANGEBYSCORE`, `ZREM`
 - Keys: `SETEX`, `TTL`, `EXPIRE`, `DEL`
 - Lua: `EVAL` (atomic claim move: `RPOP` + `SADD`)

--- a/docs/21-developer-guide.md
+++ b/docs/21-developer-guide.md
@@ -255,7 +255,7 @@ func main() {
 - `codeq:q:<command>:pending:<priority>` (list)
 - `codeq:q:<command>:inprog` (set)
 - `codeq:q:<command>:delayed` (ZSET) score = `visibleAt` epoch seconds
-- `codeq:q:<command>:dlq` (list)
+- `codeq:q:<command>:dlq` (set)
 
 **Atomic claim operation:**
 
@@ -450,12 +450,13 @@ redis-cli -h localhost -p 6666
 # List all keys
 KEYS codeq:*
 
-# Inspect queues (example: GENERATE_MASTER)
-LLEN codeq:q:generate_master:pending:0
-SCARD codeq:q:generate_master:inprog
-SMEMBERS codeq:q:generate_master:inprog
-ZRANGE codeq:q:generate_master:delayed 0 -1 WITHSCORES
-LRANGE codeq:q:generate_master:dlq 0 -1
+	# Inspect queues (example: GENERATE_MASTER)
+	LLEN codeq:q:generate_master:pending:0
+	SCARD codeq:q:generate_master:inprog
+	SMEMBERS codeq:q:generate_master:inprog
+	ZRANGE codeq:q:generate_master:delayed 0 -1 WITHSCORES
+	SCARD codeq:q:generate_master:dlq
+	SSCAN codeq:q:generate_master:dlq 0 COUNT 100
 
 # Get task details
 HGET codeq:tasks 550e8400-e29b-41d4-a716-446655440000

--- a/internal/metrics/redis_collector.go
+++ b/internal/metrics/redis_collector.go
@@ -85,7 +85,7 @@ func (c *redisCollector) Collect(ch chan<- prometheus.Metric) {
 		readyCmds[cmd] = llens
 		inprogCmds[cmd] = pipe.SCard(ctx, keyQueueInprog(cmd))
 		delayedCmds[cmd] = pipe.ZCard(ctx, keyQueueDelayed(cmd))
-		dlqCmds[cmd] = pipe.LLen(ctx, keyQueueDLQ(cmd))
+		dlqCmds[cmd] = pipe.SCard(ctx, keyQueueDLQ(cmd))
 		subsCmds[cmd] = pipe.ZCount(ctx, keySubsEvent(cmd), minScore, "+inf")
 	}
 

--- a/internal/repository/result_repository.go
+++ b/internal/repository/result_repository.go
@@ -111,6 +111,7 @@ func (r *resultRedisRepo) UpdateTaskOnComplete(ctx context.Context, id string, s
 		return fmt.Errorf("unmarshal task: %w", err)
 	}
 	t.Status = status
+	t.LastKnownLocation = domain.LocationNone
 	t.WorkerID = ""
 	t.LeaseUntil = ""
 	t.UpdatedAt = r.now()

--- a/pkg/domain/task.go
+++ b/pkg/domain/task.go
@@ -21,22 +21,34 @@ const (
 	StatusFailed     TaskStatus = "FAILED"
 )
 
+type TaskLocation string
+
+const (
+	LocationPending    TaskLocation = "PENDING_LIST"
+	LocationDelayed    TaskLocation = "DELAYED_ZSET"
+	LocationInProgress TaskLocation = "INPROG_SET"
+	LocationDLQ        TaskLocation = "DLQ_SET"
+	LocationNone       TaskLocation = "NONE"
+)
+
 type Task struct {
-	ID          string     `json:"id"`
-	Command     Command    `json:"command"`
-	Payload     string     `json:"payload"` // JSON string opaco
-	Priority    int        `json:"priority,omitempty"`
-	Webhook     string     `json:"webhook,omitempty"`
-	Status      TaskStatus `json:"status"`
-	WorkerID    string     `json:"workerId,omitempty"`
-	LeaseUntil  string     `json:"leaseUntil,omitempty"` // RFC3339
-	Attempts    int        `json:"attempts,omitempty"`
-	MaxAttempts int        `json:"maxAttempts,omitempty"`
-	Error       string     `json:"error,omitempty"`
-	ResultKey   string     `json:"resultKey,omitempty"`
-	TenantID    string     `json:"tenantId,omitempty"` // Tenant isolation
-	CreatedAt   time.Time  `json:"createdAt"`
-	UpdatedAt   time.Time  `json:"updatedAt"`
+	ID       string     `json:"id"`
+	Command  Command    `json:"command"`
+	Payload  string     `json:"payload"` // JSON string opaco
+	Priority int        `json:"priority,omitempty"`
+	Webhook  string     `json:"webhook,omitempty"`
+	Status   TaskStatus `json:"status"`
+	// lastKnownLocation is a hint for targeted admin cleanup; it is not authoritative.
+	LastKnownLocation TaskLocation `json:"lastKnownLocation,omitempty"`
+	WorkerID          string       `json:"workerId,omitempty"`
+	LeaseUntil        string       `json:"leaseUntil,omitempty"` // RFC3339
+	Attempts          int          `json:"attempts,omitempty"`
+	MaxAttempts       int          `json:"maxAttempts,omitempty"`
+	Error             string       `json:"error,omitempty"`
+	ResultKey         string       `json:"resultKey,omitempty"`
+	TenantID          string       `json:"tenantId,omitempty"` // Tenant isolation
+	CreatedAt         time.Time    `json:"createdAt"`
+	UpdatedAt         time.Time    `json:"updatedAt"`
 }
 
 var (

--- a/wiki/Storage-KVRocks.md
+++ b/wiki/Storage-KVRocks.md
@@ -1,6 +1,6 @@
 # Storage layout (KVRocks)
 
-KVRocks implements the Redis protocol and persists to disk. codeQ uses lists, hashes, sorted sets, and TTL keys. Each operation is atomic at the command level.
+KVRocks implements the Redis protocol and persists to disk. codeQ uses lists, hashes, sorted sets, sets, and TTL keys. Each operation is atomic at the command level.
 
 ## Keyspace
 
@@ -12,7 +12,7 @@ All keys are prefixed with `codeq:`.
 - `codeq:q:<command>:pending:<priority>` (list)
 - `codeq:q:<command>:inprog` (set)
 - `codeq:q:<command>:delayed` (ZSET)
-- `codeq:q:<command>:dlq` (list)
+- `codeq:q:<command>:dlq` (set)
 - `codeq:lease:<id>` (string)
 - `codeq:idempo:<key>` (string)
 - `codeq:subs:<event>` (ZSET): webhook subscriptions with TTL score
@@ -20,8 +20,8 @@ All keys are prefixed with `codeq:`.
 ## Command usage
 
 - Hash: `HSET`, `HGET`, `HDEL`
-- Lists: `LPUSH`, `RPOP`, `LLEN`, `LREM` (pending + dlq)
-- Sets: `SADD`, `SREM`, `SCARD`, `SRANDMEMBER` (in-progress tracking)
+- Lists: `LPUSH`, `RPOP`, `LLEN`, `LREM` (pending)
+- Sets: `SADD`, `SREM`, `SCARD`, `SRANDMEMBER` (in-progress tracking + DLQ)
 - ZSET: `ZADD`, `ZRANGEBYSCORE`, `ZREM`
 - Keys: `SETEX`, `TTL`, `EXPIRE`, `DEL`
 - Lua: `EVAL` (atomic claim move: `RPOP` + `SADD`)

--- a/wiki/Use-Cases-Admin-Cleanup.md
+++ b/wiki/Use-Cases-Admin-Cleanup.md
@@ -34,7 +34,7 @@ sequenceDiagram
   loop for each task up to limit
     Q->>K: HDEL tasks + HDEL results
     Q->>K: DEL lease + DEL idempo
-    Q->>K: LREM pending + SREM inprog + ZREM delayed + LREM dlq
+    Q->>K: LREM pending + SREM inprog + ZREM delayed + SREM dlq
     Q->>K: ZREM tasks:ttl
   end
   Q-->>O: 200 OK (summary)


### PR DESCRIPTION
Closes #46

### What changed
- DLQ is now a SET (`SADD/SCARD/SREM`) so admin cleanup can remove task IDs in O(1).
- Tasks now persist `lastKnownLocation` and `CleanupExpired` uses it to avoid unnecessary `LREM` scans on pending lists.
- Updated docs/wiki + changelog, plus tests.

### Migration note
If you already have `codeq:q:<command>:dlq` stored as a LIST, drain/convert before upgrade (see `docs/migration.md`).