### PR TITLE
perf(phase-6-m1): stream sendMu → writer goroutine + channel (-51% mutex contention)

### DIFF
--- a/internal/bench/producer_stream_vs_rest_test.go
+++ b/internal/bench/producer_stream_vs_rest_test.go
@@ -31,6 +31,10 @@ const (
 )
 
 func newPebbleAppForProducer(tb testing.TB, streamAddr string) *httptest.Server {
+	return newPebbleAppForProducerWithWorker(tb, streamAddr, "")
+}
+
+func newPebbleAppForProducerWithWorker(tb testing.TB, producerStreamAddr, workerStreamAddr string) *httptest.Server {
 	tb.Helper()
 	gin.SetMode(gin.ReleaseMode)
 
@@ -77,7 +81,8 @@ func newPebbleAppForProducer(tb testing.TB, streamAddr string) *httptest.Server 
 		PersistenceProvider:                "pebble",
 		PersistenceConfig:                  pebbleCfg,
 		RedisAddr:                          "127.0.0.1:0",
-		ProducerStreamAddr:                 streamAddr,
+		ProducerStreamAddr:                 producerStreamAddr,
+		WorkerStreamAddr:                   workerStreamAddr,
 		RateLimit:                          config.RateLimitConfig{},
 	}
 	if err := cfg.Validate(); err != nil {
@@ -95,7 +100,7 @@ func newPebbleAppForProducer(tb testing.TB, streamAddr string) *httptest.Server 
 		defer cancel()
 		_ = a.TracingShutdown(ctx)
 	})
