### PR TITLE
perf(phase-6-q2): worker stream batch — Ready{count}, TaskBatch, ResultBatch

### DIFF
--- a/internal/bench/profile_full_cycle_test.go
+++ b/internal/bench/profile_full_cycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"runtime"
 	"runtime/pprof"
 	"sync"
@@ -68,12 +69,16 @@ func TestProfile_FullCycle(t *testing.T) {
 	}
 	defer prodSess.Close()
 
-	// Worker side: workerclient with high concurrency to drain.
+	// Worker side: workerclient with high concurrency to drain. BatchSize
+	// is opt-in via env so the same harness can profile both single-task
+	// (PHASE6_BATCH=0) and batched (PHASE6_BATCH=N) paths.
+	batchSize, _ := strconv.Atoi(os.Getenv("PHASE6_BATCH"))
 	workerCli, err := workerclient.New(workerclient.Config{
 		Addr:         streamWorkerAddr,
 		Token:        phase2WorkerToken,
 		Commands:     []string{"GENERATE_MASTER"},
 		Concurrency:  128,
+		BatchSize:    batchSize,
 		LeaseSeconds: 300,
 	})
 	if err != nil {

--- a/internal/producer/server.go
+++ b/internal/producer/server.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -47,19 +48,66 @@ func New(scheduler services.SchedulerService, validator auth.Validator, logger *
 	}
 }
 
-// streamSession is the per-connection state. sendMu serializes Send so
-// the per-event handler goroutines never race on the gRPC stream.
+// streamSession is the per-connection state. Sends are funnelled through
+// a dedicated writer goroutine reading from sendCh, mirroring the worker
+// server (Phase 6 / M1) — profile showed sendMu mutex contention was the
+// single largest source of delay across all the stream sessions.
 type streamSession struct {
 	stream   producerpb.ProducerStream_StreamServer
-	sendMu   sync.Mutex
 	tenantID string
 	subject  string
+
+	ctx        context.Context
+	sendCh     chan *producerpb.ServerEvent
+	sendErr    atomic.Pointer[error]
+	writerDone chan struct{}
+}
+
+// sendChanBuffer caps how many CreateAcks queue ahead of the writer.
+// A producer pipelining N CreateTask events in flight will generate at
+// most N acks in close succession; 256 keeps the writer-side queue
+// shallow without forcing handlers to block on ctx-cancelled paths.
+const sendChanBuffer = 256
+
+func newStreamSession(ctx context.Context, stream producerpb.ProducerStream_StreamServer) *streamSession {
+	s := &streamSession{
+		stream:     stream,
+		ctx:        ctx,
+		sendCh:     make(chan *producerpb.ServerEvent, sendChanBuffer),
+		writerDone: make(chan struct{}),
+	}
+	go s.writeLoop()
+	return s
+}
+
+func (s *streamSession) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
+func (s *streamSession) closeWriter() {
+	close(s.sendCh)
+	<-s.writerDone
 }
 
 func (s *streamSession) send(ev *producerpb.ServerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
 }
 
 func (s *streamSession) sendAck(seq uint64, ok bool, taskID, errMsg string) error {
@@ -83,6 +131,10 @@ func (s *Server) Stream(stream producerpb.ProducerStream_StreamServer) error {
 	if err != nil {
 		return err
 	}
+	// Drain the writer before letting the rpc handler return; otherwise
+	// a final CreateAck in flight could race the stream's runtime
+	// teardown.
+	defer sess.closeWriter()
 
 	var wg sync.WaitGroup
 	for {
@@ -143,14 +195,13 @@ func (s *Server) handleHello(stream producerpb.ProducerStream_StreamServer) (*st
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "auth failed: %v", err)
 	}
-	sess := &streamSession{
-		stream:   stream,
-		tenantID: tenantIDFromClaims(claims),
-		subject:  claims.Subject,
-	}
+	sess := newStreamSession(stream.Context(), stream)
+	sess.tenantID = tenantIDFromClaims(claims)
+	sess.subject = claims.Subject
 	if err := sess.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_HelloAck{
 		HelloAck: &producerpb.HelloAck{TenantId: sess.tenantID, Subject: sess.subject},
 	}}); err != nil {
+		sess.closeWriter()
 		return nil, err
 	}
 	return sess, nil

--- a/internal/worker/proto/workerpb.proto
+++ b/internal/worker/proto/workerpb.proto
@@ -50,13 +50,19 @@ message Hello {
 }
 
 // Ready is the worker saying "I have capacity for one more task with
-// any of these commands; push me one when available." The server
-// responds with a Task message when a task becomes available; until
-// then no message is sent for this Ready. Each Ready consumes exactly
-// one Task; if the worker wants prefetching, it sends N Readys.
+// any of these commands; push me one when available." Each Ready
+// consumes up to `count` Tasks; the server responds with either:
+//   - one TaskAssignment per task (count==0 or 1; legacy path), or
+//   - one TaskBatch carrying up to count tasks (count > 1; Phase 6 / Q2).
+// When count==0 the server defaults to 1 for backward compatibility
+// with clients that never set the field.
 message Ready {
   repeated string commands = 1;
   int32 lease_seconds = 2;
+  // count = max tasks to deliver in response. 0/1 = single TaskAssignment.
+  // >1 = TaskBatch capped at count. Server may deliver fewer than count
+  // if the queue empties before the batch fills.
+  int32 count = 3;
 }
 
 // Result is the worker submitting completion for a previously-assigned
@@ -90,6 +96,15 @@ message Abandon {
   string task_id = 1;
 }
 
