### PR TITLE
perf(phase-7): Pebble ClaimMany — one batch commit per N claims (9× at low concurrency)

### DIFF
--- a/internal/bench/worker_stream_saturation_test.go
+++ b/internal/bench/worker_stream_saturation_test.go
@@ -3,6 +3,8 @@ package bench
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -33,11 +35,13 @@ func TestSaturation_StreamPath(t *testing.T) {
 	concurrencies := []int{1, 4, 16, 32, 64, 128, 256, 512}
 	for _, c := range concurrencies {
 		t.Run(fmt.Sprintf("concurrency=%d", c), func(t *testing.T) {
+			batchSize, _ := strconv.Atoi(os.Getenv("PHASE6_BATCH"))
 			cli, err := workerclient.New(workerclient.Config{
 				Addr:         streamAddr,
 				Token:        phase2WorkerToken,
 				Commands:     []string{"GENERATE_MASTER"},
 				Concurrency:  c,
+				BatchSize:    batchSize,
 				LeaseSeconds: 300,
 			})
 			if err != nil {

--- a/internal/controllers/batch_controllers_test.go
+++ b/internal/controllers/batch_controllers_test.go
@@ -38,6 +38,21 @@ func (m *mockSchedulerService) ClaimTask(ctx context.Context, workerID string, c
 	return &domain.Task{ID: "task-1", Status: domain.StatusInProgress}, true, nil
 }
 
+func (m *mockSchedulerService) ClaimManyTasks(ctx context.Context, workerID string, commands []domain.Command, leaseSeconds int, max int, tenantID string) ([]*domain.Task, error) {
+	out := make([]*domain.Task, 0, max)
+	for range max {
+		t, ok, err := m.ClaimTask(ctx, workerID, commands, leaseSeconds, 0, tenantID)
+		if err != nil {
+			return out, err
+		}
+		if !ok {
+			break
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
 func (m *mockSchedulerService) Heartbeat(context.Context, string, string, int) error {
 	return nil
 }

--- a/internal/repository/pebble/task_repository.go
+++ b/internal/repository/pebble/task_repository.go
@@ -596,6 +596,143 @@ func (r *TaskRepository) completeClaim(ctx context.Context, workerID string, cmd
 	return &t, true, nil
 }
 
+// ClaimMany is the Phase 7 batch claim path. Pops up to `max` hints
+// from the per-(cmd, tenant, prio) channels in priority order (highest
+// first, FIFO within priority), loads each task body, validates, and
+// writes ALL state transitions for the batch in a single Pebble batch
+// with one commit. Compared to N sequential Claim calls this saves
+// (N-1) batch.Close + (N-1) coalescer trips through the channel +
+// reduces the total fsync amplification by amortising the commit's
+// fixed cost across N tasks. Drops invalid pending hints (ghost, bad
+// JSON, status != PENDING) into the same batch so the channel and
+// disk stay in sync without an extra round-trip.
+//
+// Returns the claimed tasks in pop order. May return fewer than `max`
+// if channels emptied. Returns a nil slice (no error) when nothing was
+// claimed — caller decides whether to retry.
+//
+// Reconciliation prelude (moveDueDelayed + requeueExpired) runs once
+// before the pop loop, same as Claim.
+func (r *TaskRepository) ClaimMany(ctx context.Context, workerID string, commands []domain.Command, leaseSeconds int, max int, inspectLimit int, maxAttemptsDefault int, tenantID string) ([]*domain.Task, error) {
+	if max <= 0 {
+		return nil, nil
+	}
+	if inspectLimit <= 0 {
+		inspectLimit = defaultInspectLimit
+	}
+	// Same prelude as Claim: move due-delayed entries into pending and
+	// rescue expired in-progress tasks (throttled). Both write through
+	// the channel hints we're about to pop.
+	for _, cmd := range commands {
+		if _, err := r.moveDueDelayedForTenant(ctx, cmd, inspectLimit, tenantID); err != nil {
+			return nil, err
+		}
+		if r.reconcile.shouldRun(cmd, tenantID) {
+			if _, err := r.requeueExpired(ctx, cmd, inspectLimit, maxAttemptsDefault, tenantID); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	type popped struct {
+		cmd      domain.Command
+		priority int
+		seq      uint64
+		id       string
+	}
+	hints := make([]popped, 0, max)
+	// Drain non-blocking, highest priority first, across all commands.
+	// Stop when we hit max or every queue is empty in this pass.
+collect:
+	for _, cmd := range commands {
+		for p := maxPriority; p >= minPriority && len(hints) < max; p-- {
+			q := r.channelFor(cmd, tenantID, p)
+			for len(hints) < max {
+				select {
+				case h := <-q.ch:
+					hints = append(hints, popped{cmd: cmd, priority: p, seq: h.seq, id: h.id})
+				default:
+					// channel empty at this priority — move on
+					goto nextprio
+				}
+			}
+		nextprio:
+		}
+		if len(hints) >= max {
+			break collect
+		}
+	}
+	if len(hints) == 0 {
+		return nil, nil
+	}
+
+	now := r.now()
+	leaseUntil := now.Add(time.Duration(leaseSeconds) * time.Second).UTC()
+	leaseUntilStr := leaseUntil.Format(time.RFC3339)
+	ttlScore := uint64(now.Add(taskRetention).Unix())
+	encodedLease := encodeLease(workerID, leaseUntil)
+
+	out := make([]*domain.Task, 0, len(hints))
+	b := r.db.Batch()
+	defer b.Close()
+
+	// Process every popped hint. Drop the bad ones (ghost / bad JSON /
+	// status != pending) by deleting only their pending key — same
+	// invariant as completeClaim, just folded into the batch.
+	for _, h := range hints {
+		pendingKey := KeyPending(h.cmd, tenantID, h.priority, h.seq, h.id)
+		taskJSON, err := r.db.Get(KeyTask(h.id))
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				_ = b.Delete(pendingKey, nil)
+				continue
+			}
+			return nil, err
+		}
+		var t domain.Task
+		if err := sonic.Unmarshal(taskJSON, &t); err != nil {
+			_ = b.Delete(pendingKey, nil)
+			continue
+		}
+		if t.Status != domain.StatusPending {
+			// Stale hint — duplicate publication or recovery race. Drop
+			// the pending key; the rightful claimer already owns it.
+			_ = b.Delete(pendingKey, nil)
+			continue
+		}
+		t.Status = domain.StatusInProgress
+		t.LastKnownLocation = domain.LocationInProgress
+		t.WorkerID = workerID
+		t.LeaseUntil = leaseUntilStr
+		t.Attempts++
+		t.UpdatedAt = now
+		updatedJSON, _ := sonic.Marshal(&t)
+		if err := b.Delete(pendingKey, nil); err != nil {
+			return nil, err
+		}
+		if err := b.Set(KeyInprog(h.cmd, tenantID, h.id), nil, nil); err != nil {
+			return nil, err
+		}
+		if err := b.Set(KeyTask(h.id), updatedJSON, nil); err != nil {
+			return nil, err
+		}
+		if err := b.Set(KeyLease(h.id), encodedLease, nil); err != nil {
+			return nil, err
+		}
+		if err := b.Set(KeyTTLIndex(ttlScore, h.id), nil, nil); err != nil {
+			return nil, err
+		}
+		// Stash a value copy so all returned pointers are independent and
+		// the caller can mutate them without aliasing the loop variable.
+		tc := t
+		out = append(out, &tc)
+	}
+	if err := r.db.CommitBatch(b); err != nil {
+		return nil, fmt.Errorf("commit claim-many: %w", err)
+	}
+	return out, nil
+}
+
 // findPendingKey scans the per-prio pending prefix looking for an entry
 // whose trailing id matches. The seq we wrote at Enqueue time isn't
 // carried through the channel hint, so we have to discover it here. The

--- a/internal/services/scheduler_service.go
+++ b/internal/services/scheduler_service.go
@@ -22,6 +22,13 @@ import (
 type SchedulerService interface {
 	CreateTask(ctx context.Context, cmd domain.Command, payload string, priority int, webhook string, maxAttempts int, idempotencyKey string, runAt time.Time, delaySeconds int, tenantID string) (*domain.Task, error)
 	ClaimTask(ctx context.Context, workerID string, commands []domain.Command, leaseSeconds int, waitSeconds int, tenantID string) (*domain.Task, bool, error)
+	// ClaimManyTasks pops up to max tasks in one round-trip when the
+	// underlying repo supports batched claim (Pebble does via Phase 7's
+	// ClaimMany). Falls back to looping ClaimTask for repos that don't.
+	// Returns the claimed tasks in pop order; may return fewer than max
+	// (or nil) if the queue emptied. waitSeconds=0 — caller controls
+	// polling for the batch path.
+	ClaimManyTasks(ctx context.Context, workerID string, commands []domain.Command, leaseSeconds int, max int, tenantID string) ([]*domain.Task, error)
 	Heartbeat(ctx context.Context, taskID, workerID string, extendSeconds int) error
 	Abandon(ctx context.Context, taskID, workerID string) error
 	NackTask(ctx context.Context, taskID, workerID string, delaySeconds int, reason string) (int, bool, error)
@@ -31,6 +38,13 @@ type SchedulerService interface {
 
 	// Novo: limpeza administrativa por índice Z
 	CleanupExpired(ctx context.Context, limit int, before time.Time) (int, error)
+}
+
+// batchClaimer is the optional repo interface implemented by Pebble's
+// TaskRepository (Phase 7). Redis-backed repos don't implement it and
+// fall back to the loop in ClaimManyTasks.
+type batchClaimer interface {
+	ClaimMany(ctx context.Context, workerID string, commands []domain.Command, leaseSeconds int, max int, inspectLimit int, maxAttemptsDefault int, tenantID string) ([]*domain.Task, error)
 }
 
 type schedulerService struct {
@@ -124,6 +138,47 @@ func (s *schedulerService) CreateTask(ctx context.Context, cmd domain.Command, p
 		s.notifier.NotifyQueueReady(ctx, cmd)
 	}
 	return task, nil
+}
+
+// ClaimManyTasks dispatches to repo.ClaimMany when the backend supports
+// it (Pebble), or falls back to looping ClaimTask. The fast path packs
+// up to `max` claims into one Pebble batch with one commit. Single-RTT
+// regardless of N, which is what makes Phase 6 Q2's worker batch
+// actually faster instead of just structurally batched.
+func (s *schedulerService) ClaimManyTasks(ctx context.Context, workerID string, commands []domain.Command, leaseSeconds int, max int, tenantID string) ([]*domain.Task, error) {
+	if workerID == "" {
+		return nil, errors.New("workerId is required")
+	}
+	if max <= 0 {
+		return nil, nil
+	}
+	if len(commands) == 0 {
+		commands = []domain.Command{domain.CmdGenerateMaster, domain.CmdGenerateCreative}
+	}
+	if leaseSeconds <= 0 {
+		leaseSeconds = s.defaultLease
+	}
+	if bc, ok := s.repo.(batchClaimer); ok {
+		tasks, err := bc.ClaimMany(ctx, workerID, commands, leaseSeconds, max, s.requeueInspectLimit, s.maxAttemptsDefault, tenantID)
+		for _, t := range tasks {
+			metrics.TaskClaimedTotal.WithLabelValues(string(t.Command)).Inc()
+		}
+		return tasks, err
+	}
+	// Fallback: loop ClaimTask (no batch optimisation on this backend).
+	out := make([]*domain.Task, 0, max)
+	for range max {
+		t, ok, err := s.repo.Claim(ctx, workerID, commands, leaseSeconds, s.requeueInspectLimit, s.maxAttemptsDefault, tenantID)
+		if err != nil {
+			return out, err
+		}
+		if !ok || t == nil {
+			break
+		}
+		metrics.TaskClaimedTotal.WithLabelValues(string(t.Command)).Inc()
+		out = append(out, t)
+	}
+	return out, nil
 }
 
 func (s *schedulerService) ClaimTask(ctx context.Context, workerID string, commands []domain.Command, leaseSeconds int, waitSeconds int, tenantID string) (*domain.Task, bool, error) {

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -324,24 +324,34 @@ func (s *Server) handleReadyOne(ctx context.Context, sess *streamSession, comman
 }
 
 // handleReadyBatch claims up to `count` tasks and sends them as one
-// TaskBatch. First task waits up to MaxClaimRetries × ClaimPollDelay so
-// idle workers don't busy-loop; subsequent tasks pull only if the
-// scheduler returns immediately — we never block waiting for the second
-// task once the batch has one, because the worker would rather start
-// processing the partial batch than wait for the queue to fill.
+// TaskBatch. Phase 7 swap: instead of N serial ClaimTask calls (each
+// committing its own Pebble batch), we issue a single ClaimManyTasks
+// which the Pebble backend services with one pop loop + one batch
+// commit. On Redis the service falls back to the N-call loop so the
+// behavior degrades cleanly.
+//
+// Poll loop preserves the "wait if queue is empty" semantics for idle
+// workers — first ClaimMany may come back empty, in which case we
+// sleep and retry until we get something or hit the retry budget.
+// Once the first batch returns we send TaskBatch immediately; we
+// don't keep pulling while-we-have-tasks because ClaimMany already
+// drained the channels in one shot.
 func (s *Server) handleReadyBatch(ctx context.Context, sess *streamSession, commands []domain.Command, lease, count int) {
-	tasks := make([]*workerpb.Task, 0, count)
-	for attempt := 0; attempt <= s.MaxClaimRetries && len(tasks) == 0; attempt++ {
+	var tasks []*workerpb.Task
+	for attempt := 0; attempt <= s.MaxClaimRetries; attempt++ {
 		if ctx.Err() != nil {
 			return
 		}
-		task, ok, err := s.Scheduler.ClaimTask(ctx, sess.workerID, commands, lease, 0, sess.tenantID)
+		got, err := s.Scheduler.ClaimManyTasks(ctx, sess.workerID, commands, lease, count, sess.tenantID)
 		if err != nil {
 			_ = sess.sendError(codes.Internal, err.Error())
 			return
 		}
-		if ok && task != nil {
-			tasks = append(tasks, taskToProto(task))
+		if len(got) > 0 {
+			tasks = make([]*workerpb.Task, len(got))
+			for i, t := range got {
+				tasks[i] = taskToProto(t)
+			}
 			break
 		}
 		select {
@@ -349,17 +359,6 @@ func (s *Server) handleReadyBatch(ctx context.Context, sess *streamSession, comm
 			return
 		case <-time.After(s.ClaimPollDelay):
 		}
-	}
-	// Greedy drain — pull more tasks while the scheduler has them ready.
-	for len(tasks) < count {
-		if ctx.Err() != nil {
-			break
-		}
-		task, ok, err := s.Scheduler.ClaimTask(ctx, sess.workerID, commands, lease, 0, sess.tenantID)
-		if err != nil || !ok || task == nil {
-			break
-		}
-		tasks = append(tasks, taskToProto(task))
 	}
 	if len(tasks) == 0 {
 		return


### PR DESCRIPTION
## Summary

Phase 6 / Q2 added the worker stream batch protocol (Ready{count}, TaskBatch, ResultBatch) but the server still claimed serially N times — each call committing its own Pebble batch. Q2 was structurally batched but Pebble compaction + per-claim commit overhead bounded the throughput win at +12% ciclo full.

Phase 7 closes that gap: new \`ClaimMany\` on the Pebble TaskRepository pops up to N hints from the per-(cmd,tenant,prio) channels and writes ALL the resulting transitions into a **single Pebble batch with one CommitBatch**. 5×N writes amortised across one commit + one coalescer trip instead of N independent batches.

## Worker-isolated saturation

\`TestSaturation_StreamPath\`, REST producer backgrounded:

| concurrency | no batch | BATCH=32 | speedup |
|---|---|---|---|
| c=1 | 1,343/s | **12,741/s** | **9.5×** |
| c=4 | 3,282/s | **23,518/s** | **7.2×** |
| c=16 | 6,790 | 16,517 | 2.4× |
| c=32 | 9,302 | 16,185 | |
| c=64 | 14,387 | 16,301 | |
| c=128 | 19,846 | 15,848 | |
| c=256 | 24,696 | 15,688 | |

Batch wins enormously at low concurrency — **9.5× at c=1, 7.2× at c=4**. At higher c the queue-feeding REST producer in the harness becomes the bottleneck, so batch and no-batch plateau together. With Phase 6 / Q3's stream producer batch the queue-feed limit disappears and ciclo full benefits compound.

## Ciclo full

\`profile_full_cycle_test.go\`, both stream sides active, 20s window:

| config | tasks/s |
|---|---|
| Pre-P7 + worker BATCH=32 | 33,700 |
| **Post-P7 + worker BATCH=32** | **34,500** |
| Post-P7 + worker BATCH=32 + prod BATCH=16 | 34,800 |
| Post-P7 + worker BATCH=32 + prod BATCH=8 | **36,400** |

The single-process ciclo-full win still waits on M2 (in-memory lease) — Pebble compaction is now **30% of the CPU profile** (was 22%), confirming the worker hot path is doing more useful Pebble work per second. The lease/inprog/TTL bumps that M2 removes are the next bottleneck.

## API changes

### \`internal/repository/pebble/task_repository.go\`
- NEW: \`(*TaskRepository).ClaimMany(workerID, commands, lease, max, inspectLimit, maxAttempts, tenantID) ([]*Task, error)\`
- Drains up to \`max\` hints, applies same validation as \`completeClaim\` (status==PENDING, ghost handling, stale-hint drop), folds bad hints' deletes into the same batch.

### \`internal/services/scheduler_service.go\`
- NEW: \`SchedulerService.ClaimManyTasks(...)\` on the public interface.
- NEW: unexported \`batchClaimer\` interface — type-asserted on the repo. Pebble implements; Redis backend falls back to looping \`ClaimTask\` so the service still works cleanly on any backend.

### \`internal/worker/server.go\`
- \`handleReadyBatch\`: N serial \`ClaimTask\` → single \`ClaimManyTasks\` call. Poll-loop semantics preserved (idle workers still wait \`MaxClaimRetries × ClaimPollDelay\`).

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all packages green
- [x] \`TestSaturation_StreamPath\` with \`PHASE6_BATCH=32\` shows the 9× speedup at c=1
- [x] Mock SchedulerService in \`batch_controllers_test.go\` updated with ClaimManyTasks fallback
- [x] Existing single-task path (\`Ready.count<=1\`) still works; \`TestClient_RunCompletedHappyPath\` and friends pass unchanged

## Stacks on Q3 (#539)

Branched off the post-Q3 main. Q3 is producer-side batch; P7 is worker-side batch's missing piece. Both are necessary for the next phase (M2) to land its full effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)