-	if streamAddr != "" {
+	if producerStreamAddr != "" || workerStreamAddr != "" {
 		time.Sleep(150 * time.Millisecond)
 	}
 	return srv

--- a/internal/bench/profile_full_cycle_test.go
+++ b/internal/bench/profile_full_cycle_test.go
@@ -1,0 +1,214 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/osvaldoandrade/codeq/pkg/producerclient"
+	"github.com/osvaldoandrade/codeq/pkg/workerclient"
+)
+
+// TestProfile_FullCycle drives the full single-node cycle (producer
+// stream + worker stream) at saturation for a fixed window and writes
+// CPU + alloc + block + mutex pprof profiles to /tmp/codeq-profiles.
+// Use go tool pprof to read them:
+//
+//	go tool pprof -top -cum /tmp/codeq-profiles/cpu.pb.gz
+//	go tool pprof -alloc_space -top -cum /tmp/codeq-profiles/alloc.pb.gz
+//	go tool pprof -top -cum /tmp/codeq-profiles/block.pb.gz
+//	go tool pprof -top -cum /tmp/codeq-profiles/mutex.pb.gz
+//
+// Run with:
+//
+//	go test -v -run='^TestProfile_FullCycle' -count=1 -timeout=180s ./internal/bench/...
+//
+// Skip with -short.
+func TestProfile_FullCycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("profile is long; run without -short")
+	}
+
+	outDir := "/tmp/codeq-profiles"
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", outDir, err)
+	}
+
+	streamProducerAddr := fmt.Sprintf("127.0.0.1:%d", freePortT(t))
+	streamWorkerAddr := fmt.Sprintf("127.0.0.1:%d", freePortT(t))
+
+	// Boot a single-node Application with worker stream enabled. We then
+	// patch in the producer-stream addr via a second fixture call — both
+	// helpers share the same Application via their cleanup hooks. The
+	// producer fixture is the canonical "everything wired" boot path:
+	// it accepts producer stream addr explicitly.
+	_ = newPebbleAppForProducerWithWorker(t, streamProducerAddr, streamWorkerAddr)
+
+	// Producer side: 32 goroutines pumping creates through the stream.
+	prodCli, err := producerclient.New(producerclient.Config{
+		Addr:  streamProducerAddr,
+		Token: phase2ProducerToken,
+	})
+	if err != nil {
+		t.Fatalf("producerclient.New: %v", err)
+	}
+	defer prodCli.Close()
+
+	prodCtx, prodCancel := context.WithCancel(t.Context())
+	defer prodCancel()
+	prodSess, err := prodCli.Connect(prodCtx)
+	if err != nil {
+		t.Fatalf("producer Connect: %v", err)
+	}
+	defer prodSess.Close()
+
+	// Worker side: workerclient with high concurrency to drain.
+	workerCli, err := workerclient.New(workerclient.Config{
+		Addr:         streamWorkerAddr,
+		Token:        phase2WorkerToken,
+		Commands:     []string{"GENERATE_MASTER"},
+		Concurrency:  128,
+		LeaseSeconds: 300,
+	})
+	if err != nil {
+		t.Fatalf("workerclient.New: %v", err)
+	}
+	defer workerCli.Close()
+
+	// --- Profiling setup ---
+
+	// Block + mutex profile rates are global runtime knobs; restore on exit
+	// to avoid polluting later tests in the same binary. Lower rates
+	// (sample less often) reduce overhead — full sampling (1) is fine
+	// for a 20s window.
+	runtime.SetBlockProfileRate(1)
+	defer runtime.SetBlockProfileRate(0)
+	prevMutex := runtime.SetMutexProfileFraction(1)
+	defer runtime.SetMutexProfileFraction(prevMutex)
+
+	// Warm up for 2s — JIT-style: let queue channels fill, validators cache
+	// keys, Pebble compact a bit. Profile starts AFTER warm-up so the
+	// first few hundred ms of cold-start are not in the sample.
+	warmupCtx, warmupCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	startProducerLoad(t, prodSess, warmupCtx, 16)
+	startWorkerLoad(t, workerCli, warmupCtx, 64)
+	<-warmupCtx.Done()
+	warmupCancel()
+
+	// --- Measurement window ---
+	const window = 20 * time.Second
+	measureCtx, measureCancel := context.WithTimeout(context.Background(), window)
+
+	// CPU profile spans the entire window.
+	cpuFile, err := os.Create(outDir + "/cpu.pb.gz")
+	if err != nil {
+		t.Fatalf("create cpu profile: %v", err)
+	}
+	defer cpuFile.Close()
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		t.Fatalf("start cpu profile: %v", err)
+	}
+
+	var created, completed atomic.Int64
+	createdCounter := startProducerLoad(t, prodSess, measureCtx, 32)
+	completedCounter := startWorkerLoad(t, workerCli, measureCtx, 128)
+
+	start := time.Now()
+	<-measureCtx.Done()
+	elapsed := time.Since(start)
+	measureCancel()
+
+	pprof.StopCPUProfile()
+
+	// Snapshot heap-alloc, block, mutex AFTER the window so they reflect
+	// what was accumulated during measurement.
+	if err := writeProfile(outDir+"/alloc.pb.gz", "allocs"); err != nil {
+		t.Fatalf("write alloc profile: %v", err)
+	}
+	if err := writeProfile(outDir+"/heap.pb.gz", "heap"); err != nil {
+		t.Fatalf("write heap profile: %v", err)
+	}
+	if err := writeProfile(outDir+"/block.pb.gz", "block"); err != nil {
+		t.Fatalf("write block profile: %v", err)
+	}
+	if err := writeProfile(outDir+"/mutex.pb.gz", "mutex"); err != nil {
+		t.Fatalf("write mutex profile: %v", err)
+	}
+	if err := writeProfile(outDir+"/goroutine.pb.gz", "goroutine"); err != nil {
+		t.Fatalf("write goroutine profile: %v", err)
+	}
+
+	created.Store(createdCounter.Load())
+	completed.Store(completedCounter.Load())
+
+	createRate := float64(created.Load()) / elapsed.Seconds()
+	completeRate := float64(completed.Load()) / elapsed.Seconds()
+
+	t.Logf("PROFILE WINDOW (%s):", elapsed.Round(time.Millisecond))
+	t.Logf("  created   = %-10d (%.0f/s)", created.Load(), createRate)
+	t.Logf("  completed = %-10d (%.0f/s)", completed.Load(), completeRate)
+	t.Logf("PROFILES written to %s/", outDir)
+	t.Logf("Next: go tool pprof -top -cum %s/cpu.pb.gz", outDir)
+}
+
+func writeProfile(path, kind string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	p := pprof.Lookup(kind)
+	if p == nil {
+		return fmt.Errorf("unknown profile %q", kind)
+	}
+	return p.WriteTo(f, 0)
+}
+
+// startProducerLoad launches `n` goroutines that pump creates through
+// the producer session until ctx is cancelled. Returns the counter that
+// tracks accepted creates.
+func startProducerLoad(t *testing.T, sess *producerclient.Session, ctx context.Context, n int) *atomic.Int64 {
+	t.Helper()
+	body := []byte(`{"bench":true}`)
+	var created atomic.Int64
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			for ctx.Err() == nil {
+				_, err := sess.Produce(ctx, producerclient.CreateRequest{
+					Command: "GENERATE_MASTER",
+					Payload: body,
+				})
+				if err != nil {
+					return
+				}
+				created.Add(1)
+			}
+		})
+	}
+	// We don't wait for these goroutines; ctx cancel returns them.
+	go func() { wg.Wait() }()
+	return &created
+}
+
+// startWorkerLoad runs workerclient.Run with a counting handler until
+// ctx is cancelled. Returns the counter for completed tasks. The
+// `concurrency` argument is ignored — workerclient.Config.Concurrency
+// owns the slot count for the session.
+func startWorkerLoad(t *testing.T, cli *workerclient.Client, ctx context.Context, _ int) *atomic.Int64 {
+	t.Helper()
+	var completed atomic.Int64
+	go func() {
+		_ = cli.Run(ctx, func(_ context.Context, _ workerclient.Task) workerclient.Result {
+			completed.Add(1)
+			return workerclient.Completed(nil)
+		})
+	}()
+	return &completed
+}