+// ResultBatch is the worker submitting completion for N tasks in a
+// single message. Equivalent to N Result events but the server
+// processes them with one BatchSubmit call (single Pebble batch +
+// single round-trip of acks), eliminating the per-task Send overhead
+// and amortising claim/result write paths. Phase 6 / Q2.
+message ResultBatch {
+  repeated Result results = 1;
+}
+
 message WorkerEvent {
   oneof event {
     Hello hello = 1;
@@ -98,6 +113,7 @@ message WorkerEvent {
     Nack nack = 4;
     Heartbeat heartbeat = 5;
     Abandon abandon = 6;
+    ResultBatch result_batch = 7;
   }
 }
 
@@ -112,6 +128,20 @@ message HelloAck {
 // If no task is available the server holds the Ready until one is.
 message TaskAssignment {
   Task task = 1;
+}
+
+// TaskBatch is the server's response to a Ready with count > 1.
+// Carries up to Ready.count Tasks in a single message. May be shorter
+// than count if the queue emptied; an empty TaskBatch is a legal
+// no-tasks-available response.
+message TaskBatch {
+  repeated Task tasks = 1;
+}
+
+// ResultAckBatch acknowledges all results in a ResultBatch in one
+// message. Order matches the ResultBatch.results order.
+message ResultAckBatch {
+  repeated ResultAck acks = 1;
 }
 
 message ResultAck {
@@ -156,6 +186,8 @@ message ServerEvent {
     NackAck nack_ack = 5;
     AbandonAck abandon_ack = 6;
     ServerError error = 7;
+    TaskBatch task_batch = 8;
+    ResultAckBatch result_ack_batch = 9;
   }
 }
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -58,18 +59,80 @@ func New(scheduler services.SchedulerService, results services.ResultsService, v
 	}
 }
 
-// streamSession holds per-connection state. The send mutex serializes
-// every Send call on the stream — gRPC's generated server stream type
-// is not safe for concurrent writes, so all the per-event handler
-// goroutines funnel through this lock.
+// streamSession holds per-connection state. Sends are serialized via a
+// dedicated writer goroutine reading from sendCh rather than a mutex
+// around stream.Send: profile (Phase 6) showed the sendMu mutex
+// accounting for ~74% of the mutex profile under load. The channel
+// approach avoids the cache-line ping-pong that mutex contention
+// produces across the many per-event handler goroutines.
 type streamSession struct {
 	stream   workerpb.WorkerStream_StreamServer
-	sendMu   sync.Mutex
 	workerID string
 	tenantID string
 	claims   *auth.Claims
 	commands []domain.Command // resolved from scope/eventTypes claim
 	hasWild  bool
+
+	// sendCh is the writer's inbox. Buffered so per-event goroutines
+	// pushing acks don't block during transient Send latency; on
+	// overflow the producer falls through to ctx-cancelled or the
+	// channel close path.
+	sendCh chan *workerpb.ServerEvent
+	// sendErr captures the first Send failure so subsequent senders bail
+	// fast instead of queuing into a dead stream. atomic.Pointer for
+	// lock-free read on the hot path.
+	sendErr atomic.Pointer[error]
+	// writerDone closes when the writer goroutine has fully drained and
+	// stopped. Used by Stream() to ensure no in-flight Send races the
+	// rpc handler return.
+	writerDone chan struct{}
+	// ctx mirrors stream.Context() so send() can fall through on
+	// cancellation without consulting stream.Context() each call.
+	ctx context.Context
+}
+
+// sendChanBuffer bounds how many ServerEvents we'll queue ahead of the
+// writer. Sized large enough to absorb a burst of acks from a worker
+// with N concurrent Ready/Result slots without blocking, small enough
+// that pathological backpressure surfaces quickly as ctx cancellation.
+const sendChanBuffer = 256
+
+// newStreamSession wires the writer goroutine. Caller is responsible
+// for invoking sess.close() before Stream() returns so the writer
+// exits cleanly.
+func newStreamSession(ctx context.Context, stream workerpb.WorkerStream_StreamServer) *streamSession {
+	s := &streamSession{
+		stream:     stream,
+		sendCh:     make(chan *workerpb.ServerEvent, sendChanBuffer),
+		writerDone: make(chan struct{}),
+		ctx:        ctx,
+	}
+	go s.writeLoop()
+	return s
+}
+
+// writeLoop owns the stream's Send side. It drains sendCh until the
+// channel is closed, marking the first Send failure on sendErr so
+// readers can short-circuit.
+func (s *streamSession) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			// Already failed; drain remaining events without sending so
+			// the producers' channel sends don't block.
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
+// closeWriter signals the writer to drain and exit, then waits.
+func (s *streamSession) closeWriter() {
+	close(s.sendCh)
+	<-s.writerDone
 }
 
 // Stream is the bidirectional rpc. First message MUST be Hello; the
@@ -82,6 +145,10 @@ func (s *Server) Stream(stream workerpb.WorkerStream_StreamServer) error {
 	if err != nil {
 		return err
 	}
+	// Ensure the writer goroutine drains and exits before we return,
+	// otherwise the gRPC runtime can reap the stream while a final Send
+	// is still in flight.
+	defer sess.closeWriter()
 
 	var wg sync.WaitGroup
 	// Read loop runs in the caller goroutine; per-event work spawns child
@@ -179,12 +246,10 @@ func (s *Server) handleHello(stream workerpb.WorkerStream_StreamServer) (*stream
 	}
 	tenantID := tenantIDFromClaims(claims)
 
-	sess := &streamSession{
-		stream:   stream,
-		workerID: workerID,
-		tenantID: tenantID,
-		claims:   claims,
-	}
+	sess := newStreamSession(stream.Context(), stream)
+	sess.workerID = workerID
+	sess.tenantID = tenantID
+	sess.claims = claims
 	for _, ev := range claims.EventTypes {
 		if ev == "*" {
 			sess.hasWild = true
@@ -198,6 +263,7 @@ func (s *Server) handleHello(stream workerpb.WorkerStream_StreamServer) (*stream
 			HelloAck: &workerpb.HelloAck{WorkerId: workerID, TenantId: tenantID},
 		},
 	}); err != nil {
+		sess.closeWriter()
 		return nil, err
 	}
 	return sess, nil
@@ -419,9 +485,15 @@ func (s *Server) resolveCommands(sess *streamSession, requested []string) ([]dom
 }
 
 func (s *streamSession) send(ev *workerpb.ServerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
 }
 
 func (s *streamSession) sendError(code codes.Code, msg string) error {

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -191,6 +191,15 @@ func (s *Server) Stream(stream workerpb.WorkerStream_StreamServer) error {
 				defer wg.Done()
 				s.handleResult(ctx, sess, req)
 			}(e.Result)
+		case *workerpb.WorkerEvent_ResultBatch:
+			if !sess.requireScope("codeq:result") {
+				continue
+			}
+			wg.Add(1)
+			go func(req *workerpb.ResultBatch) {
+				defer wg.Done()
+				s.handleResultBatch(ctx, sess, req)
+			}(e.ResultBatch)
 		case *workerpb.WorkerEvent_Nack:
 			if !sess.requireScope("codeq:nack") {
 				continue
@@ -279,10 +288,18 @@ func (s *Server) handleReady(ctx context.Context, sess *streamSession, req *work
 	if lease <= 0 {
 		lease = s.DefaultLease
 	}
-	// Poll until a task is available, the stream closes, or we hit the
-	// retry budget. The repo doesn't block server-side, so we busy-wait
-	// with a small delay between attempts. This is intentionally simple;
-	// a future revision can wake on producer-side push notification.
+	// count=0 / count=1 → legacy single-task path. count > 1 → batch.
+	count := int(req.Count)
+	if count <= 1 {
+		s.handleReadyOne(ctx, sess, commands, lease)
+		return
+	}
+	s.handleReadyBatch(ctx, sess, commands, lease, count)
+}
+
+// handleReadyOne is the unchanged single-task path; kept verbatim so
+// existing clients see no behavior change.
+func (s *Server) handleReadyOne(ctx context.Context, sess *streamSession, commands []domain.Command, lease int) {
 	for attempt := 0; attempt <= s.MaxClaimRetries; attempt++ {
 		if ctx.Err() != nil {
 			return
@@ -304,8 +321,121 @@ func (s *Server) handleReady(ctx context.Context, sess *streamSession, req *work
 		case <-time.After(s.ClaimPollDelay):
 		}
 	}
-	// No task within the retry budget — silently drop. The worker is
-	// free to send another Ready.
+}
+
+// handleReadyBatch claims up to `count` tasks and sends them as one
+// TaskBatch. First task waits up to MaxClaimRetries × ClaimPollDelay so
+// idle workers don't busy-loop; subsequent tasks pull only if the
+// scheduler returns immediately — we never block waiting for the second
+// task once the batch has one, because the worker would rather start
+// processing the partial batch than wait for the queue to fill.
+func (s *Server) handleReadyBatch(ctx context.Context, sess *streamSession, commands []domain.Command, lease, count int) {
+	tasks := make([]*workerpb.Task, 0, count)
+	for attempt := 0; attempt <= s.MaxClaimRetries && len(tasks) == 0; attempt++ {
+		if ctx.Err() != nil {
+			return
+		}
+		task, ok, err := s.Scheduler.ClaimTask(ctx, sess.workerID, commands, lease, 0, sess.tenantID)
+		if err != nil {
+			_ = sess.sendError(codes.Internal, err.Error())
+			return
+		}
+		if ok && task != nil {
+			tasks = append(tasks, taskToProto(task))
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(s.ClaimPollDelay):
+		}
+	}
+	// Greedy drain — pull more tasks while the scheduler has them ready.
+	for len(tasks) < count {
+		if ctx.Err() != nil {
+			break
+		}
+		task, ok, err := s.Scheduler.ClaimTask(ctx, sess.workerID, commands, lease, 0, sess.tenantID)
+		if err != nil || !ok || task == nil {
+			break
+		}
+		tasks = append(tasks, taskToProto(task))
+	}
+	if len(tasks) == 0 {
+		return
+	}
+	_ = sess.send(&workerpb.ServerEvent{Event: &workerpb.ServerEvent_TaskBatch{
+		TaskBatch: &workerpb.TaskBatch{Tasks: tasks},
+	}})
+}
+
+// handleResultBatch is the batched submit path. Eliminates the per-task
+// Send + Pebble commit overhead that handleResult pays for each result,
+// by funnelling all N results through ResultsService.BatchSubmit (one
+// GetTasksBatch + one BatchUpdateTasksOnComplete on Pebble). Acks come
+// back as a single ResultAckBatch matching the input order so the
+// client can correlate without extra bookkeeping.
+func (s *Server) handleResultBatch(ctx context.Context, sess *streamSession, req *workerpb.ResultBatch) {
+	if req == nil || len(req.Results) == 0 {
+		return
+	}
+	acks := make([]*workerpb.ResultAck, len(req.Results))
+	items := make([]domain.BatchSubmitItem, 0, len(req.Results))
+	itemIdx := make([]int, 0, len(req.Results)) // results index for each item
+
+	// First pass: validate per-result, parse JSON; rejects produce a
+	// ResultAck in-place without touching the service. Valid results
+	// get batched for one BatchSubmit call.
+	for i, r := range req.Results {
+		if r == nil {
+			acks[i] = &workerpb.ResultAck{Ok: false, ErrorMessage: "nil result"}
+			continue
+		}
+		if err := validateResultStatus(r.Status); err != nil {
+			acks[i] = &workerpb.ResultAck{TaskId: r.TaskId, Ok: false, ErrorMessage: err.Error()}
+			continue
+		}
+		var resultVal map[string]any
+		if len(r.ResultJson) > 0 {
+			if err := sonic.Unmarshal(r.ResultJson, &resultVal); err != nil {
+				acks[i] = &workerpb.ResultAck{TaskId: r.TaskId, Ok: false, ErrorMessage: "invalid result_json"}
+				continue
+			}
+		}
+		items = append(items, domain.BatchSubmitItem{
+			TaskID: r.TaskId,
+			SubmitResultRequest: domain.SubmitResultRequest{
+				Status:   domain.TaskStatus(r.Status),
+				WorkerID: sess.workerID,
+				Result:   resultVal,
+				Error:    r.Error,
+			},
+		})
+		itemIdx = append(itemIdx, i)
+	}
+
+	if len(items) > 0 {
+		resps, err := s.Results.BatchSubmit(ctx, items)
+		if err != nil {
+			// Whole-batch failure: ack every queued item with the same error.
+			for _, i := range itemIdx {
+				acks[i] = &workerpb.ResultAck{TaskId: req.Results[i].TaskId, Ok: false, ErrorMessage: err.Error()}
+			}
+		} else {
+			for k, resp := range resps {
+				i := itemIdx[k]
+				if resp.Error != "" {
+					acks[i] = &workerpb.ResultAck{TaskId: resp.TaskID, Ok: false, ErrorMessage: resp.Error}
+				} else {
+					acks[i] = &workerpb.ResultAck{TaskId: resp.TaskID, Ok: true}
+				}
+			}
+		}
+	}
+
+	_ = sess.send(&workerpb.ServerEvent{Event: &workerpb.ServerEvent_ResultAckBatch{
+		ResultAckBatch: &workerpb.ResultAckBatch{Acks: acks},
+	}})
 }
 
 func (s *Server) handleResult(ctx context.Context, sess *streamSession, req *workerpb.Result) {

--- a/internal/worker/workerpb/workerpb.pb.go
+++ b/internal/worker/workerpb/workerpb.pb.go
@@ -234,14 +234,21 @@ func (x *Hello) GetWorkerId() string {
 }
 
 // Ready is the worker saying "I have capacity for one more task with
-// any of these commands; push me one when available." The server
-// responds with a Task message when a task becomes available; until
-// then no message is sent for this Ready. Each Ready consumes exactly
-// one Task; if the worker wants prefetching, it sends N Readys.
+// any of these commands; push me one when available." Each Ready
+// consumes up to `count` Tasks; the server responds with either:
+//   - one TaskAssignment per task (count==0 or 1; legacy path), or
+//   - one TaskBatch carrying up to count tasks (count > 1; Phase 6 / Q2).
+//
+// When count==0 the server defaults to 1 for backward compatibility
+// with clients that never set the field.
 type Ready struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Commands      []string               `protobuf:"bytes,1,rep,name=commands,proto3" json:"commands,omitempty"`
-	LeaseSeconds  int32                  `protobuf:"varint,2,opt,name=lease_seconds,json=leaseSeconds,proto3" json:"lease_seconds,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Commands     []string               `protobuf:"bytes,1,rep,name=commands,proto3" json:"commands,omitempty"`
+	LeaseSeconds int32                  `protobuf:"varint,2,opt,name=lease_seconds,json=leaseSeconds,proto3" json:"lease_seconds,omitempty"`
+	// count = max tasks to deliver in response. 0/1 = single TaskAssignment.
+	// >1 = TaskBatch capped at count. Server may deliver fewer than count
+	// if the queue empties before the batch fills.
+	Count         int32 `protobuf:"varint,3,opt,name=count,proto3" json:"count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -286,6 +293,13 @@ func (x *Ready) GetCommands() []string {
 func (x *Ready) GetLeaseSeconds() int32 {
 	if x != nil {
 		return x.LeaseSeconds
+	}
+	return 0
+}
+
+func (x *Ready) GetCount() int32 {
+	if x != nil {
+		return x.Count
 	}
 	return 0
 }
@@ -523,6 +537,55 @@ func (x *Abandon) GetTaskId() string {
 	return ""
 }
 
+// ResultBatch is the worker submitting completion for N tasks in a
+// single message. Equivalent to N Result events but the server
+// processes them with one BatchSubmit call (single Pebble batch +
+// single round-trip of acks), eliminating the per-task Send overhead
+// and amortising claim/result write paths. Phase 6 / Q2.
+type ResultBatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Results       []*Result              `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResultBatch) Reset() {
+	*x = ResultBatch{}
+	mi := &file_workerpb_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResultBatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResultBatch) ProtoMessage() {}
+
+func (x *ResultBatch) ProtoReflect() protoreflect.Message {
+	mi := &file_workerpb_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResultBatch.ProtoReflect.Descriptor instead.
+func (*ResultBatch) Descriptor() ([]byte, []int) {
+	return file_workerpb_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ResultBatch) GetResults() []*Result {
+	if x != nil {
+		return x.Results
+	}
+	return nil
+}
+
 type WorkerEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Event:
@@ -533,6 +596,7 @@ type WorkerEvent struct {
 	//	*WorkerEvent_Nack
 	//	*WorkerEvent_Heartbeat
 	//	*WorkerEvent_Abandon
+	//	*WorkerEvent_ResultBatch
 	Event         isWorkerEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -540,7 +604,7 @@ type WorkerEvent struct {
 
 func (x *WorkerEvent) Reset() {
 	*x = WorkerEvent{}
-	mi := &file_workerpb_proto_msgTypes[7]
+	mi := &file_workerpb_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -552,7 +616,7 @@ func (x *WorkerEvent) String() string {
 func (*WorkerEvent) ProtoMessage() {}
 
 func (x *WorkerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[7]
+	mi := &file_workerpb_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -565,7 +629,7 @@ func (x *WorkerEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkerEvent.ProtoReflect.Descriptor instead.
 func (*WorkerEvent) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{7}
+	return file_workerpb_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *WorkerEvent) GetEvent() isWorkerEvent_Event {
@@ -629,6 +693,15 @@ func (x *WorkerEvent) GetAbandon() *Abandon {
 	return nil
 }
 
+func (x *WorkerEvent) GetResultBatch() *ResultBatch {
+	if x != nil {
+		if x, ok := x.Event.(*WorkerEvent_ResultBatch); ok {
+			return x.ResultBatch
+		}
+	}
+	return nil
+}
+
 type isWorkerEvent_Event interface {
 	isWorkerEvent_Event()
 }
@@ -657,6 +730,10 @@ type WorkerEvent_Abandon struct {
 	Abandon *Abandon `protobuf:"bytes,6,opt,name=abandon,proto3,oneof"`
 }
 
+type WorkerEvent_ResultBatch struct {
+	ResultBatch *ResultBatch `protobuf:"bytes,7,opt,name=result_batch,json=resultBatch,proto3,oneof"`
+}
+
 func (*WorkerEvent_Hello) isWorkerEvent_Event() {}
 
 func (*WorkerEvent_Ready) isWorkerEvent_Event() {}
@@ -669,6 +746,8 @@ func (*WorkerEvent_Heartbeat) isWorkerEvent_Event() {}
 
 func (*WorkerEvent_Abandon) isWorkerEvent_Event() {}
 
+func (*WorkerEvent_ResultBatch) isWorkerEvent_Event() {}
+
 type HelloAck struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	WorkerId      string                 `protobuf:"bytes,1,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
@@ -679,7 +758,7 @@ type HelloAck struct {
 
 func (x *HelloAck) Reset() {
 	*x = HelloAck{}
-	mi := &file_workerpb_proto_msgTypes[8]
+	mi := &file_workerpb_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -691,7 +770,7 @@ func (x *HelloAck) String() string {
 func (*HelloAck) ProtoMessage() {}
 
 func (x *HelloAck) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[8]
+	mi := &file_workerpb_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -704,7 +783,7 @@ func (x *HelloAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HelloAck.ProtoReflect.Descriptor instead.
 func (*HelloAck) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{8}
+	return file_workerpb_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *HelloAck) GetWorkerId() string {
@@ -732,7 +811,7 @@ type TaskAssignment struct {
 
 func (x *TaskAssignment) Reset() {
 	*x = TaskAssignment{}
-	mi := &file_workerpb_proto_msgTypes[9]
+	mi := &file_workerpb_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -744,7 +823,7 @@ func (x *TaskAssignment) String() string {
 func (*TaskAssignment) ProtoMessage() {}
 
 func (x *TaskAssignment) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[9]
+	mi := &file_workerpb_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -757,12 +836,106 @@ func (x *TaskAssignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskAssignment.ProtoReflect.Descriptor instead.
 func (*TaskAssignment) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{9}
+	return file_workerpb_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *TaskAssignment) GetTask() *Task {
 	if x != nil {
 		return x.Task
+	}
+	return nil
+}
+
+// TaskBatch is the server's response to a Ready with count > 1.
+// Carries up to Ready.count Tasks in a single message. May be shorter
+// than count if the queue emptied; an empty TaskBatch is a legal
+// no-tasks-available response.
+type TaskBatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Tasks         []*Task                `protobuf:"bytes,1,rep,name=tasks,proto3" json:"tasks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaskBatch) Reset() {
+	*x = TaskBatch{}
+	mi := &file_workerpb_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaskBatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaskBatch) ProtoMessage() {}
+
+func (x *TaskBatch) ProtoReflect() protoreflect.Message {
+	mi := &file_workerpb_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaskBatch.ProtoReflect.Descriptor instead.
+func (*TaskBatch) Descriptor() ([]byte, []int) {
+	return file_workerpb_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *TaskBatch) GetTasks() []*Task {
+	if x != nil {
+		return x.Tasks
+	}
+	return nil
+}
+
+// ResultAckBatch acknowledges all results in a ResultBatch in one
+// message. Order matches the ResultBatch.results order.
+type ResultAckBatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Acks          []*ResultAck           `protobuf:"bytes,1,rep,name=acks,proto3" json:"acks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResultAckBatch) Reset() {
+	*x = ResultAckBatch{}
+	mi := &file_workerpb_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResultAckBatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResultAckBatch) ProtoMessage() {}
+
+func (x *ResultAckBatch) ProtoReflect() protoreflect.Message {
+	mi := &file_workerpb_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResultAckBatch.ProtoReflect.Descriptor instead.
+func (*ResultAckBatch) Descriptor() ([]byte, []int) {
+	return file_workerpb_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ResultAckBatch) GetAcks() []*ResultAck {
+	if x != nil {
+		return x.Acks
 	}
 	return nil
 }
@@ -780,7 +953,7 @@ type ResultAck struct {
 
 func (x *ResultAck) Reset() {
 	*x = ResultAck{}
-	mi := &file_workerpb_proto_msgTypes[10]
+	mi := &file_workerpb_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -792,7 +965,7 @@ func (x *ResultAck) String() string {
 func (*ResultAck) ProtoMessage() {}
 
 func (x *ResultAck) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[10]
+	mi := &file_workerpb_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -805,7 +978,7 @@ func (x *ResultAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResultAck.ProtoReflect.Descriptor instead.
 func (*ResultAck) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{10}
+	return file_workerpb_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ResultAck) GetTaskId() string {
@@ -840,7 +1013,7 @@ type HeartbeatAck struct {
 
 func (x *HeartbeatAck) Reset() {
 	*x = HeartbeatAck{}
-	mi := &file_workerpb_proto_msgTypes[11]
+	mi := &file_workerpb_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -852,7 +1025,7 @@ func (x *HeartbeatAck) String() string {
 func (*HeartbeatAck) ProtoMessage() {}
 
 func (x *HeartbeatAck) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[11]
+	mi := &file_workerpb_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -865,7 +1038,7 @@ func (x *HeartbeatAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatAck.ProtoReflect.Descriptor instead.
 func (*HeartbeatAck) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{11}
+	return file_workerpb_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *HeartbeatAck) GetTaskId() string {
@@ -902,7 +1075,7 @@ type NackAck struct {
 
 func (x *NackAck) Reset() {
 	*x = NackAck{}
-	mi := &file_workerpb_proto_msgTypes[12]
+	mi := &file_workerpb_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -914,7 +1087,7 @@ func (x *NackAck) String() string {
 func (*NackAck) ProtoMessage() {}
 
 func (x *NackAck) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[12]
+	mi := &file_workerpb_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -927,7 +1100,7 @@ func (x *NackAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NackAck.ProtoReflect.Descriptor instead.
 func (*NackAck) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{12}
+	return file_workerpb_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *NackAck) GetTaskId() string {
@@ -976,7 +1149,7 @@ type AbandonAck struct {
 
 func (x *AbandonAck) Reset() {
 	*x = AbandonAck{}
-	mi := &file_workerpb_proto_msgTypes[13]
+	mi := &file_workerpb_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -988,7 +1161,7 @@ func (x *AbandonAck) String() string {
 func (*AbandonAck) ProtoMessage() {}
 
 func (x *AbandonAck) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[13]
+	mi := &file_workerpb_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1001,7 +1174,7 @@ func (x *AbandonAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AbandonAck.ProtoReflect.Descriptor instead.
 func (*AbandonAck) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{13}
+	return file_workerpb_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AbandonAck) GetTaskId() string {
@@ -1035,7 +1208,7 @@ type ServerError struct {
 
 func (x *ServerError) Reset() {
 	*x = ServerError{}
-	mi := &file_workerpb_proto_msgTypes[14]
+	mi := &file_workerpb_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1047,7 +1220,7 @@ func (x *ServerError) String() string {
 func (*ServerError) ProtoMessage() {}
 
 func (x *ServerError) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[14]
+	mi := &file_workerpb_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1060,7 +1233,7 @@ func (x *ServerError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerError.ProtoReflect.Descriptor instead.
 func (*ServerError) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{14}
+	return file_workerpb_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ServerError) GetMessage() string {
@@ -1088,6 +1261,8 @@ type ServerEvent struct {
 	//	*ServerEvent_NackAck
 	//	*ServerEvent_AbandonAck
 	//	*ServerEvent_Error
+	//	*ServerEvent_TaskBatch
+	//	*ServerEvent_ResultAckBatch
 	Event         isServerEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1095,7 +1270,7 @@ type ServerEvent struct {
 
 func (x *ServerEvent) Reset() {
 	*x = ServerEvent{}
-	mi := &file_workerpb_proto_msgTypes[15]
+	mi := &file_workerpb_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1107,7 +1282,7 @@ func (x *ServerEvent) String() string {
 func (*ServerEvent) ProtoMessage() {}
 
 func (x *ServerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_workerpb_proto_msgTypes[15]
+	mi := &file_workerpb_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1120,7 +1295,7 @@ func (x *ServerEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerEvent.ProtoReflect.Descriptor instead.
 func (*ServerEvent) Descriptor() ([]byte, []int) {
-	return file_workerpb_proto_rawDescGZIP(), []int{15}
+	return file_workerpb_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ServerEvent) GetEvent() isServerEvent_Event {
@@ -1193,6 +1368,24 @@ func (x *ServerEvent) GetError() *ServerError {
 	return nil
 }
 
+func (x *ServerEvent) GetTaskBatch() *TaskBatch {
+	if x != nil {
+		if x, ok := x.Event.(*ServerEvent_TaskBatch); ok {
+			return x.TaskBatch
+		}
+	}
+	return nil
+}
+
+func (x *ServerEvent) GetResultAckBatch() *ResultAckBatch {
+	if x != nil {
+		if x, ok := x.Event.(*ServerEvent_ResultAckBatch); ok {
+			return x.ResultAckBatch
+		}
+	}
+	return nil
+}
+
 type isServerEvent_Event interface {
 	isServerEvent_Event()
 }
@@ -1225,6 +1418,14 @@ type ServerEvent_Error struct {
 	Error *ServerError `protobuf:"bytes,7,opt,name=error,proto3,oneof"`
 }
 
+type ServerEvent_TaskBatch struct {
+	TaskBatch *TaskBatch `protobuf:"bytes,8,opt,name=task_batch,json=taskBatch,proto3,oneof"`
+}
+
+type ServerEvent_ResultAckBatch struct {
+	ResultAckBatch *ResultAckBatch `protobuf:"bytes,9,opt,name=result_ack_batch,json=resultAckBatch,proto3,oneof"`
+}
+
 func (*ServerEvent_HelloAck) isServerEvent_Event() {}
 
 func (*ServerEvent_Task) isServerEvent_Event() {}
@@ -1238,6 +1439,10 @@ func (*ServerEvent_NackAck) isServerEvent_Event() {}
 func (*ServerEvent_AbandonAck) isServerEvent_Event() {}
 
 func (*ServerEvent_Error) isServerEvent_Event() {}
+
+func (*ServerEvent_TaskBatch) isServerEvent_Event() {}
+
+func (*ServerEvent_ResultAckBatch) isServerEvent_Event() {}
 
 var File_workerpb_proto protoreflect.FileDescriptor
 
@@ -1264,10 +1469,11 @@ const file_workerpb_proto_rawDesc = "" +
 	"updated_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\":\n" +
 	"\x05Hello\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12\x1b\n" +
-	"\tworker_id\x18\x02 \x01(\tR\bworkerId\"H\n" +
+	"\tworker_id\x18\x02 \x01(\tR\bworkerId\"^\n" +
 	"\x05Ready\x12\x1a\n" +
 	"\bcommands\x18\x01 \x03(\tR\bcommands\x12#\n" +
-	"\rlease_seconds\x18\x02 \x01(\x05R\fleaseSeconds\"p\n" +
+	"\rlease_seconds\x18\x02 \x01(\x05R\fleaseSeconds\x12\x14\n" +
+	"\x05count\x18\x03 \x01(\x05R\x05count\"p\n" +
 	"\x06Result\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1f\n" +
@@ -1282,20 +1488,27 @@ const file_workerpb_proto_rawDesc = "" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12%\n" +
 	"\x0eextend_seconds\x18\x02 \x01(\x05R\rextendSeconds\"\"\n" +
 	"\aAbandon\x12\x17\n" +
-	"\atask_id\x18\x01 \x01(\tR\x06taskId\"\x9e\x02\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\"9\n" +
+	"\vResultBatch\x12*\n" +
+	"\aresults\x18\x01 \x03(\v2\x10.workerpb.ResultR\aresults\"\xda\x02\n" +
 	"\vWorkerEvent\x12'\n" +
 	"\x05hello\x18\x01 \x01(\v2\x0f.workerpb.HelloH\x00R\x05hello\x12'\n" +
 	"\x05ready\x18\x02 \x01(\v2\x0f.workerpb.ReadyH\x00R\x05ready\x12*\n" +
 	"\x06result\x18\x03 \x01(\v2\x10.workerpb.ResultH\x00R\x06result\x12$\n" +
 	"\x04nack\x18\x04 \x01(\v2\x0e.workerpb.NackH\x00R\x04nack\x123\n" +
 	"\theartbeat\x18\x05 \x01(\v2\x13.workerpb.HeartbeatH\x00R\theartbeat\x12-\n" +
-	"\aabandon\x18\x06 \x01(\v2\x11.workerpb.AbandonH\x00R\aabandonB\a\n" +
+	"\aabandon\x18\x06 \x01(\v2\x11.workerpb.AbandonH\x00R\aabandon\x12:\n" +
+	"\fresult_batch\x18\a \x01(\v2\x15.workerpb.ResultBatchH\x00R\vresultBatchB\a\n" +
 	"\x05event\"D\n" +
 	"\bHelloAck\x12\x1b\n" +
 	"\tworker_id\x18\x01 \x01(\tR\bworkerId\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"4\n" +
 	"\x0eTaskAssignment\x12\"\n" +
-	"\x04task\x18\x01 \x01(\v2\x0e.workerpb.TaskR\x04task\"Y\n" +
+	"\x04task\x18\x01 \x01(\v2\x0e.workerpb.TaskR\x04task\"1\n" +
+	"\tTaskBatch\x12$\n" +
+	"\x05tasks\x18\x01 \x03(\v2\x0e.workerpb.TaskR\x05tasks\"9\n" +
+	"\x0eResultAckBatch\x12'\n" +
+	"\x04acks\x18\x01 \x03(\v2\x13.workerpb.ResultAckR\x04acks\"Y\n" +
 	"\tResultAck\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x0e\n" +
 	"\x02ok\x18\x02 \x01(\bR\x02ok\x12#\n" +
@@ -1317,7 +1530,7 @@ const file_workerpb_proto_rawDesc = "" +
 	"\rerror_message\x18\x03 \x01(\tR\ferrorMessage\";\n" +
 	"\vServerError\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x12\n" +
-	"\x04code\x18\x02 \x01(\tR\x04code\"\x86\x03\n" +
+	"\x04code\x18\x02 \x01(\tR\x04code\"\x82\x04\n" +
 	"\vServerEvent\x121\n" +
 	"\thello_ack\x18\x01 \x01(\v2\x12.workerpb.HelloAckH\x00R\bhelloAck\x12.\n" +
 	"\x04task\x18\x02 \x01(\v2\x18.workerpb.TaskAssignmentH\x00R\x04task\x124\n" +
@@ -1327,7 +1540,10 @@ const file_workerpb_proto_rawDesc = "" +
 	"\bnack_ack\x18\x05 \x01(\v2\x11.workerpb.NackAckH\x00R\anackAck\x127\n" +
 	"\vabandon_ack\x18\x06 \x01(\v2\x14.workerpb.AbandonAckH\x00R\n" +
 	"abandonAck\x12-\n" +
-	"\x05error\x18\a \x01(\v2\x15.workerpb.ServerErrorH\x00R\x05errorB\a\n" +
+	"\x05error\x18\a \x01(\v2\x15.workerpb.ServerErrorH\x00R\x05error\x124\n" +
+	"\n" +
+	"task_batch\x18\b \x01(\v2\x13.workerpb.TaskBatchH\x00R\ttaskBatch\x12D\n" +
+	"\x10result_ack_batch\x18\t \x01(\v2\x18.workerpb.ResultAckBatchH\x00R\x0eresultAckBatchB\a\n" +
 	"\x05event2J\n" +
 	"\fWorkerStream\x12:\n" +
 	"\x06Stream\x12\x15.workerpb.WorkerEvent\x1a\x15.workerpb.ServerEvent(\x010\x01B:Z8github.com/osvaldoandrade/codeq/internal/worker/workerpbb\x06proto3"
@@ -1344,7 +1560,7 @@ func file_workerpb_proto_rawDescGZIP() []byte {
 	return file_workerpb_proto_rawDescData
 }
 
-var file_workerpb_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_workerpb_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_workerpb_proto_goTypes = []any{
 	(*Task)(nil),                  // 0: workerpb.Task
 	(*Hello)(nil),                 // 1: workerpb.Hello
@@ -1353,41 +1569,50 @@ var file_workerpb_proto_goTypes = []any{
 	(*Nack)(nil),                  // 4: workerpb.Nack
 	(*Heartbeat)(nil),             // 5: workerpb.Heartbeat
 	(*Abandon)(nil),               // 6: workerpb.Abandon
-	(*WorkerEvent)(nil),           // 7: workerpb.WorkerEvent
-	(*HelloAck)(nil),              // 8: workerpb.HelloAck
-	(*TaskAssignment)(nil),        // 9: workerpb.TaskAssignment
-	(*ResultAck)(nil),             // 10: workerpb.ResultAck
-	(*HeartbeatAck)(nil),          // 11: workerpb.HeartbeatAck
-	(*NackAck)(nil),               // 12: workerpb.NackAck
-	(*AbandonAck)(nil),            // 13: workerpb.AbandonAck
-	(*ServerError)(nil),           // 14: workerpb.ServerError
-	(*ServerEvent)(nil),           // 15: workerpb.ServerEvent
-	(*timestamppb.Timestamp)(nil), // 16: google.protobuf.Timestamp
+	(*ResultBatch)(nil),           // 7: workerpb.ResultBatch
+	(*WorkerEvent)(nil),           // 8: workerpb.WorkerEvent
+	(*HelloAck)(nil),              // 9: workerpb.HelloAck
+	(*TaskAssignment)(nil),        // 10: workerpb.TaskAssignment
+	(*TaskBatch)(nil),             // 11: workerpb.TaskBatch
+	(*ResultAckBatch)(nil),        // 12: workerpb.ResultAckBatch
+	(*ResultAck)(nil),             // 13: workerpb.ResultAck
+	(*HeartbeatAck)(nil),          // 14: workerpb.HeartbeatAck
+	(*NackAck)(nil),               // 15: workerpb.NackAck
+	(*AbandonAck)(nil),            // 16: workerpb.AbandonAck
+	(*ServerError)(nil),           // 17: workerpb.ServerError
+	(*ServerEvent)(nil),           // 18: workerpb.ServerEvent
+	(*timestamppb.Timestamp)(nil), // 19: google.protobuf.Timestamp
 }
 var file_workerpb_proto_depIdxs = []int32{
-	16, // 0: workerpb.Task.created_at:type_name -> google.protobuf.Timestamp
-	16, // 1: workerpb.Task.updated_at:type_name -> google.protobuf.Timestamp
-	1,  // 2: workerpb.WorkerEvent.hello:type_name -> workerpb.Hello
-	2,  // 3: workerpb.WorkerEvent.ready:type_name -> workerpb.Ready
-	3,  // 4: workerpb.WorkerEvent.result:type_name -> workerpb.Result
-	4,  // 5: workerpb.WorkerEvent.nack:type_name -> workerpb.Nack
-	5,  // 6: workerpb.WorkerEvent.heartbeat:type_name -> workerpb.Heartbeat
-	6,  // 7: workerpb.WorkerEvent.abandon:type_name -> workerpb.Abandon
-	0,  // 8: workerpb.TaskAssignment.task:type_name -> workerpb.Task
-	8,  // 9: workerpb.ServerEvent.hello_ack:type_name -> workerpb.HelloAck
-	9,  // 10: workerpb.ServerEvent.task:type_name -> workerpb.TaskAssignment
-	10, // 11: workerpb.ServerEvent.result_ack:type_name -> workerpb.ResultAck
-	11, // 12: workerpb.ServerEvent.heartbeat_ack:type_name -> workerpb.HeartbeatAck
-	12, // 13: workerpb.ServerEvent.nack_ack:type_name -> workerpb.NackAck
-	13, // 14: workerpb.ServerEvent.abandon_ack:type_name -> workerpb.AbandonAck
-	14, // 15: workerpb.ServerEvent.error:type_name -> workerpb.ServerError
-	7,  // 16: workerpb.WorkerStream.Stream:input_type -> workerpb.WorkerEvent
-	15, // 17: workerpb.WorkerStream.Stream:output_type -> workerpb.ServerEvent
-	17, // [17:18] is the sub-list for method output_type
-	16, // [16:17] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	19, // 0: workerpb.Task.created_at:type_name -> google.protobuf.Timestamp
+	19, // 1: workerpb.Task.updated_at:type_name -> google.protobuf.Timestamp
+	3,  // 2: workerpb.ResultBatch.results:type_name -> workerpb.Result
+	1,  // 3: workerpb.WorkerEvent.hello:type_name -> workerpb.Hello
+	2,  // 4: workerpb.WorkerEvent.ready:type_name -> workerpb.Ready
+	3,  // 5: workerpb.WorkerEvent.result:type_name -> workerpb.Result
+	4,  // 6: workerpb.WorkerEvent.nack:type_name -> workerpb.Nack
+	5,  // 7: workerpb.WorkerEvent.heartbeat:type_name -> workerpb.Heartbeat
+	6,  // 8: workerpb.WorkerEvent.abandon:type_name -> workerpb.Abandon
+	7,  // 9: workerpb.WorkerEvent.result_batch:type_name -> workerpb.ResultBatch
+	0,  // 10: workerpb.TaskAssignment.task:type_name -> workerpb.Task
+	0,  // 11: workerpb.TaskBatch.tasks:type_name -> workerpb.Task
+	13, // 12: workerpb.ResultAckBatch.acks:type_name -> workerpb.ResultAck
+	9,  // 13: workerpb.ServerEvent.hello_ack:type_name -> workerpb.HelloAck
+	10, // 14: workerpb.ServerEvent.task:type_name -> workerpb.TaskAssignment
+	13, // 15: workerpb.ServerEvent.result_ack:type_name -> workerpb.ResultAck
+	14, // 16: workerpb.ServerEvent.heartbeat_ack:type_name -> workerpb.HeartbeatAck
+	15, // 17: workerpb.ServerEvent.nack_ack:type_name -> workerpb.NackAck
+	16, // 18: workerpb.ServerEvent.abandon_ack:type_name -> workerpb.AbandonAck
+	17, // 19: workerpb.ServerEvent.error:type_name -> workerpb.ServerError
+	11, // 20: workerpb.ServerEvent.task_batch:type_name -> workerpb.TaskBatch
+	12, // 21: workerpb.ServerEvent.result_ack_batch:type_name -> workerpb.ResultAckBatch
+	8,  // 22: workerpb.WorkerStream.Stream:input_type -> workerpb.WorkerEvent
+	18, // 23: workerpb.WorkerStream.Stream:output_type -> workerpb.ServerEvent
+	23, // [23:24] is the sub-list for method output_type
+	22, // [22:23] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_workerpb_proto_init() }
@@ -1395,15 +1620,16 @@ func file_workerpb_proto_init() {
 	if File_workerpb_proto != nil {
 		return
 	}
-	file_workerpb_proto_msgTypes[7].OneofWrappers = []any{
+	file_workerpb_proto_msgTypes[8].OneofWrappers = []any{
 		(*WorkerEvent_Hello)(nil),
 		(*WorkerEvent_Ready)(nil),
 		(*WorkerEvent_Result)(nil),
 		(*WorkerEvent_Nack)(nil),
 		(*WorkerEvent_Heartbeat)(nil),
 		(*WorkerEvent_Abandon)(nil),
+		(*WorkerEvent_ResultBatch)(nil),
 	}
-	file_workerpb_proto_msgTypes[15].OneofWrappers = []any{
+	file_workerpb_proto_msgTypes[18].OneofWrappers = []any{
 		(*ServerEvent_HelloAck)(nil),
 		(*ServerEvent_Task)(nil),
 		(*ServerEvent_ResultAck)(nil),
@@ -1411,6 +1637,8 @@ func file_workerpb_proto_init() {
 		(*ServerEvent_NackAck)(nil),
 		(*ServerEvent_AbandonAck)(nil),
 		(*ServerEvent_Error)(nil),
+		(*ServerEvent_TaskBatch)(nil),
+		(*ServerEvent_ResultAckBatch)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1418,7 +1646,7 @@ func file_workerpb_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_workerpb_proto_rawDesc), len(file_workerpb_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/producerclient/client.go
+++ b/pkg/producerclient/client.go
@@ -103,7 +103,10 @@ type CreateRequest struct {
 
 // Session is one authenticated stream. Produce on it is safe to call
 // from many goroutines concurrently. Close to release reader goroutine
-// and stream resources.
+// and stream resources. Sends go through a dedicated writer goroutine
+// reading from sendCh — Phase 6 / M1 profile showed sendMu contention
+// across pipelined Produce callers was a meaningful chunk of total
+// delay.
 type Session struct {
 	cli     *Client
 	stream  producerpb.ProducerStream_StreamClient
@@ -114,7 +117,11 @@ type Session struct {
 	tenantID string
 	subject  string
 
-	sendMu  sync.Mutex // serializes stream.Send
+	streamCtx  context.Context
+	sendCh     chan *producerpb.ProducerEvent
+	sendErr    atomic.Pointer[error]
+	writerDone chan struct{}
+
 	seq     atomic.Uint64
 	pending sync.Map // seq → chan ackResult
 
@@ -122,6 +129,11 @@ type Session struct {
 	readErrMu sync.Mutex
 	readDone  chan struct{}
 }
+
+// sendChanBufferClient is sized to absorb N pipelined CreateTask events
+// from many goroutines. 256 keeps the writer's queue shallow while
+// avoiding ctx-cancelled errors during transient gRPC flush latency.
+const sendChanBufferClient = 256
 
 // ackResult is what slot goroutines receive from the reader.
 type ackResult struct {
@@ -142,12 +154,18 @@ func (c *Client) Connect(ctx context.Context) (*Session, error) {
 		return nil, fmt.Errorf("producerclient: open stream: %w", err)
 	}
 	sess := &Session{
-		cli:      c,
-		stream:   stream,
-		cancel:   cancel,
-		readDone: make(chan struct{}),
+		cli:        c,
+		stream:     stream,
+		cancel:     cancel,
+		readDone:   make(chan struct{}),
+		streamCtx:  streamCtx,
+		sendCh:     make(chan *producerpb.ProducerEvent, sendChanBufferClient),
+		writerDone: make(chan struct{}),
 	}
+	go sess.writeLoop()
 	if err := sess.handshake(); err != nil {
+		close(sess.sendCh)
+		<-sess.writerDone
 		cancel()
 		return nil, err
 	}
@@ -155,10 +173,29 @@ func (c *Client) Connect(ctx context.Context) (*Session, error) {
 	return sess, nil
 }
 
+func (s *Session) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
 func (s *Session) send(ev *producerpb.ProducerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.streamCtx.Done():
+		return s.streamCtx.Err()
+	}
 }
 
 func (s *Session) handshake() error {
@@ -323,14 +360,20 @@ func (s *Session) TenantID() string { return s.tenantID }
 // Subject returns the JWT subject the server resolved this session to.
 func (s *Session) Subject() string { return s.subject }
 
-// Close cancels the stream, releases the reader goroutine, and unblocks
-// any pending Produce calls with an error. Safe to call multiple times.
+// Close cancels the stream, releases the reader + writer goroutines,
+// and unblocks any pending Produce calls with an error. Safe to call
+// multiple times.
 func (s *Session) Close() error {
 	s.closeMu.Lock()
 	defer s.closeMu.Unlock()
 	if s.closed.Swap(true) {
 		return nil
 	}
+	// Drain the writer first so any in-flight send completes (or fails
+	// cleanly via sendErr) before we tear the stream down. Closing
+	// sendCh signals writeLoop to exit once it finishes the queue.
+	close(s.sendCh)
+	<-s.writerDone
 	// CloseSend tells the server we're done writing — it gets a clean
 	// EOF on its Recv loop. cancel() then propagates the close to the
 	// reader so it exits as well.

--- a/pkg/workerclient/client.go
+++ b/pkg/workerclient/client.go
@@ -41,11 +41,21 @@ type Config struct {
 	Commands []string
 
 	// Concurrency is the number of in-flight tasks the client maintains.
-	// Defaults to 1. Each slot holds one Ready→Task→Result cycle.
+	// Defaults to 1. Each slot holds one Ready→Task(s)→Result(s) cycle.
 	Concurrency int
 
 	// LeaseSeconds is sent on each Ready. 0 means "server default".
 	LeaseSeconds int
+
+	// BatchSize controls how many tasks each slot tries to claim per
+	// Ready, and how many Results coalesce into one ResultBatch. 0/1
+	// keeps the legacy single-task path (one Ready → one Task → one
+	// Result per cycle). >1 enables Phase 6 / Q2 batching: each cycle
+	// pulls up to BatchSize Tasks via Ready{count=BatchSize} → server
+	// replies with TaskBatch, and the resulting Results are sent back
+	// as one ResultBatch. Amortises gRPC framing + Pebble commit cost
+	// across the batch.
+	BatchSize int
 
 	// IdleBackoff is how long a slot waits before re-sending Ready when
 	// the previous Ready didn't yield a task within ReadyTimeout. Defaults
@@ -139,8 +149,13 @@ func (c *Client) Run(ctx context.Context, h Handler) error {
 type session struct {
 	cfg    Config
 	stream workerpb.WorkerStream_StreamClient
-	taskCh chan *workerpb.Task
-	log    *slog.Logger
+	// batchCh delivers each Ready's response to one slot. For
+	// BatchSize<=1 the batch contains exactly one task (legacy single-
+	// task path). For BatchSize>1 it contains up to BatchSize tasks
+	// from a single TaskBatch — kept together so the slot can issue
+	// one ResultBatch in response without serial Send overhead.
+	batchCh chan []*workerpb.Task
+	log     *slog.Logger
 
 	ctx        context.Context
 	sendCh     chan *workerpb.WorkerEvent
@@ -157,7 +172,7 @@ func newSession(ctx context.Context, cfg Config, stream workerpb.WorkerStream_St
 	s := &session{
 		cfg:        cfg,
 		stream:     stream,
-		taskCh:     make(chan *workerpb.Task),
+		batchCh:    make(chan []*workerpb.Task),
 		log:        cfg.Logger,
 		ctx:        ctx,
 		sendCh:     make(chan *workerpb.WorkerEvent, sendChanBufferClient),
@@ -210,7 +225,7 @@ func (s *session) run(ctx context.Context, h Handler) error {
 	readerErrCh := make(chan error, 1)
 	go func() {
 		readerErrCh <- s.readLoop(ctx)
-		close(s.taskCh)
+		close(s.batchCh)
 	}()
 
 	// N slots in parallel, each looping: Ready → Task → Handler → Result.
@@ -269,11 +284,21 @@ func (s *session) readLoop(ctx context.Context) error {
 		switch e := ev.Event.(type) {
 		case *workerpb.ServerEvent_Task:
 			select {
-			case s.taskCh <- e.Task.Task:
+			case s.batchCh <- []*workerpb.Task{e.Task.Task}:
+			case <-ctx.Done():
+				return nil
+			}
+		case *workerpb.ServerEvent_TaskBatch:
+			if len(e.TaskBatch.Tasks) == 0 {
+				continue
+			}
+			select {
+			case s.batchCh <- e.TaskBatch.Tasks:
 			case <-ctx.Done():
 				return nil
 			}
 		case *workerpb.ServerEvent_ResultAck,
+			*workerpb.ServerEvent_ResultAckBatch,
 			*workerpb.ServerEvent_HeartbeatAck,
 			*workerpb.ServerEvent_NackAck,
 			*workerpb.ServerEvent_AbandonAck:
@@ -290,6 +315,10 @@ func (s *session) readLoop(ctx context.Context) error {
 }
 
 func (s *session) slotLoop(ctx context.Context, h Handler) {
+	batchSize := s.cfg.BatchSize
+	if batchSize < 1 {
+		batchSize = 1
+	}
 	for {
 		if ctx.Err() != nil {
 			return
@@ -298,6 +327,7 @@ func (s *session) slotLoop(ctx context.Context, h Handler) {
 			Ready: &workerpb.Ready{
 				Commands:     s.cfg.Commands,
 				LeaseSeconds: int32(s.cfg.LeaseSeconds),
+				Count:        int32(batchSize),
 			},
 		}}); err != nil {
 			s.log.Warn("workerclient: send ready", "err", err)
@@ -305,13 +335,58 @@ func (s *session) slotLoop(ctx context.Context, h Handler) {
 		}
 
 		select {
-		case t, ok := <-s.taskCh:
+		case batch, ok := <-s.batchCh:
 			if !ok {
 				return
 			}
-			s.dispatch(ctx, h, t)
+			s.dispatchBatch(ctx, h, batch)
 		case <-ctx.Done():
 			return
+		}
+	}
+}
+
+// dispatchBatch invokes the handler for every task in the batch and
+// coalesces the results into one ResultBatch send when len(batch)>1.
+// Splits Result vs Nack vs Abandon per result kind: only "Completed"
+// and "Failed" carry through the batch path because BatchSubmit on
+// the server only handles Submit. Nack and Abandon are rare under
+// load and fall back to per-message sends.
+func (s *session) dispatchBatch(ctx context.Context, h Handler, batch []*workerpb.Task) {
+	if len(batch) == 1 {
+		s.dispatch(ctx, h, batch[0])
+		return
+	}
+	results := make([]*workerpb.Result, 0, len(batch))
+	for _, pt := range batch {
+		t := protoToTask(pt)
+		res := h(ctx, t)
+		switch res.kind {
+		case resultCompleted:
+			var payload []byte
+			if res.body != nil {
+				if b, err := sonic.Marshal(res.body); err == nil {
+					payload = b
+				}
+			}
+			results = append(results, &workerpb.Result{
+				TaskId: pt.Id, Status: "COMPLETED", ResultJson: payload,
+			})
+		case resultFailed:
+			results = append(results, &workerpb.Result{
+				TaskId: pt.Id, Status: "FAILED", Error: res.err,
+			})
+		default:
+			// Nack / Abandon don't go through BatchSubmit on the server;
+			// send per-task so they take the rare-path handler.
+			_ = s.applyResult(pt.Id, res)
+		}
+	}
+	if len(results) > 0 {
+		if err := s.send(&workerpb.WorkerEvent{Event: &workerpb.WorkerEvent_ResultBatch{
+			ResultBatch: &workerpb.ResultBatch{Results: results},
+		}}); err != nil {
+			s.log.Warn("workerclient: send result batch", "err", err)
 		}
 	}
 }

--- a/pkg/workerclient/client.go
+++ b/pkg/workerclient/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -124,29 +125,76 @@ func (c *Client) Run(ctx context.Context, h Handler) error {
 		return fmt.Errorf("workerclient: open stream: %w", err)
 	}
 
-	sess := &session{
-		cfg:    c.cfg,
-		stream: stream,
-		taskCh: make(chan *workerpb.Task),
-		log:    c.cfg.Logger,
-	}
+	sess := newSession(ctx, c.cfg, stream)
+	defer sess.closeWriter()
 	return sess.run(ctx, h)
 }
 
 // session bundles the per-Run mutable state. One session per Run call.
+// Sends are funnelled through a single writer goroutine reading from
+// sendCh instead of a mutex around stream.Send: profile (Phase 6)
+// pinned the client-side sendMu at ~26% of the mutex profile under
+// 128-slot load, with the per-slot Ready/Result loops fighting each
+// other for the lock.
 type session struct {
 	cfg    Config
 	stream workerpb.WorkerStream_StreamClient
 	taskCh chan *workerpb.Task
 	log    *slog.Logger
 
-	sendMu sync.Mutex // serializes stream.Send across slots + reader
+	ctx        context.Context
+	sendCh     chan *workerpb.WorkerEvent
+	sendErr    atomic.Pointer[error]
+	writerDone chan struct{}
+}
+
+// sendChanBufferClient is sized to absorb a burst of Ready/Result
+// messages from every slot in flight. 256 keeps queueing latency low
+// while avoiding spurious context cancellations during gRPC flushes.
+const sendChanBufferClient = 256
+
+func newSession(ctx context.Context, cfg Config, stream workerpb.WorkerStream_StreamClient) *session {
+	s := &session{
+		cfg:        cfg,
+		stream:     stream,
+		taskCh:     make(chan *workerpb.Task),
+		log:        cfg.Logger,
+		ctx:        ctx,
+		sendCh:     make(chan *workerpb.WorkerEvent, sendChanBufferClient),
+		writerDone: make(chan struct{}),
+	}
+	go s.writeLoop()
+	return s
+}
+
+func (s *session) writeLoop() {
+	defer close(s.writerDone)
+	for ev := range s.sendCh {
+		if s.sendErr.Load() != nil {
+			continue
+		}
+		if err := s.stream.Send(ev); err != nil {
+			cp := err
+			s.sendErr.Store(&cp)
+		}
+	}
+}
+
+func (s *session) closeWriter() {
+	close(s.sendCh)
+	<-s.writerDone
 }
 
 func (s *session) send(ev *workerpb.WorkerEvent) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.stream.Send(ev)
+	if errPtr := s.sendErr.Load(); errPtr != nil {
+		return *errPtr
+	}
+	select {
+	case s.sendCh <- ev:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
 }
 
 func (s *session) run(ctx context.Context, h Handler) error {

--- a/pkg/workerclient/client_test.go
+++ b/pkg/workerclient/client_test.go
@@ -289,3 +289,54 @@ func TestClient_RunRequiresHandler(t *testing.T) {
 		t.Error("nil handler should error")
 	}
 }
+
+// TestClient_RunBatchSize drives the Phase 6 / Q2 batch path end-to-end:
+// 20 tasks enqueued, BatchSize=8, Concurrency=1. The single slot should
+// pull tasks in batches and submit results as ResultBatches. Test
+// passes if all 20 tasks are processed within the deadline.
+func TestClient_RunBatchSize(t *testing.T) {
+	f := newFixture(t)
+	defer f.stop()
+
+	const n = 20
+	for i := range n {
+		f.enqueue(t, fmt.Sprintf(`{"command":"GENERATE_MASTER","payload":{"i":%d}}`, i))
+	}
+
+	c, err := workerclient.New(workerclient.Config{
+		Addr:         f.streamAddr,
+		Token:        "dev-token",
+		Commands:     []string{"GENERATE_MASTER"},
+		Concurrency:  1,
+		BatchSize:    8,
+		LeaseSeconds: 60,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer c.Close()
+
+	var processed atomic.Int64
+	done := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		_ = c.Run(ctx, func(_ context.Context, _ workerclient.Task) workerclient.Result {
+			if processed.Add(1) >= n {
+				select {
+				case <-done:
+				default:
+					close(done)
+				}
+			}
+			return workerclient.Completed(map[string]any{"ok": true})
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("processed only %d/%d before timeout", processed.Load(), n)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 6 / Q2 adds native batch ops to the worker streaming protocol so a worker can claim N tasks per Ready and submit N results per send, collapsing the 2-RTT-per-task pattern that bounded the single-task ciclo full at ~30k tasks/s. Stacks on M1 (#534).

## Protocol changes (backward-compatible)

\`internal/worker/proto/workerpb.proto\`:

| Message | Change |
|---|---|
| \`Ready\` | New \`count\` field. 0/1 = legacy single-task; >1 = batched (server replies with TaskBatch). |
| \`ResultBatch\` | NEW WorkerEvent variant carrying N Results. |
| \`TaskBatch\` | NEW ServerEvent variant carrying up to count Tasks. |
| \`ResultAckBatch\` | NEW ServerEvent variant; order matches ResultBatch.results. |

Clients that never set Ready.count and never send ResultBatch see the legacy path unchanged. Server detects mode per-Ready.

## Server (\`internal/worker/server.go\`)

- \`handleReady\` splits to \`handleReadyOne\` (legacy) and \`handleReadyBatch\` (claim up to count, send one TaskBatch).
- Greedy claim: first task waits up to MaxClaimRetries × ClaimPollDelay so idle workers don't busy-loop; subsequent tasks pull only if the scheduler returns immediately.
- \`handleResultBatch\` funnels through \`ResultsService.BatchSubmit\` (1 GetTasksBatch + 1 BatchUpdateTasksOnComplete on Pebble) and emits a single ResultAckBatch matching input order.

## Client (\`pkg/workerclient/client.go\`)

- \`Config.BatchSize\` controls per-slot \`Ready.count\`.
- Reader fans either TaskAssignment (legacy) or TaskBatch into the same \`batchCh chan []*Task\` so slot logic stays uniform — batch of 1 vs batch of N.
- \`dispatchBatch\` routes resultCompleted / resultFailed through ResultBatch and falls back to per-task send for Nack / Abandon (BatchSubmit doesn't handle those — they take the rare-path handler).

## Numbers (ciclo full, 20s, single Pebble node)

| BatchSize | tasks/s |
|---|---|
| 0 (legacy) | 30,112 |
| 16 | 33,161 (+10%) |
| 32 | 33,671 (+12%) |

Gain is smaller than the protocol overhead alone would suggest because the server's claim loop still calls \`ClaimTask\` serially N times per batch — each ClaimTask still commits its own Pebble batch. The grpc framing savings are real (handleReadyBatch is 12% cum vs the spread of per-Ready handlers before) but Pebble compaction (22% cum) and the syscall floor (\`runtime.nanotime\` 22% flat) dominate at this load.

**The full batch win lands once Phase 7 collapses the N ClaimTask calls into a single ClaimMany repo op.** The protocol is already in place for that to land without another client/server change.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 28 packages green
- [x] \`TestClient_RunBatchSize\` — 20 tasks, BatchSize=8, Concurrency=1; passes end-to-end via batched Ready → TaskBatch → ResultBatch → ResultAckBatch.
- [x] Existing single-task tests (Hello/Ready/Result/Nack/Heartbeat/Abandon) still pass — legacy path unchanged.
- [x] Profile re-run confirms handleReadyBatch in CPU profile (12% cum), no regression in single-task path.

## Stacks on M1 (#534)

This branch is cut from M1 — Q2 multiplies per-slot Send frequency (batches → more events per second per slot), which is exactly the load M1's writer goroutine + sendCh was designed to absorb without the sendMu contention re-emerging. If M1 merges first, Q2 rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)