### PR TITLE
perf(phase-6-q3): producer stream batch — +87% creates/s isolated

### DIFF
--- a/internal/bench/producer_stream_vs_rest_test.go
+++ b/internal/bench/producer_stream_vs_rest_test.go
@@ -207,3 +207,71 @@ func TestProducerThroughput_StreamPath(t *testing.T) {
 	t.Logf("STREAM: created=%d duration=%s rate=%.0f creates/s",
 		created.Load(), elapsed.Round(time.Millisecond), rate)
 }
+
+// TestProducerThroughput_StreamBatchPath measures the Phase 6 / Q3
+// producer batch path: 32 goroutines pumping ProduceBatch with batches
+// of 16. Net effect is the same total in-flight load as the single
+// path but with N requests per stream message.
+func TestProducerThroughput_StreamBatchPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("throughput tests are long; run without -short")
+	}
+	streamAddr := fmt.Sprintf("127.0.0.1:%d", freePortT(t))
+	_ = newPebbleAppForProducer(t, streamAddr)
+
+	cli, err := producerclient.New(producerclient.Config{
+		Addr:  streamAddr,
+		Token: phase2ProducerToken,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer cli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	sess, err := cli.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer sess.Close()
+
+	const batchSize = 16
+	body := []byte(`{"bench":true}`)
+	var created atomic.Int64
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range phase3Concurrency {
+		wg.Go(func() {
+			reqs := make([]producerclient.CreateRequest, batchSize)
+			for i := range reqs {
+				reqs[i] = producerclient.CreateRequest{Command: "GENERATE_MASTER", Payload: body}
+			}
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				results, err := sess.ProduceBatch(ctx, reqs)
+				if err != nil {
+					return
+				}
+				for _, r := range results {
+					if r.Err == nil {
+						created.Add(1)
+					}
+				}
+			}
+		})
+	}
+
+	start := time.Now()
+	time.Sleep(phase3Duration)
+	close(stop)
+	wg.Wait()
+	elapsed := time.Since(start)
+	rate := float64(created.Load()) / elapsed.Seconds()
+	t.Logf("STREAM-BATCH (size=%d): created=%d duration=%s rate=%.0f creates/s",
+		batchSize, created.Load(), elapsed.Round(time.Millisecond), rate)
+}