--- a/internal/producer/server.go
+++ b/internal/producer/server.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -47,19 +48,66 @@ func New(scheduler services.SchedulerService, validator auth.Validator, logger *
 	}
 }
 
-// streamSession is the per-connection state. sendMu serializes Send so
-// the per-event handler goroutines never race on the gRPC stream.
+// streamSession is the per-connection state. Sends are funnelled through
+// a dedicated writer goroutine reading from sendCh, mirroring the worker
+// server (Phase 6 / M1) — profile showed sendMu mutex contention was the
+// single largest source of delay across all the stream sessions.
 type streamSession struct {
 	stream   producerpb.ProducerStream_StreamServer
-	sendMu   sync.Mutex
 	tenantID string
 	subject  string
+
+	ctx        context.Context
+	sendCh     chan *producerpb.ServerEvent
+	sendErr    atomic.Pointer[error]
+	writerDone chan struct{}
+}
+
+// sendChanBuffer caps how many CreateAcks queue ahead of the writer.
+// A producer pipelining N CreateTask events in flight will generate at
+// most N acks in close succession; 256 keeps the writer-side queue
+// shallow without forcing handlers to block on ctx-cancelled paths.
+const sendChanBuffer = 256
+
+func newStreamSession(ctx context.Context, stream producerpb.ProducerStream_StreamServer) *streamSession {
+	s := &streamSession{
+		stream:     stream,
+		ctx:        ctx,
+		sendCh:     make(chan *producerpb.ServerEvent, sendChanBuffer),
+		writerDone: make(chan struct{}),
+	}
+	go s.writeLoop()
+	return s
+}
+
+func (s *streamSession) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
+func (s *streamSession) closeWriter() {
+	close(s.sendCh)
+	<-s.writerDone
 }
 
 func (s *streamSession) send(ev *producerpb.ServerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
 }
 
 func (s *streamSession) sendAck(seq uint64, ok bool, taskID, errMsg string) error {
@@ -83,6 +131,10 @@ func (s *Server) Stream(stream producerpb.ProducerStream_StreamServer) error {
 	if err != nil {
 		return err
 	}
+	// Drain the writer before letting the rpc handler return; otherwise
+	// a final CreateAck in flight could race the stream's runtime
+	// teardown.
+	defer sess.closeWriter()
 
 	var wg sync.WaitGroup
 	for {
@@ -143,14 +195,13 @@ func (s *Server) handleHello(stream producerpb.ProducerStream_StreamServer) (*st
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "auth failed: %v", err)
 	}
-	sess := &streamSession{
-		stream:   stream,
-		tenantID: tenantIDFromClaims(claims),
-		subject:  claims.Subject,
-	}
+	sess := newStreamSession(stream.Context(), stream)
+	sess.tenantID = tenantIDFromClaims(claims)
+	sess.subject = claims.Subject
 	if err := sess.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_HelloAck{
 		HelloAck: &producerpb.HelloAck{TenantId: sess.tenantID, Subject: sess.subject},
 	}}); err != nil {
+		sess.closeWriter()
 		return nil, err
 	}
 	return sess, nil

--- a/internal/repository/pebble/subscription_repository.go
+++ b/internal/repository/pebble/subscription_repository.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -73,6 +74,31 @@ func parseSubEventKey(cmd domain.Command, k []byte) (expiresAtUnix uint64, id st
 	return expiresAtUnix, string(rest[9:]), true
 }
 
+// parseSubEventKeyAny is the cmd-agnostic variant used by recovery and
+// cleanup paths where the cmd is unknown up front. Key layout:
+//
+//	codeq/subevt/<cmd>/<expires_be8>/<id>
+func parseSubEventKeyAny(k []byte) (cmd domain.Command, expiresAtUnix uint64, ok bool) {
+	if !strings.HasPrefix(string(k), pSubEvent) {
+		return "", 0, false
+	}
+	rest := k[len(pSubEvent):]
+	sep := strings.IndexByte(string(rest), '/')
+	if sep <= 0 {
+		return "", 0, false
+	}
+	cmd = domain.Command(string(rest[:sep]))
+	tail := rest[sep+1:]
+	if len(tail) < 9 {
+		return "", 0, false
+	}
+	expiresAtUnix = beUint64(tail[:8])
+	if tail[8] != '/' {
+		return "", 0, false
+	}
+	return cmd, expiresAtUnix, true
+}
+
 // subscriptionRepo implements repository.SubscriptionRepository.
 // Notify throttling and round-robin counters are persisted to survive
 // restart; the rr counter increments via Get→Set since Pebble has no
@@ -83,10 +109,61 @@ type subscriptionRepo struct {
 	tz *time.Location
 
 	rrMu sync.Map // key string → *sync.Mutex
+
+	// activeByCmd is the per-command active-subscription counter that
+	// backs HasActive. Maintained by Create (++) and CleanupExpired (--).
+	// Heartbeat is a net no-op (delete+insert under different score).
+	// Producer NotifyQueueReady consults this to skip the Pebble iter
+	// when no subs exist. Recovered at Open() by recoverActiveCounts so
+	// a restart doesn't strand the counter at zero while live subs sit
+	// on disk.
+	activeByCmd sync.Map // key string (cmd) → *atomic.Int64
 }
 
 func NewSubscriptionRepository(db *DB, tz *time.Location) repository.SubscriptionRepository {
-	return &subscriptionRepo{db: db, tz: tz}
+	r := &subscriptionRepo{db: db, tz: tz}
+	// Best-effort recover: failures here only mean HasActive may return
+	// false when subs exist, in which case the next Create call brings
+	// the counter back up. The NotifyQueueReady fast-path stays correct
+	// because ListActive runs against on-disk truth either way.
+	_ = r.recoverActiveCounts()
+	return r
+}
+
+// activeCounter returns the atomic counter for cmd, lazy-initialized.
+func (r *subscriptionRepo) activeCounter(cmd domain.Command) *atomic.Int64 {
+	if v, ok := r.activeByCmd.Load(string(cmd)); ok {
+		return v.(*atomic.Int64)
+	}
+	c := new(atomic.Int64)
+	actual, _ := r.activeByCmd.LoadOrStore(string(cmd), c)
+	return actual.(*atomic.Int64)
+}
+
+// recoverActiveCounts scans every subscription event entry at startup
+// and seeds the active counter. Cost is O(N) over all subs once at
+// Open; later writes maintain the counter incrementally.
+func (r *subscriptionRepo) recoverActiveCounts() error {
+	lower := []byte(pSubEvent)
+	upper := prefixUpper(lower)
+	it, err := r.db.Iter(lower, upper)
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+	now := uint64(time.Now().Unix())
+	for valid := it.First(); valid; valid = it.Next() {
+		k := it.Key()
+		cmd, expires, ok := parseSubEventKeyAny(k)
+		if !ok {
+			continue
+		}
+		if expires < now {
+			continue
+		}
+		r.activeCounter(cmd).Add(1)
+	}
+	return it.Error()
 }
 
 func (r *subscriptionRepo) now() time.Time { return time.Now().In(r.tz) }
@@ -116,6 +193,11 @@ func (r *subscriptionRepo) Create(ctx context.Context, sub domain.Subscription, 
 	}
 	if err := r.db.CommitBatch(b); err != nil {
 		return nil, err
+	}
+	// Bump the per-cmd active counter after the durable commit so a
+	// failed commit doesn't leave the counter ahead of disk truth.
+	for _, evt := range sub.EventTypes {
+		r.activeCounter(evt).Add(1)
 	}
 	return &sub, nil
 }
@@ -170,6 +252,21 @@ func (r *subscriptionRepo) Get(ctx context.Context, id string) (*domain.Subscrip
 		return nil, fmt.Errorf("unmarshal subscription: %w", err)
 	}
 	return &s, nil