--- a/internal/bench/profile_full_cycle_test.go
+++ b/internal/bench/profile_full_cycle_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"runtime"
 	"runtime/pprof"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -177,13 +177,39 @@ func writeProfile(path, kind string) error {
 
 // startProducerLoad launches `n` goroutines that pump creates through
 // the producer session until ctx is cancelled. Returns the counter that
-// tracks accepted creates.
+// tracks accepted creates. PHASE6_PROD_BATCH env > 1 switches each
+// goroutine to ProduceBatch with that batch size — the Phase 6 / Q3
+// producer-side batch path.
 func startProducerLoad(t *testing.T, sess *producerclient.Session, ctx context.Context, n int) *atomic.Int64 {
 	t.Helper()
 	body := []byte(`{"bench":true}`)
+	batchSize, _ := strconv.Atoi(os.Getenv("PHASE6_PROD_BATCH"))
 	var created atomic.Int64
 	var wg sync.WaitGroup
 	for range n {
+		if batchSize > 1 {
+			wg.Go(func() {
+				reqs := make([]producerclient.CreateRequest, batchSize)
+				for i := range reqs {
+					reqs[i] = producerclient.CreateRequest{
+						Command: "GENERATE_MASTER",
+						Payload: body,
+					}
+				}
+				for ctx.Err() == nil {
+					results, err := sess.ProduceBatch(ctx, reqs)
+					if err != nil {
+						return
+					}
+					for _, r := range results {
+						if r.Err == nil {
+							created.Add(1)
+						}
+					}
+				}
+			})
+			continue
+		}
 		wg.Go(func() {
 			for ctx.Err() == nil {
 				_, err := sess.Produce(ctx, producerclient.CreateRequest{

--- a/internal/producer/producerpb/producerpb.pb.go
+++ b/internal/producer/producerpb/producerpb.pb.go
@@ -216,12 +216,63 @@ func (x *CreateTask) GetTraceState() string {
 	return ""
 }
 
+// CreateTaskBatch is a producer pipelining N CreateTasks into a single
+// stream message. Server processes them with one fan-out goroutine
+// instead of one per CreateTask, and emits a single CreateAckBatch
+// covering every seq. The Pebble commit coalescer (Phase 1.1) merges
+// the resulting writes into fewer commits; combined with the reduced
+// gRPC framing this is the Phase 6 / Q3 batch path for producers.
+type CreateTaskBatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Tasks         []*CreateTask          `protobuf:"bytes,1,rep,name=tasks,proto3" json:"tasks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateTaskBatch) Reset() {
+	*x = CreateTaskBatch{}
+	mi := &file_producerpb_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateTaskBatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateTaskBatch) ProtoMessage() {}
+
+func (x *CreateTaskBatch) ProtoReflect() protoreflect.Message {
+	mi := &file_producerpb_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateTaskBatch.ProtoReflect.Descriptor instead.
+func (*CreateTaskBatch) Descriptor() ([]byte, []int) {
+	return file_producerpb_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *CreateTaskBatch) GetTasks() []*CreateTask {
+	if x != nil {
+		return x.Tasks
+	}
+	return nil
+}
+
 type ProducerEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Event:
 	//
 	//	*ProducerEvent_Hello
 	//	*ProducerEvent_Create
+	//	*ProducerEvent_CreateBatch
 	Event         isProducerEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -229,7 +280,7 @@ type ProducerEvent struct {
 
 func (x *ProducerEvent) Reset() {
 	*x = ProducerEvent{}
-	mi := &file_producerpb_proto_msgTypes[2]
+	mi := &file_producerpb_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -241,7 +292,7 @@ func (x *ProducerEvent) String() string {
 func (*ProducerEvent) ProtoMessage() {}
 
 func (x *ProducerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_producerpb_proto_msgTypes[2]
+	mi := &file_producerpb_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -254,7 +305,7 @@ func (x *ProducerEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProducerEvent.ProtoReflect.Descriptor instead.
 func (*ProducerEvent) Descriptor() ([]byte, []int) {
-	return file_producerpb_proto_rawDescGZIP(), []int{2}
+	return file_producerpb_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ProducerEvent) GetEvent() isProducerEvent_Event {
@@ -282,6 +333,15 @@ func (x *ProducerEvent) GetCreate() *CreateTask {
 	return nil
 }
 
+func (x *ProducerEvent) GetCreateBatch() *CreateTaskBatch {
+	if x != nil {
+		if x, ok := x.Event.(*ProducerEvent_CreateBatch); ok {
+			return x.CreateBatch
+		}
+	}
+	return nil
+}
+
 type isProducerEvent_Event interface {
 	isProducerEvent_Event()
 }
@@ -294,9 +354,15 @@ type ProducerEvent_Create struct {
 	Create *CreateTask `protobuf:"bytes,2,opt,name=create,proto3,oneof"`
 }
 
+type ProducerEvent_CreateBatch struct {
+	CreateBatch *CreateTaskBatch `protobuf:"bytes,3,opt,name=create_batch,json=createBatch,proto3,oneof"`
+}
+
 func (*ProducerEvent_Hello) isProducerEvent_Event() {}
 
 func (*ProducerEvent_Create) isProducerEvent_Event() {}
+
+func (*ProducerEvent_CreateBatch) isProducerEvent_Event() {}
 
 type HelloAck struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -308,7 +374,7 @@ type HelloAck struct {
 
 func (x *HelloAck) Reset() {
 	*x = HelloAck{}
-	mi := &file_producerpb_proto_msgTypes[3]
+	mi := &file_producerpb_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -320,7 +386,7 @@ func (x *HelloAck) String() string {
 func (*HelloAck) ProtoMessage() {}
 
 func (x *HelloAck) ProtoReflect() protoreflect.Message {
-	mi := &file_producerpb_proto_msgTypes[3]
+	mi := &file_producerpb_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -333,7 +399,7 @@ func (x *HelloAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HelloAck.ProtoReflect.Descriptor instead.
 func (*HelloAck) Descriptor() ([]byte, []int) {
-	return file_producerpb_proto_rawDescGZIP(), []int{3}
+	return file_producerpb_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *HelloAck) GetTenantId() string {
@@ -365,7 +431,7 @@ type CreateAck struct {
 
 func (x *CreateAck) Reset() {
 	*x = CreateAck{}
-	mi := &file_producerpb_proto_msgTypes[4]
+	mi := &file_producerpb_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -377,7 +443,7 @@ func (x *CreateAck) String() string {
 func (*CreateAck) ProtoMessage() {}
 
 func (x *CreateAck) ProtoReflect() protoreflect.Message {
-	mi := &file_producerpb_proto_msgTypes[4]
+	mi := &file_producerpb_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -390,7 +456,7 @@ func (x *CreateAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAck.ProtoReflect.Descriptor instead.
 func (*CreateAck) Descriptor() ([]byte, []int) {
-	return file_producerpb_proto_rawDescGZIP(), []int{4}
+	return file_producerpb_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *CreateAck) GetSeq() uint64 {
@@ -431,7 +497,7 @@ type ServerError struct {
 
 func (x *ServerError) Reset() {
 	*x = ServerError{}
-	mi := &file_producerpb_proto_msgTypes[5]
+	mi := &file_producerpb_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -443,7 +509,7 @@ func (x *ServerError) String() string {
 func (*ServerError) ProtoMessage() {}
 
 func (x *ServerError) ProtoReflect() protoreflect.Message {
-	mi := &file_producerpb_proto_msgTypes[5]
+	mi := &file_producerpb_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -456,7 +522,7 @@ func (x *ServerError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerError.ProtoReflect.Descriptor instead.
 func (*ServerError) Descriptor() ([]byte, []int) {
-	return file_producerpb_proto_rawDescGZIP(), []int{5}
+	return file_producerpb_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ServerError) GetCode() string {
@@ -473,6 +539,52 @@ func (x *ServerError) GetMessage() string {
 	return ""
 }
 
+// CreateAckBatch acks every CreateTask in a CreateTaskBatch in one
+// message. Order matches the input order.
+type CreateAckBatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Acks          []*CreateAck           `protobuf:"bytes,1,rep,name=acks,proto3" json:"acks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateAckBatch) Reset() {
+	*x = CreateAckBatch{}
+	mi := &file_producerpb_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateAckBatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateAckBatch) ProtoMessage() {}
+
+func (x *CreateAckBatch) ProtoReflect() protoreflect.Message {
+	mi := &file_producerpb_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateAckBatch.ProtoReflect.Descriptor instead.
+func (*CreateAckBatch) Descriptor() ([]byte, []int) {
+	return file_producerpb_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CreateAckBatch) GetAcks() []*CreateAck {
+	if x != nil {
+		return x.Acks
+	}
+	return nil
+}
+
 type ServerEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Event:
@@ -480,6 +592,7 @@ type ServerEvent struct {
 	//	*ServerEvent_HelloAck
 	//	*ServerEvent_CreateAck
 	//	*ServerEvent_Error
+	//	*ServerEvent_CreateAckBatch
 	Event         isServerEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -487,7 +600,7 @@ type ServerEvent struct {
 
 func (x *ServerEvent) Reset() {
 	*x = ServerEvent{}
-	mi := &file_producerpb_proto_msgTypes[6]
+	mi := &file_producerpb_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -499,7 +612,7 @@ func (x *ServerEvent) String() string {
 func (*ServerEvent) ProtoMessage() {}
 
 func (x *ServerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_producerpb_proto_msgTypes[6]
+	mi := &file_producerpb_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -512,7 +625,7 @@ func (x *ServerEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerEvent.ProtoReflect.Descriptor instead.
 func (*ServerEvent) Descriptor() ([]byte, []int) {
-	return file_producerpb_proto_rawDescGZIP(), []int{6}
+	return file_producerpb_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ServerEvent) GetEvent() isServerEvent_Event {
@@ -549,6 +662,15 @@ func (x *ServerEvent) GetError() *ServerError {
 	return nil
 }
 
+func (x *ServerEvent) GetCreateAckBatch() *CreateAckBatch {
+	if x != nil {
+		if x, ok := x.Event.(*ServerEvent_CreateAckBatch); ok {
+			return x.CreateAckBatch
+		}
+	}
+	return nil
+}
+
 type isServerEvent_Event interface {
 	isServerEvent_Event()
 }
@@ -565,11 +687,17 @@ type ServerEvent_Error struct {
 	Error *ServerError `protobuf:"bytes,3,opt,name=error,proto3,oneof"`
 }
 
+type ServerEvent_CreateAckBatch struct {
+	CreateAckBatch *CreateAckBatch `protobuf:"bytes,4,opt,name=create_ack_batch,json=createAckBatch,proto3,oneof"`
+}
+
 func (*ServerEvent_HelloAck) isServerEvent_Event() {}
 
 func (*ServerEvent_CreateAck) isServerEvent_Event() {}
 
 func (*ServerEvent_Error) isServerEvent_Event() {}
+
+func (*ServerEvent_CreateAckBatch) isServerEvent_Event() {}
 
 var File_producerpb_proto protoreflect.FileDescriptor
 
@@ -593,10 +721,13 @@ const file_producerpb_proto_rawDesc = "" +
 	"\ftrace_parent\x18\n" +
 	" \x01(\tR\vtraceParent\x12\x1f\n" +
 	"\vtrace_state\x18\v \x01(\tR\n" +
-	"traceState\"u\n" +
+	"traceState\"?\n" +
+	"\x0fCreateTaskBatch\x12,\n" +
+	"\x05tasks\x18\x01 \x03(\v2\x16.producerpb.CreateTaskR\x05tasks\"\xb7\x01\n" +
 	"\rProducerEvent\x12)\n" +
 	"\x05hello\x18\x01 \x01(\v2\x11.producerpb.HelloH\x00R\x05hello\x120\n" +
-	"\x06create\x18\x02 \x01(\v2\x16.producerpb.CreateTaskH\x00R\x06createB\a\n" +
+	"\x06create\x18\x02 \x01(\v2\x16.producerpb.CreateTaskH\x00R\x06create\x12@\n" +
+	"\fcreate_batch\x18\x03 \x01(\v2\x1b.producerpb.CreateTaskBatchH\x00R\vcreateBatchB\a\n" +
 	"\x05event\"A\n" +
 	"\bHelloAck\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x18\n" +
@@ -608,12 +739,15 @@ const file_producerpb_proto_rawDesc = "" +
 	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\";\n" +
 	"\vServerError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\xb4\x01\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\";\n" +
+	"\x0eCreateAckBatch\x12)\n" +
+	"\x04acks\x18\x01 \x03(\v2\x15.producerpb.CreateAckR\x04acks\"\xfc\x01\n" +
 	"\vServerEvent\x123\n" +
 	"\thello_ack\x18\x01 \x01(\v2\x14.producerpb.HelloAckH\x00R\bhelloAck\x126\n" +
 	"\n" +
 	"create_ack\x18\x02 \x01(\v2\x15.producerpb.CreateAckH\x00R\tcreateAck\x12/\n" +
-	"\x05error\x18\x03 \x01(\v2\x17.producerpb.ServerErrorH\x00R\x05errorB\a\n" +
+	"\x05error\x18\x03 \x01(\v2\x17.producerpb.ServerErrorH\x00R\x05error\x12F\n" +
+	"\x10create_ack_batch\x18\x04 \x01(\v2\x1a.producerpb.CreateAckBatchH\x00R\x0ecreateAckBatchB\a\n" +
 	"\x05event2R\n" +
 	"\x0eProducerStream\x12@\n" +
 	"\x06Stream\x12\x19.producerpb.ProducerEvent\x1a\x17.producerpb.ServerEvent(\x010\x01B>Z<github.com/osvaldoandrade/codeq/internal/producer/producerpbb\x06proto3"
@@ -630,31 +764,37 @@ func file_producerpb_proto_rawDescGZIP() []byte {
 	return file_producerpb_proto_rawDescData
 }
 
-var file_producerpb_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_producerpb_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_producerpb_proto_goTypes = []any{
 	(*Hello)(nil),                 // 0: producerpb.Hello
 	(*CreateTask)(nil),            // 1: producerpb.CreateTask
-	(*ProducerEvent)(nil),         // 2: producerpb.ProducerEvent
-	(*HelloAck)(nil),              // 3: producerpb.HelloAck
-	(*CreateAck)(nil),             // 4: producerpb.CreateAck
-	(*ServerError)(nil),           // 5: producerpb.ServerError
-	(*ServerEvent)(nil),           // 6: producerpb.ServerEvent
-	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*CreateTaskBatch)(nil),       // 2: producerpb.CreateTaskBatch
+	(*ProducerEvent)(nil),         // 3: producerpb.ProducerEvent
+	(*HelloAck)(nil),              // 4: producerpb.HelloAck
+	(*CreateAck)(nil),             // 5: producerpb.CreateAck
+	(*ServerError)(nil),           // 6: producerpb.ServerError
+	(*CreateAckBatch)(nil),        // 7: producerpb.CreateAckBatch
+	(*ServerEvent)(nil),           // 8: producerpb.ServerEvent
+	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
 }
 var file_producerpb_proto_depIdxs = []int32{
-	7, // 0: producerpb.CreateTask.run_at:type_name -> google.protobuf.Timestamp
-	0, // 1: producerpb.ProducerEvent.hello:type_name -> producerpb.Hello
-	1, // 2: producerpb.ProducerEvent.create:type_name -> producerpb.CreateTask
-	3, // 3: producerpb.ServerEvent.hello_ack:type_name -> producerpb.HelloAck
-	4, // 4: producerpb.ServerEvent.create_ack:type_name -> producerpb.CreateAck
-	5, // 5: producerpb.ServerEvent.error:type_name -> producerpb.ServerError
-	2, // 6: producerpb.ProducerStream.Stream:input_type -> producerpb.ProducerEvent
-	6, // 7: producerpb.ProducerStream.Stream:output_type -> producerpb.ServerEvent
-	7, // [7:8] is the sub-list for method output_type
-	6, // [6:7] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	9,  // 0: producerpb.CreateTask.run_at:type_name -> google.protobuf.Timestamp
+	1,  // 1: producerpb.CreateTaskBatch.tasks:type_name -> producerpb.CreateTask
+	0,  // 2: producerpb.ProducerEvent.hello:type_name -> producerpb.Hello
+	1,  // 3: producerpb.ProducerEvent.create:type_name -> producerpb.CreateTask
+	2,  // 4: producerpb.ProducerEvent.create_batch:type_name -> producerpb.CreateTaskBatch
+	5,  // 5: producerpb.CreateAckBatch.acks:type_name -> producerpb.CreateAck
+	4,  // 6: producerpb.ServerEvent.hello_ack:type_name -> producerpb.HelloAck
+	5,  // 7: producerpb.ServerEvent.create_ack:type_name -> producerpb.CreateAck
+	6,  // 8: producerpb.ServerEvent.error:type_name -> producerpb.ServerError
+	7,  // 9: producerpb.ServerEvent.create_ack_batch:type_name -> producerpb.CreateAckBatch
+	3,  // 10: producerpb.ProducerStream.Stream:input_type -> producerpb.ProducerEvent
+	8,  // 11: producerpb.ProducerStream.Stream:output_type -> producerpb.ServerEvent
+	11, // [11:12] is the sub-list for method output_type
+	10, // [10:11] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_producerpb_proto_init() }
@@ -662,14 +802,16 @@ func file_producerpb_proto_init() {
 	if File_producerpb_proto != nil {
 		return
 	}
-	file_producerpb_proto_msgTypes[2].OneofWrappers = []any{
+	file_producerpb_proto_msgTypes[3].OneofWrappers = []any{
 		(*ProducerEvent_Hello)(nil),
 		(*ProducerEvent_Create)(nil),
+		(*ProducerEvent_CreateBatch)(nil),
 	}
-	file_producerpb_proto_msgTypes[6].OneofWrappers = []any{
+	file_producerpb_proto_msgTypes[8].OneofWrappers = []any{
 		(*ServerEvent_HelloAck)(nil),
 		(*ServerEvent_CreateAck)(nil),
 		(*ServerEvent_Error)(nil),
+		(*ServerEvent_CreateAckBatch)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -677,7 +819,7 @@ func file_producerpb_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_producerpb_proto_rawDesc), len(file_producerpb_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/producer/proto/producerpb.proto
+++ b/internal/producer/proto/producerpb.proto
@@ -51,10 +51,21 @@ message CreateTask {
   string trace_state = 11;
 }
 
+// CreateTaskBatch is a producer pipelining N CreateTasks into a single
+// stream message. Server processes them with one fan-out goroutine
+// instead of one per CreateTask, and emits a single CreateAckBatch
+// covering every seq. The Pebble commit coalescer (Phase 1.1) merges
+// the resulting writes into fewer commits; combined with the reduced
+// gRPC framing this is the Phase 6 / Q3 batch path for producers.
+message CreateTaskBatch {
+  repeated CreateTask tasks = 1;
+}
+
 message ProducerEvent {
   oneof event {
     Hello hello = 1;
     CreateTask create = 2;
+    CreateTaskBatch create_batch = 3;
   }
 }
 
@@ -80,11 +91,18 @@ message ServerError {
   string message = 2;
 }
 
+// CreateAckBatch acks every CreateTask in a CreateTaskBatch in one
+// message. Order matches the input order.
+message CreateAckBatch {
+  repeated CreateAck acks = 1;
+}
+
 message ServerEvent {
   oneof event {
     HelloAck hello_ack = 1;
     CreateAck create_ack = 2;
     ServerError error = 3;
+    CreateAckBatch create_ack_batch = 4;
   }
 }
 

--- a/internal/producer/server.go
+++ b/internal/producer/server.go
@@ -110,16 +110,6 @@ func (s *streamSession) send(ev *producerpb.ServerEvent) error {
 	}
 }
 
-func (s *streamSession) sendAck(seq uint64, ok bool, taskID, errMsg string) error {
-	return s.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_CreateAck{
-		CreateAck: &producerpb.CreateAck{
-			Seq:          seq,
-			Ok:           ok,
-			TaskId:       taskID,
-			ErrorMessage: errMsg,
-		},
-	}})
-}
 
 // Stream is the bidirectional rpc. First message MUST be Hello; the
 // server validates the token and replies with HelloAck. Subsequent
@@ -167,6 +157,12 @@ func (s *Server) Stream(stream producerpb.ProducerStream_StreamServer) error {
 				defer wg.Done()
 				s.handleCreate(ctx, sess, req)
 			}(e.Create)
+		case *producerpb.ProducerEvent_CreateBatch:
+			wg.Add(1)
+			go func(req *producerpb.CreateTaskBatch) {
+				defer wg.Done()
+				s.handleCreateBatch(ctx, sess, req)
+			}(e.CreateBatch)
 		default:
 			_ = sess.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_Error{
 				Error: &producerpb.ServerError{Code: codes.InvalidArgument.String(), Message: "unknown-event"},
@@ -208,28 +204,32 @@ func (s *Server) handleHello(stream producerpb.ProducerStream_StreamServer) (*st
 }
 
 func (s *Server) handleCreate(ctx context.Context, sess *streamSession, req *producerpb.CreateTask) {
+	ack := s.processCreate(ctx, sess, req)
+	_ = sess.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_CreateAck{CreateAck: ack}})
+}
+
+// processCreate validates one CreateTask request, invokes the scheduler,
+// and returns the resulting CreateAck. Shared by handleCreate (single
+// ack) and handleCreateBatch (acks coalesced into CreateAckBatch).
+func (s *Server) processCreate(ctx context.Context, sess *streamSession, req *producerpb.CreateTask) *producerpb.CreateAck {
 	if req == nil {
-		return
+		return &producerpb.CreateAck{Ok: false, ErrorMessage: "nil request"}
 	}
 	cmd := domain.Command(strings.TrimSpace(req.Command))
 	if cmd == "" {
-		_ = sess.sendAck(req.Seq, false, "", "command is required")
-		return
+		return &producerpb.CreateAck{Seq: req.Seq, Ok: false, ErrorMessage: "command is required"}
 	}
 	if req.DelaySeconds < 0 {
-		_ = sess.sendAck(req.Seq, false, "", "delaySeconds must be >= 0")
-		return
+		return &producerpb.CreateAck{Seq: req.Seq, Ok: false, ErrorMessage: "delaySeconds must be >= 0"}
 	}
 	var runAt time.Time
 	if req.RunAt != nil {
 		runAt = req.RunAt.AsTime()
 	}
-
 	payload := string(req.Payload)
 	if payload == "" {
 		payload = "null"
 	}
-
 	task, err := s.Scheduler.CreateTask(
 		ctx,
 		cmd,
@@ -243,10 +243,35 @@ func (s *Server) handleCreate(ctx context.Context, sess *streamSession, req *pro
 		sess.tenantID,
 	)
 	if err != nil {
-		_ = sess.sendAck(req.Seq, false, "", err.Error())
+		return &producerpb.CreateAck{Seq: req.Seq, Ok: false, ErrorMessage: err.Error()}
+	}
+	return &producerpb.CreateAck{Seq: req.Seq, Ok: true, TaskId: task.ID}
+}
+
+// handleCreateBatch fans out N CreateTasks in parallel goroutines so
+// the Pebble write loop and notifier still process them concurrently
+// (the Phase 1.1 commit coalescer merges the writes into fewer Pebble
+// commits). All N results are then bundled into one CreateAckBatch
+// so the wire-side ack is a single Send instead of N. Net effect on
+// the producer hot path: one Recv + one fan-out goroutine + one Send,
+// vs N Recv + N fan-out goroutines + N Sends.
+func (s *Server) handleCreateBatch(ctx context.Context, sess *streamSession, req *producerpb.CreateTaskBatch) {
+	if req == nil || len(req.Tasks) == 0 {
 		return
 	}
-	_ = sess.sendAck(req.Seq, true, task.ID, "")
+	acks := make([]*producerpb.CreateAck, len(req.Tasks))
+	var wg sync.WaitGroup
+	for i, t := range req.Tasks {
+		wg.Add(1)
+		go func(idx int, tk *producerpb.CreateTask) {
+			defer wg.Done()
+			acks[idx] = s.processCreate(ctx, sess, tk)
+		}(i, t)
+	}
+	wg.Wait()
+	_ = sess.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_CreateAckBatch{
+		CreateAckBatch: &producerpb.CreateAckBatch{Acks: acks},
+	}})
 }
 
 // tenantIDFromClaims mirrors middleware/tenant.go's extractTenantID but

--- a/pkg/producerclient/client.go
+++ b/pkg/producerclient/client.go
@@ -249,6 +249,10 @@ func (s *Session) readLoop() {
 		switch e := ev.Event.(type) {
 		case *producerpb.ServerEvent_CreateAck:
 			s.deliver(e.CreateAck)
+		case *producerpb.ServerEvent_CreateAckBatch:
+			for _, ack := range e.CreateAckBatch.Acks {
+				s.deliver(ack)
+			}
 		case *producerpb.ServerEvent_Error:
 			s.cli.cfg.Logger.Warn("producerclient: server error event",
 				"code", e.Error.Code, "msg", e.Error.Message)
@@ -336,6 +340,92 @@ func (s *Session) Produce(ctx context.Context, req CreateRequest) (string, error
 		s.pending.Delete(seq)
 		return "", ctx.Err()
 	}
+}
+
+// ProduceBatch pipelines N CreateTasks into a single CreateTaskBatch
+// message and waits for the matching CreateAckBatch. Returns one
+// BatchResult per request in input order — Err non-nil on rejection,
+// TaskID set on success. Phase 6 / Q3 batch entry point.
+//
+// Compared to N concurrent Produce calls: one stream Send (vs N), one
+// goroutine fan-out on the server (vs N event handlers), one
+// CreateAckBatch on the wire (vs N CreateAcks). The server still
+// processes each task in parallel internally so per-task latency is
+// not serialised.
+func (s *Session) ProduceBatch(ctx context.Context, reqs []CreateRequest) ([]BatchResult, error) {
+	if len(reqs) == 0 {
+		return nil, nil
+	}
+	if s.closed.Load() {
+		return nil, errors.New("producerclient: session closed")
+	}
+	if err := s.peekReadErr(); err != nil {
+		return nil, err
+	}
+
+	pbTasks := make([]*producerpb.CreateTask, len(reqs))
+	channels := make([]chan ackResult, len(reqs))
+	seqs := make([]uint64, len(reqs))
+	for i, req := range reqs {
+		seq := s.seq.Add(1)
+		ch := make(chan ackResult, 1)
+		s.pending.Store(seq, ch)
+		seqs[i] = seq
+		channels[i] = ch
+
+		var runAt *timestamppb.Timestamp
+		if !req.RunAt.IsZero() {
+			runAt = timestamppb.New(req.RunAt)
+		}
+		pbTasks[i] = &producerpb.CreateTask{
+			Seq:            seq,
+			Command:        req.Command,
+			Payload:        req.Payload,
+			Priority:       int32(req.Priority),
+			Webhook:        req.Webhook,
+			MaxAttempts:    int32(req.MaxAttempts),
+			IdempotencyKey: req.IdempotencyKey,
+			RunAt:          runAt,
+			DelaySeconds:   int32(req.DelaySeconds),
+			TraceParent:    req.TraceParent,
+			TraceState:     req.TraceState,
+		}
+	}
+
+	ev := &producerpb.ProducerEvent{Event: &producerpb.ProducerEvent_CreateBatch{
+		CreateBatch: &producerpb.CreateTaskBatch{Tasks: pbTasks},
+	}}
+	if err := s.send(ev); err != nil {
+		for _, seq := range seqs {
+			s.pending.Delete(seq)
+		}
+		return nil, fmt.Errorf("producerclient: send batch: %w", err)
+	}
+
+	results := make([]BatchResult, len(reqs))
+	for i, ch := range channels {
+		select {
+		case res := <-ch:
+			results[i] = BatchResult{TaskID: res.taskID, Err: res.err}
+		case <-ctx.Done():
+			// Cancel cleanup: drop pending entries for the remaining seqs so
+			// late acks don't leak into stale channels. The reader will see
+			// "ack for unknown seq" but that's harmless.
+			for _, seq := range seqs[i:] {
+				s.pending.Delete(seq)
+			}
+			return results[:i], ctx.Err()
+		}
+	}
+	return results, nil
+}
+
+// BatchResult is one slot of a ProduceBatch reply. Err is set if the
+// server rejected the request (validation, scheduler error); otherwise
+// TaskID is the assigned id.
+type BatchResult struct {
+	TaskID string
+	Err    error
 }
 
 // peekReadErr returns a non-nil error if the reader goroutine has

--- a/pkg/producerclient/client_test.go
+++ b/pkg/producerclient/client_test.go
@@ -273,3 +273,98 @@ func TestNewValidatesRequiredFields(t *testing.T) {
 		t.Error("missing Token should error")
 	}
 }
+
+// TestProduceBatch_HappyPath drives the Phase 6 / Q3 batch path
+// end-to-end: 16 CreateTasks in one CreateTaskBatch, server fans out
+// in parallel, replies with one CreateAckBatch. All results must come
+// back with non-empty task ids and no error.
+func TestProduceBatch_HappyPath(t *testing.T) {
+	f := newFixture(t)
+	defer f.stop()
+
+	c, err := producerclient.New(producerclient.Config{Addr: f.streamAddr, Token: "dev-token"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sess, err := c.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer sess.Close()
+
+	const n = 16
+	reqs := make([]producerclient.CreateRequest, n)
+	for i := range n {
+		reqs[i] = producerclient.CreateRequest{
+			Command: "GENERATE_MASTER",
+			Payload: fmt.Appendf(nil, `{"i":%d}`, i),
+		}
+	}
+	results, err := sess.ProduceBatch(ctx, reqs)
+	if err != nil {
+		t.Fatalf("ProduceBatch: %v", err)
+	}
+	if len(results) != n {
+		t.Fatalf("results len=%d, want %d", len(results), n)
+	}
+	seenIDs := make(map[string]struct{}, n)
+	for i, r := range results {
+		if r.Err != nil {
+			t.Errorf("result[%d].Err=%v", i, r.Err)
+			continue
+		}
+		if r.TaskID == "" {
+			t.Errorf("result[%d] empty TaskID", i)
+			continue
+		}
+		if _, dup := seenIDs[r.TaskID]; dup {
+			t.Errorf("result[%d] duplicate TaskID %s", i, r.TaskID)
+		}
+		seenIDs[r.TaskID] = struct{}{}
+	}
+}
+
+// TestProduceBatch_RejectsInvalid mixes valid and invalid requests
+// (empty command) in one batch and verifies acks come back per-index
+// with the right ok/err split.
+func TestProduceBatch_RejectsInvalid(t *testing.T) {
+	f := newFixture(t)
+	defer f.stop()
+
+	c, err := producerclient.New(producerclient.Config{Addr: f.streamAddr, Token: "dev-token"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sess, err := c.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer sess.Close()
+
+	reqs := []producerclient.CreateRequest{
+		{Command: "GENERATE_MASTER", Payload: []byte(`{"ok":1}`)},
+		{Command: "", Payload: []byte(`{"bad":1}`)}, // invalid
+		{Command: "GENERATE_MASTER", Payload: []byte(`{"ok":2}`)},
+	}
+	results, err := sess.ProduceBatch(ctx, reqs)
+	if err != nil {
+		t.Fatalf("ProduceBatch: %v", err)
+	}
+	if results[0].Err != nil || results[0].TaskID == "" {
+		t.Errorf("results[0] should succeed: %+v", results[0])
+	}
+	if results[1].Err == nil {
+		t.Errorf("results[1] should fail: %+v", results[1])
+	}
+	if results[2].Err != nil || results[2].TaskID == "" {
+		t.Errorf("results[2] should succeed: %+v", results[2])
+	}
+}


### PR DESCRIPTION
## Summary

Symmetric to Q2 on the worker side: adds native batch ops to the producer streaming protocol so a producer can pipeline N CreateTasks in a single message and get one CreateAckBatch back.

## Protocol changes (backward-compatible)

\`internal/producer/proto/producerpb.proto\`:

| Message | Change |
|---|---|
| \`CreateTaskBatch\` | NEW ProducerEvent variant carrying N CreateTasks. |
| \`CreateAckBatch\` | NEW ServerEvent variant; order matches input. |

Existing CreateTask / CreateAck unchanged — legacy clients see no behavior change.

## Server

\`handleCreate\` refactored to delegate to \`processCreate\` which returns the ack without sending. \`handleCreateBatch\` fan-outs N \`processCreate\` calls in parallel goroutines (each task hits the Pebble write loop concurrently — Phase 1.1's commit coalescer merges into fewer commits) and emits one CreateAckBatch.

Net change on the server hot path:

- one Recv + one fan-out goroutine + one Send

instead of:

- N Recv + N fan-out goroutines + N Sends

## Client

\`Session.ProduceBatch(ctx, []CreateRequest) []BatchResult\` is the new entry point. Allocates N seqs, registers N pending channels, sends one CreateTaskBatch, waits for matching acks via the existing per-seq \`sync.Map\` plumbing. Single \`Produce\` path unchanged. \`readLoop\` fans \`CreateAckBatch\` entries through \`deliver\` one-by-one so the seq → pending channel correlation stays the same.

## Numbers (producer-side isolated, 32 goroutines, 6s window)

| Path | creates/s | vs REST |
|---|---|---|
| REST | 16,447 | 1.00× |
| Stream Produce (Phase 3) | 73,031 | 4.44× |
| **Stream ProduceBatch=16 (Q3)** | **136,392** | **8.29×** |

**+87% over Phase 3** at the producer hot path in isolation.

## What about ciclo full?

Ciclo full (\`TestProfile_FullCycle\`) is unchanged at ~34k tasks/s with Q3 enabled because the worker side is now the gargalo — the producer just fills the queue faster. Sustained ciclo-full throughput is bounded by the slower of producer-side and worker-side, and Phase 6 has now reached the point where the worker hot path is the limiting factor.

The 87% producer win unlocks once Phase 7 (ClaimMany in the Pebble repo) lets the worker side catch up. Until then Q3 is a structural investment, not a measured ciclo-full improvement.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all packages green
- [x] \`TestProduceBatch_HappyPath\` — 16-task batch round-trip
- [x] \`TestProduceBatch_RejectsInvalid\` — mixed valid/invalid; acks split correctly
- [x] \`TestProducerThroughput_StreamBatchPath\` — 32×16 batch saturation (136k creates/s)
- [x] Existing producer tests (Produce, RejectsInvalid, HandshakeRejectsBadToken) still pass

## Roadmap state

After Q3 (this PR):

| Phase | Producer/s | Worker/s (ciclo full) |
|---|---|---|
| Pre-Phase-6 | 62k | 21k |
| + Q1 | 62k | 33k |
| + M1 + Q2 | 62k | 34k |
| + Q3 (this PR) | **136k** | 34k |
| Need for 400k | 400k | 400k |

Next: **Phase 7 (ClaimMany)** is now the highest-ROI lever — it's what makes Q3's producer throughput visible end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)