+}
+
+// HasActive is the in-memory fast path consulted by NotifyQueueReady
+// to skip the expensive Pebble iter when no subscriptions exist. The
+// counter can lag actual disk truth by a few ms (Create bumps it after
+// CommitBatch, CleanupExpired decrements after delete), and a crash
+// loses the value entirely — recoverActiveCounts at Open() rebuilds it.
+// Caller MUST still treat ListActive as authoritative; this is purely
+// an optimization to make zero-subscription configurations free.
+func (r *subscriptionRepo) HasActive(ctx context.Context, cmd domain.Command) bool {
+	c, ok := r.activeByCmd.Load(string(cmd))
+	if !ok {
+		return false
+	}
+	return c.(*atomic.Int64).Load() > 0
 }
 
 func (r *subscriptionRepo) ListActive(ctx context.Context, cmd domain.Command, now time.Time) ([]domain.Subscription, error) {
@@ -291,22 +388,23 @@ func (r *subscriptionRepo) CleanupExpired(ctx context.Context, limit int, before
 	type expired struct {
 		eventKey []byte
 		subID    string
+		cmd      domain.Command
 	}
 	bucket := make([]expired, 0, limit)
 	for valid := it.First(); valid && len(bucket) < limit; valid = it.Next() {
 		k := append([]byte(nil), it.Key()...)
-		// Parse the score (big-endian 8 bytes immediately after the cmd
-		// separator). For cleanup we don't need the cmd back — just the id.
-		idx := strings.LastIndexByte(string(k), '/')
-		if idx < 0 || idx < 8 {
+		cmd, score, ok := parseSubEventKeyAny(k)
+		if !ok {
 			continue
 		}
-		scoreStart := idx - 8
-		score := beUint64(k[scoreStart:idx])
 		if score >= beforeUnix {
 			continue
 		}
-		bucket = append(bucket, expired{eventKey: k, subID: string(k[idx+1:])})
+		idx := strings.LastIndexByte(string(k), '/')
+		if idx < 0 {
+			continue
+		}
+		bucket = append(bucket, expired{eventKey: k, subID: string(k[idx+1:]), cmd: cmd})
 	}
 	if len(bucket) == 0 {
 		return 0, nil
@@ -330,6 +428,11 @@ func (r *subscriptionRepo) CleanupExpired(ctx context.Context, limit int, before
 	}
 	if err := r.db.CommitBatch(b); err != nil {
 		return 0, err
+	}
+	// Decrement active counter for each cleaned event entry. After the
+	// commit so a failed commit doesn't drive the counter below zero.
+	for _, e := range bucket {
+		r.activeCounter(e.cmd).Add(-1)
 	}
 	return cleaned, nil
 }

--- a/internal/repository/subscription_repository.go
+++ b/internal/repository/subscription_repository.go
@@ -19,6 +19,16 @@ type SubscriptionRepository interface {
 	Heartbeat(ctx context.Context, id string, ttlSeconds int) (*domain.Subscription, error)
 	Get(ctx context.Context, id string) (*domain.Subscription, error)
 	ListActive(ctx context.Context, cmd domain.Command, now time.Time) ([]domain.Subscription, error)
+	// HasActive is the producer hot-path fast check: return true only if
+	// there is at least one (possibly stale-but-not-yet-cleaned) active
+	// subscription for cmd. Implementations are free to be conservatively
+	// wrong (return true when no subs are actually active) — the caller
+	// follows up with ListActive which is authoritative. Must be O(1) on
+	// the happy path so NotifyQueueReady can skip the expensive scan when
+	// nothing is registered. Phase 6 profiling showed ListActive
+	// dominated the producer create path with 22% CPU + 27% allocs even
+	// when zero subscriptions existed.
+	HasActive(ctx context.Context, cmd domain.Command) bool
 	AllowNotify(ctx context.Context, id string, minIntervalSeconds int) (bool, error)
 	AllowNotifyBatch(ctx context.Context, subs []domain.Subscription) (map[string]bool, error)
 	NextGroupIndex(ctx context.Context, cmd domain.Command, groupID string, mod int) (int, error)
@@ -117,6 +127,21 @@ func (r *subscriptionRedisRepo) Get(ctx context.Context, id string) (*domain.Sub
 		return nil, fmt.Errorf("unmarshal sub: %w", err)
 	}
 	return &sub, nil
+}
+
+// HasActive returns true iff the event index has at least one entry
+// for cmd, by doing a single ZCARD instead of the full ListActive
+// pipeline. It is intentionally allowed to be conservatively wrong
+// (returning true for entries whose score is already in the past);
+// the caller follows up with ListActive which honors the score filter.
+// 1 RTT and zero allocations on the happy "no subs" path.
+func (r *subscriptionRedisRepo) HasActive(ctx context.Context, cmd domain.Command) bool {
+	n, err := r.rdb.ZCard(ctx, r.keySubsEvent(cmd)).Result()
+	if err != nil && err != redis.Nil {
+		// Fail-open: a transient redis blip shouldn't silently drop notifies.
+		return true
+	}
+	return n > 0
 }
 
 func (r *subscriptionRedisRepo) ListActive(ctx context.Context, cmd domain.Command, now time.Time) ([]domain.Subscription, error) {

--- a/internal/services/notifier_service.go
+++ b/internal/services/notifier_service.go
@@ -53,6 +53,16 @@ func NewNotifierService(repo repository.SubscriptionRepository, logger *slog.Log
 }
 
 func (n *notifierService) NotifyQueueReady(ctx context.Context, cmd domain.Command) {
+	// Fast-path: producers running with no subscriptions registered for
+	// this command should pay zero cost here. Profile (Phase 6) showed
+	// ListActive dominating the create hot path with 22% CPU + 27% allocs
+	// even when no subs existed, because Pebble's iter open+scan+close
+	// runs for every Enqueue. HasActive is an O(1) atomic counter check
+	// (Pebble) or single ZCARD RTT (Redis) that lets us bail before
+	// touching the iterator.
+	if !n.repo.HasActive(ctx, cmd) {
+		return
+	}
 	subs, err := n.repo.ListActive(ctx, cmd, time.Now())
 	if err != nil || len(subs) == 0 {
 		return

--- a/internal/services/scheduler_service_test.go
+++ b/internal/services/scheduler_service_test.go
@@ -55,6 +55,10 @@ func (m *mockSubscriptionRepo) ListActive(ctx context.Context, cmd domain.Comman
 	return nil, nil
 }
 
+func (m *mockSubscriptionRepo) HasActive(ctx context.Context, cmd domain.Command) bool {
+	return false
+}
+
 func (m *mockSubscriptionRepo) AllowNotify(ctx context.Context, id string, minIntervalSeconds int) (bool, error) {
 	return true, nil
 }

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -58,18 +59,80 @@ func New(scheduler services.SchedulerService, results services.ResultsService, v
 	}
 }
 
-// streamSession holds per-connection state. The send mutex serializes
-// every Send call on the stream — gRPC's generated server stream type
-// is not safe for concurrent writes, so all the per-event handler
-// goroutines funnel through this lock.
+// streamSession holds per-connection state. Sends are serialized via a
+// dedicated writer goroutine reading from sendCh rather than a mutex
+// around stream.Send: profile (Phase 6) showed the sendMu mutex
+// accounting for ~74% of the mutex profile under load. The channel
+// approach avoids the cache-line ping-pong that mutex contention
+// produces across the many per-event handler goroutines.
 type streamSession struct {
 	stream   workerpb.WorkerStream_StreamServer
-	sendMu   sync.Mutex
 	workerID string
 	tenantID string
 	claims   *auth.Claims
 	commands []domain.Command // resolved from scope/eventTypes claim
 	hasWild  bool
+
+	// sendCh is the writer's inbox. Buffered so per-event goroutines
+	// pushing acks don't block during transient Send latency; on
+	// overflow the producer falls through to ctx-cancelled or the
+	// channel close path.
+	sendCh chan *workerpb.ServerEvent
+	// sendErr captures the first Send failure so subsequent senders bail
+	// fast instead of queuing into a dead stream. atomic.Pointer for
+	// lock-free read on the hot path.
+	sendErr atomic.Pointer[error]
+	// writerDone closes when the writer goroutine has fully drained and
+	// stopped. Used by Stream() to ensure no in-flight Send races the
+	// rpc handler return.
+	writerDone chan struct{}
+	// ctx mirrors stream.Context() so send() can fall through on
+	// cancellation without consulting stream.Context() each call.
+	ctx context.Context
+}
+
+// sendChanBuffer bounds how many ServerEvents we'll queue ahead of the
+// writer. Sized large enough to absorb a burst of acks from a worker
+// with N concurrent Ready/Result slots without blocking, small enough
+// that pathological backpressure surfaces quickly as ctx cancellation.
+const sendChanBuffer = 256
+
+// newStreamSession wires the writer goroutine. Caller is responsible
+// for invoking sess.close() before Stream() returns so the writer
+// exits cleanly.
+func newStreamSession(ctx context.Context, stream workerpb.WorkerStream_StreamServer) *streamSession {
+	s := &streamSession{
+		stream:     stream,
+		sendCh:     make(chan *workerpb.ServerEvent, sendChanBuffer),
+		writerDone: make(chan struct{}),
+		ctx:        ctx,
+	}
+	go s.writeLoop()
+	return s
+}
+
+// writeLoop owns the stream's Send side. It drains sendCh until the
+// channel is closed, marking the first Send failure on sendErr so
+// readers can short-circuit.
+func (s *streamSession) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			// Already failed; drain remaining events without sending so
+			// the producers' channel sends don't block.
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
+// closeWriter signals the writer to drain and exit, then waits.
+func (s *streamSession) closeWriter() {
+	close(s.sendCh)
+	<-s.writerDone
 }
 
 // Stream is the bidirectional rpc. First message MUST be Hello; the
@@ -82,6 +145,10 @@ func (s *Server) Stream(stream workerpb.WorkerStream_StreamServer) error {
 	if err != nil {
 		return err
 	}
+	// Ensure the writer goroutine drains and exits before we return,
+	// otherwise the gRPC runtime can reap the stream while a final Send
+	// is still in flight.
+	defer sess.closeWriter()
 
 	var wg sync.WaitGroup
 	// Read loop runs in the caller goroutine; per-event work spawns child
@@ -179,12 +246,10 @@ func (s *Server) handleHello(stream workerpb.WorkerStream_StreamServer) (*stream
 	}
 	tenantID := tenantIDFromClaims(claims)
 
-	sess := &streamSession{
-		stream:   stream,
-		workerID: workerID,
-		tenantID: tenantID,
-		claims:   claims,
-	}
+	sess := newStreamSession(stream.Context(), stream)
+	sess.workerID = workerID
+	sess.tenantID = tenantID
+	sess.claims = claims
 	for _, ev := range claims.EventTypes {
 		if ev == "*" {
 			sess.hasWild = true
@@ -198,6 +263,7 @@ func (s *Server) handleHello(stream workerpb.WorkerStream_StreamServer) (*stream
 			HelloAck: &workerpb.HelloAck{WorkerId: workerID, TenantId: tenantID},
 		},
 	}); err != nil {
+		sess.closeWriter()
 		return nil, err
 	}
 	return sess, nil
@@ -419,9 +485,15 @@ func (s *Server) resolveCommands(sess *streamSession, requested []string) ([]dom
 }
 
 func (s *streamSession) send(ev *workerpb.ServerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
 }
 
 func (s *streamSession) sendError(code codes.Code, msg string) error {

--- a/pkg/producerclient/client.go
+++ b/pkg/producerclient/client.go
@@ -103,7 +103,10 @@ type CreateRequest struct {
 
 // Session is one authenticated stream. Produce on it is safe to call
 // from many goroutines concurrently. Close to release reader goroutine
-// and stream resources.
+// and stream resources. Sends go through a dedicated writer goroutine
+// reading from sendCh — Phase 6 / M1 profile showed sendMu contention
+// across pipelined Produce callers was a meaningful chunk of total
+// delay.
 type Session struct {
 	cli     *Client
 	stream  producerpb.ProducerStream_StreamClient
@@ -114,7 +117,11 @@ type Session struct {
 	tenantID string
 	subject  string
 
-	sendMu  sync.Mutex // serializes stream.Send
+	streamCtx  context.Context
+	sendCh     chan *producerpb.ProducerEvent
+	sendErr    atomic.Pointer[error]
+	writerDone chan struct{}
+
 	seq     atomic.Uint64
 	pending sync.Map // seq → chan ackResult
 
@@ -122,6 +129,11 @@ type Session struct {
 	readErrMu sync.Mutex
 	readDone  chan struct{}
 }
+
+// sendChanBufferClient is sized to absorb N pipelined CreateTask events
+// from many goroutines. 256 keeps the writer's queue shallow while
+// avoiding ctx-cancelled errors during transient gRPC flush latency.
+const sendChanBufferClient = 256
 
 // ackResult is what slot goroutines receive from the reader.
 type ackResult struct {
@@ -142,12 +154,18 @@ func (c *Client) Connect(ctx context.Context) (*Session, error) {
 		return nil, fmt.Errorf("producerclient: open stream: %w", err)
 	}
 	sess := &Session{
-		cli:      c,
-		stream:   stream,
-		cancel:   cancel,
-		readDone: make(chan struct{}),
+		cli:        c,
+		stream:     stream,
+		cancel:     cancel,
+		readDone:   make(chan struct{}),
+		streamCtx:  streamCtx,
+		sendCh:     make(chan *producerpb.ProducerEvent, sendChanBufferClient),
+		writerDone: make(chan struct{}),
 	}
+	go sess.writeLoop()
 	if err := sess.handshake(); err != nil {
+		close(sess.sendCh)
+		<-sess.writerDone
 		cancel()
 		return nil, err
 	}
@@ -155,10 +173,29 @@ func (c *Client) Connect(ctx context.Context) (*Session, error) {
 	return sess, nil
 }
 
+func (s *Session) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
 func (s *Session) send(ev *producerpb.ProducerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.streamCtx.Done():
+		return s.streamCtx.Err()
+	}
 }
 
 func (s *Session) handshake() error {
@@ -323,14 +360,20 @@ func (s *Session) TenantID() string { return s.tenantID }
 // Subject returns the JWT subject the server resolved this session to.
 func (s *Session) Subject() string { return s.subject }
 
-// Close cancels the stream, releases the reader goroutine, and unblocks
-// any pending Produce calls with an error. Safe to call multiple times.
+// Close cancels the stream, releases the reader + writer goroutines,
+// and unblocks any pending Produce calls with an error. Safe to call
+// multiple times.
 func (s *Session) Close() error {
 	s.closeMu.Lock()
 	defer s.closeMu.Unlock()
 	if s.closed.Swap(true) {
 		return nil
 	}
+	// Drain the writer first so any in-flight send completes (or fails
+	// cleanly via sendErr) before we tear the stream down. Closing
+	// sendCh signals writeLoop to exit once it finishes the queue.
+	close(s.sendCh)
+	<-s.writerDone
 	// CloseSend tells the server we're done writing — it gets a clean
 	// EOF on its Recv loop. cancel() then propagates the close to the
 	// reader so it exits as well.

--- a/pkg/workerclient/client.go
+++ b/pkg/workerclient/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -124,29 +125,76 @@ func (c *Client) Run(ctx context.Context, h Handler) error {
 		return fmt.Errorf("workerclient: open stream: %w", err)
 	}
 
-	sess := &session{
-		cfg:    c.cfg,
-		stream: stream,
-		taskCh: make(chan *workerpb.Task),
-		log:    c.cfg.Logger,
-	}
+	sess := newSession(ctx, c.cfg, stream)
+	defer sess.closeWriter()
 	return sess.run(ctx, h)
 }
 
 // session bundles the per-Run mutable state. One session per Run call.
+// Sends are funnelled through a single writer goroutine reading from
+// sendCh instead of a mutex around stream.Send: profile (Phase 6)
+// pinned the client-side sendMu at ~26% of the mutex profile under
+// 128-slot load, with the per-slot Ready/Result loops fighting each
+// other for the lock.
 type session struct {
 	cfg    Config
 	stream workerpb.WorkerStream_StreamClient
 	taskCh chan *workerpb.Task
 	log    *slog.Logger
 
-	sendMu sync.Mutex // serializes stream.Send across slots + reader
+	ctx        context.Context
+	sendCh     chan *workerpb.WorkerEvent
+	sendErr    atomic.Pointer[error]
+	writerDone chan struct{}
+}
+
+// sendChanBufferClient is sized to absorb a burst of Ready/Result
+// messages from every slot in flight. 256 keeps queueing latency low
+// while avoiding spurious context cancellations during gRPC flushes.
+const sendChanBufferClient = 256
+
+func newSession(ctx context.Context, cfg Config, stream workerpb.WorkerStream_StreamClient) *session {
+	s := &session{
+		cfg:        cfg,
+		stream:     stream,
+		taskCh:     make(chan *workerpb.Task),
+		log:        cfg.Logger,
+		ctx:        ctx,
+		sendCh:     make(chan *workerpb.WorkerEvent, sendChanBufferClient),
+		writerDone: make(chan struct{}),
+	}
+	go s.writeLoop()
+	return s
+}
+
+func (s *session) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
+func (s *session) closeWriter() {
+	close(s.sendCh)
+	<-s.writerDone
 }
 
 func (s *session) send(ev *workerpb.WorkerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
 }
 
 func (s *session) run(ctx context.Context, h Handler) error {


### PR DESCRIPTION
## Summary

Profile-driven follow-up to Q1 (#533). The post-Q1 mutex profile pinned `sync.Mutex.Unlock` at 74% of mutex contention delay (53.68s of 72.28s), almost all of it on the per-stream sendMu used by worker + producer streams to serialize the gRPC stream.Send. This PR replaces the lock with a per-stream writer goroutine reading from a buffered sendCh on both the server and client side of both streams.

## Why a channel and not just a smaller critical section

The gRPC generated stream.Send is not thread-safe — concurrent calls will corrupt the wire format — so some form of serialization is required. The historical choice (sync.Mutex) protected correctness but at full saturation each per-event handler goroutine waited on the same lock, and the cache line carrying the mutex's atomic state ping-ponged constantly across cores. The mutex profile (post-Q1) reflected exactly this:

| Hotspot | cum delay |
|---|---|
| `sync.Mutex.Unlock` | 53.68s (74%) |
| `worker.streamSession.send` | 25.84s (36%) |
| `workerclient.session.send` | 18.69s (26%) |

Replacing the lock with a single-writer goroutine eliminates the cross-core serialization. Handlers enqueue events on a buffered channel (default 256-deep, sized to absorb a burst of acks from N concurrent slots), and one dedicated goroutine drains them into the actual Send. Lock-free read of `sendErr atomic.Pointer[error]` lets senders bail fast when the writer has marked the stream dead.

## Numbers

`profile_full_cycle_test.go`, 20s window, 32 producer slots + 128 worker slots, single Pebble node:

| Phase | tasks/s ciclo full | mutex contention delay |
|---|---|---|
| Post-Q1 (#533) | 33,555 | 72.28s |
| Post-M1 | 33,409 | **35.09s (-51%)** |

Throughput unchanged because the harness is not mutex-bound today — it's CPU-bound on Pebble compaction (~16% cum) and worker.handleReady (~13% cum). The mutex savings show up later when Q2 (`ReadyBatch`/`ResultBatch`) and Q3 (`CreateBatch`) multiply per-slot Send frequency: at that point sendMu would have re-emerged as the hard ceiling, and with the channel writer it doesn't.

`sync.Mutex.Unlock` dropped out of the top of the mutex profile entirely. The remaining contention (runtime.unlock 32s) is the Go scheduler's channel-select internals, which is qualitatively cheaper because it doesn't busy-spin across cores.

## Symmetric application

Same shape applied to all four sides of the protocol:

- `internal/worker/server.go` — `streamSession`
- `pkg/workerclient/client.go` — `session`
- `internal/producer/server.go` — `streamSession`
- `pkg/producerclient/client.go` — `Session`

Each gets `sendChanBuffer=256`, a `writeLoop()` that does the actual Send, and a `closeWriter()` helper that drains and joins before the rpc returns so a final Send doesn't race the runtime tearing down the stream.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race ./internal/worker/... ./pkg/workerclient/... ./internal/producer/... ./pkg/producerclient/...` clean
- [x] All existing stream tests pass (Hello/Ready/Result/Nack/Heartbeat/Abandon, producer Produce + reject + handshake)
- [x] Profile re-run confirms -51% mutex contention

## Stacking on Q1

Branched off Q1 (#533) — no file conflict (Q1 touches subscription_repository + notifier_service; this touches stream code). If Q1 merges first, this rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)