### PR TITLE
docs(wave2-u3): expand load testing with stream benches and shard sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,108 @@
-# codeQ
+# codeq
 
-Reactive scheduling and completion system backed by persistent queues. Choose your storage: KVRocks (distributed) or Pebble (embedded).
+> Embedded high-performance task queue. One Go binary, Pebble for
+> storage, gRPC streams on the wire. 83k tasks/s on a single 12-core
+> box with zero external dependencies.
 
-This repository contains the core runtime, HTTP API wiring, and a Helm chart for small clusters.
-The production service wrapper lives at:
-https://github.com/codecompany/codeq-service
+[![Go Reference](https://pkg.go.dev/badge/github.com/osvaldoandrade/codeq.svg)](https://pkg.go.dev/github.com/osvaldoandrade/codeq)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Issues](https://img.shields.io/github/issues/osvaldoandrade/codeq.svg)](https://github.com/osvaldoandrade/codeq/issues)
 
-## Links
+## What is codeq?
 
-- GitHub: https://github.com/osvaldoandrade/codeq
-- Issues: https://github.com/osvaldoandrade/codeq/issues
-- Specs index: `docs/README.md`
+codeq is a task queue written in Go. The default deployment is a single
+process: the server, the persistence layer (Pebble, the RocksDB-style
+LSM from CockroachDB), the lease table, and the gRPC + HTTP API all
+share one binary and one disk directory. There is no Redis to run, no
+broker to babysit, no consensus to coordinate.
 
-## Why codeQ
+On a 12-core Linux box, that single binary sustains **83,420 tasks/s**
+for the full create → claim → complete cycle and **136,392 creates/s**
+for producer-only workloads — measured by the in-tree benchmarks in
+`internal/bench/`. When one machine is no longer enough, cluster mode
+(consistent-hash ring + gRPC routing between nodes) and a legacy Redis
+backend are opt-in.
 
-codeQ provides:
+## Architecture overview
 
-- Persistent queues with pluggable storage backends:
-  - **Redis/KVRocks** (distributed, cluster-capable)
-  - **Pebble** (embedded, zero-dependency, ideal for local development)
-- Pull-based worker claims with leases.
-- **Multi-tenant queue isolation** with automatic tenant ID extraction from JWT claims.
-- **Horizontal scaling with queue sharding**: Optional pluggable `ShardSupplier` interface for routing commands/tenants across multiple KVRocks instances.
-- **Pluggable persistence backends**: Redis, memory (testing), and extensible plugin architecture for custom storage (PostgreSQL, DynamoDB, Cassandra, etc.).
-- NACK + backoff + delayed queues.
-- DLQ for tasks that exceed `maxAttempts`.
-- Result storage and optional callbacks (webhooks).
-- Worker auth via JWT (JWKS), producer auth via Tikti access tokens (JWKS).
-- **Official SDKs** for Java and Node.js/TypeScript with framework integrations.
-- **Distributed tracing** with OpenTelemetry support for end-to-end observability.
-- **Optimized performance**: O(1) queue operations with pipelined lease repair for low-latency claims even under high load.
-- **Load testing framework**: Comprehensive k6 scenarios and Go benchmarks for performance validation and regression testing.
+```mermaid
+graph TB
+  subgraph Clients
+    PSDK[Producer SDK]
+    WSDK[Worker SDK]
+    CURL[HTTP / curl]
+  end
+  subgraph Server[codeq server -- single binary]
+    HTTP[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+  end
+  subgraph Storage[Embedded persistence]
+    P0[Pebble shard 0]
+    P1[Pebble shard 1]
+    PN[Pebble shard N-1]
+  end
+  subgraph Optional[Opt-in scaling]
+    CL[Cluster -- consistent-hash + gRPC]
+    REDIS[Redis backend -- legacy HA]
+  end
+  PSDK --> PGRPC
+  WSDK --> WGRPC
+  CURL --> HTTP
+  HTTP --> LEASE
+  PGRPC --> LEASE
+  WGRPC --> LEASE
+  LEASE --> P0
+  LEASE --> P1
+  LEASE --> PN
+  Server -.-> CL
+  Server -.-> REDIS
+```
 
-## Get started
+Producers and workers connect over long-lived bidirectional gRPC
+streams. Each request hits the in-memory lease table first, then commits
+to a Pebble shard chosen by `hash(taskID) % N`. Each shard runs its own
+commit pipeline and compaction loop, which is what lets a 4-shard
+configuration roughly double the single-shard throughput on the same
+hardware.
 
-### Local development with Docker Compose
+## Performance
 
-The quickest way to try codeQ locally:
+All numbers measured on a 12-core Linux box, Go 1.25.0, loopback gRPC,
+Pebble with `fsyncOnCommit=false`. Full bench harness lives in
+`internal/bench/`.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle (create + claim + complete), 4 Pebble shards | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| Worker-only, batched claim+complete | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep (full cycle, 1 / 2 / 4 / 6 / 8 shards) | 42k / 65k / **83k** / 68k / 67k tasks/s | same as full cycle harness with `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on a 12-core box; past that, write
+amplification and goroutine contention start to dominate. See
+[docs/30-performance-baselines.md](docs/30-performance-baselines.md)
+for raw output and per-release history.
+
+## Why codeq vs alternatives
+
+| Feature | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | **None** (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper / KRaft cluster |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | n/a (no task semantics) |
+| Language affinity | Go server, SDKs for Java, Node, Python, Go | Go only | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant isolation | **Built in** (JWT tenantId namespacing) | DIY | DIY | DIY | DIY |
+| Time-to-first-task | `docker run` + `curl` | Run Redis + Asynq | Run Redis + worker | Run broker + workers + result backend | Multi-step cluster bootstrap |
+
+codeq is the right call when you want task-queue semantics (claims,
+leases, retries, DLQ, results) without standing up a broker. It is the
+wrong call if you need Kafka-scale event streaming, distributed
+consensus by default, or HA without configuring the Redis backend or
+cluster mode.
+
+## Quick start (5 minutes)
 
 ```bash
 git clone https://github.com/osvaldoandrade/codeq
@@ -47,125 +113,10 @@ docker compose \
   up -d
 ```
 
-This starts KVRocks, the codeQ API server, and seeds example tasks. Access at `http://localhost:8080`.
+This brings up the codeq server on `http://localhost:8080` with the
+embedded Pebble backend (no Redis required) and seeds example tasks.
 
-See [Local Development Guide](docs/22-local-development.md) for details on hot reload, testing, and observability.
-
-### Install a server
-
-Use the console wizard to generate a Docker or Kubernetes/Helm install bundle:
-
-```bash
-codeq install
-```
-
-Non-interactive Kubernetes example:
-
-```bash
-codeq install \
-  --target kubernetes \
-  --size small \
-  --namespace codeq \
-  --identity-service-url https://issuer.example.com \
-  --worker-jwks-url https://issuer.example.com/.well-known/jwks.json \
-  --worker-issuer https://issuer.example.com
-```
-
-### Install CLI (macOS/Linux/Windows via Git Bash)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
-```
-
-Requires `git` and `go`.
-
-### Install CLI via npm (npmjs)
-
-```bash
-npm i -g @osvaldoandrade/codeq
-codeq --help
-```
-
-Upgrade:
-
-```bash
-npm i -g @osvaldoandrade/codeq@latest
-```
-
-### Use SDKs for Java, Node.js, Python, and Go
-
-Integrate codeQ into your microservices with official SDKs:
-
-**Java** (Spring Boot, Quarkus, Micronaut):
-```xml
-<dependency>
-    <groupId>io.codeq</groupId>
-    <artifactId>codeq-sdk-java</artifactId>
-    <version>1.0.0</version>
-</dependency>
-```
-
-**Node.js/TypeScript** (Express, NestJS):
-```bash
-npm install @osvaldoandrade/codeq-client
-```
-
-**Python** (FastAPI, Django, Flask):
-```bash
-pip install codeq-client
-```
-
-**Go** (Gin, Echo, stdlib):
-```bash
-go get github.com/osvaldoandrade/codeq/sdks/go
-```
-
-📚 **SDK Documentation**:
-- [SDK Overview & Quick Start](sdks/README.md)
-- [Java SDK](sdks/java/README.md)
-- [Node.js SDK](sdks/nodejs/README.md)
-- [Python SDK](sdks/python/README.md)
-- [Go SDK](sdks/go/README.md)
-- [Integration Guides](docs/integrations/)
-- [Example Applications](examples/)
-
-### Helm
-
-The chart in this repo deploys codeQ and, by default in the small profile, a single-node KVRocks instance.
-
-```bash
-git clone https://github.com/osvaldoandrade/codeq
-cd codeq
-
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-small.yaml \
-  --namespace codeq --create-namespace \
-  --set secrets.enabled=true \
-  --set secrets.webhookHmacSecret=YOUR_SECRET \
-  --set config.identityServiceUrl=https://your-auth-server.com \
-  --set config.workerJwksUrl=https://your-jwks \
-  --set config.workerIssuer=https://issuer
-```
-
-Disable embedded KVRocks and point to your own:
-
-```bash
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-medium.yaml \
-  --set kvrocks.enabled=false \
-  --set config.redisAddr=your-kvrocks:6666
-```
-
-### 2) Service runtime
-
-The API server and Dockerfile are in the service repo:
-https://github.com/codecompany/codeq-service
-
-That repo consumes this module and exposes the HTTP API.
-
-## Quick API flow
-
-Create a task (producer token):
+Create a task:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks \
@@ -174,7 +125,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"priority":3}'
 ```
 
-Claim a task (worker JWT):
+Claim a task (as a worker):
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
@@ -183,7 +134,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
   -d '{"commands":["GENERATE_MASTER"],"leaseSeconds":120,"waitSeconds":10}'
 ```
 
-Submit result:
+Submit a result:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
@@ -192,49 +143,95 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
   -d '{"status":"COMPLETED","result":{"ok":true}}'
 ```
 
-## Specs and docs
+For high-throughput producers and workers, use the gRPC streaming API
+(2-3x the HTTP throughput, amortized auth, pipelined acks): see
+[docs/34-streaming-api-guide.md](docs/34-streaming-api-guide.md).
 
-Start here: `docs/README.md`
+## Where next
 
-Key references:
+- [Getting started tutorial](docs/00-getting-started.md) — your first
+  task, end to end.
+- [Overview](docs/01-overview.md) — goals, non-goals, when (and when
+  not) to pick codeq.
+- [Architecture](docs/03-architecture.md) — package layout and request
+  flows.
+- [Performance tuning](docs/17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Operational runbooks](docs/29-operational-runbooks.md) — on-call
+  procedures for the common failure modes.
+- [Streaming API guide](docs/34-streaming-api-guide.md) — gRPC
+  producer and worker streams.
+- [Cluster architecture](docs/05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Style guide](docs/_STYLE.md) — voice, numbers, diagrams, links.
 
-- **Getting Started Tutorial**: `docs/00-getting-started.md` - **Start here for your first experience with codeQ**
-- **Overview**: `docs/01-overview.md` - System goals and design principles
-- **Architecture**: `docs/03-architecture.md` - System components and multi-tenant architecture
-- **Security**: `docs/09-security.md` - Authentication, authorization, and tenant isolation
-- **HTTP API**: `docs/04-http-api.md` - Complete API reference
-- **CLI Reference**: `docs/15-cli-reference.md` - CLI command documentation
-- **SDK Integration**: `sdks/README.md` - Official Java and Node.js SDKs
-  - [Java Integration](docs/integrations/java-integration.md) - Spring Boot, Quarkus, Micronaut
-  - [Node.js Integration](docs/integrations/nodejs-integration.md) - Express, NestJS, React
-- **Examples**: `examples/` - Working examples with Java and Node.js frameworks
-- **Developer Guide**: `docs/21-developer-guide.md` - Contributing and internal architecture
-- **Queue model**: `docs/05-queueing-model.md` - Queue semantics
-- **Storage layout**: `docs/07-storage-kvrocks.md` - KVRocks data structures
-- **Backoff and retries**: `docs/11-backoff.md` - Retry logic
-- **Webhooks**: `docs/12-webhooks.md` - Push notifications
-- **Configuration**: `docs/14-configuration.md` - Config reference
-- **Operations**: `docs/10-operations.md` - Metrics, health checks, and tracing
-- **Workflows**: `docs/16-workflows.md` - GitHub Actions automation
-- **Performance**: `docs/17-performance-tuning.md` - Optimization guide
-- **Load Testing**: `docs/26-load-testing.md` - Load testing framework and benchmarks
-- **Testing**: `docs/19-testing.md` - Test coverage and strategy
-- **Authentication Plugins**: `docs/20-authentication-plugins.md` - Plugin system for custom auth
-- **Persistence Plugins**: `docs/27-persistence-plugin-system.md` - Pluggable storage backends (Redis, Memory, and more)
-- **Design Documents**:
-  - `docs/24-queue-sharding-hld.md` - Queue sharding high-level design
-  - `docs/25-plugin-architecture-hld.md` - Plugin architecture for persistence and auth
-- **Migration**: `docs/migration.md` - Upgrade guide
-- **Contributing**: `CONTRIBUTING.md` - Contribution guidelines
+## SDKs
+
+Official client libraries for the languages most likely to talk to
+codeq from application code:
+
+- **Go** — `go get github.com/osvaldoandrade/codeq/sdks/go` ([README](sdks/go/README.md))
+- **Java** (Spring Boot, Quarkus, Micronaut) — [sdks/java/README.md](sdks/java/README.md)
+- **Node.js / TypeScript** (Express, NestJS) — [sdks/nodejs/README.md](sdks/nodejs/README.md)
+- **Python** (FastAPI, Django, Flask) — [sdks/python/README.md](sdks/python/README.md)
+
+Integration recipes per framework live under
+[docs/integrations/](docs/integrations/). End-to-end example apps live
+under [examples/](examples/).
 
 ## Repo layout
 
-- `pkg/`: public packages (`app`, `config`, `domain`)
-- `internal/`: controllers, middleware, services, repositories, providers
-- `deploy/`: Docker Compose, Kubernetes, and config examples
-- `helm/codeq`: Helm chart and size profiles
-- `docs/`: full specification
+```text
+cmd/                  CLI entrypoints (codeq install, server)
+internal/             unexported packages
+  bench/              throughput + latency benchmarks (source of truth for perf claims)
+  cluster/            consistent-hash ring, gRPC router, bloom gossip
+  controllers/        HTTP handlers (Gin)
+  middleware/         auth, tracing, rate-limit, tenant extraction
+  producer/           gRPC producer-stream server
+  worker/             gRPC worker-stream server
+  repository/         persistence implementations (Redis legacy + Pebble)
+  services/           scheduler, results, callbacks, subscriptions
+pkg/                  public packages (app, auth, config, domain,
+                      producerclient, workerclient)
+sdks/                 official SDKs (go, java, nodejs, python)
+deploy/               docker-compose and Kubernetes config
+helm/codeq/           Helm chart and size profiles
+docs/                 specifications, runbooks, performance baselines
+examples/             end-to-end example applications
+```
+
+## Install the CLI
+
+macOS, Linux, or Windows via Git Bash:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
+```
+
+Or via npm:
+
+```bash
+npm i -g @osvaldoandrade/codeq
+codeq --help
+```
+
+To generate a Docker or Kubernetes install bundle (with embedded Pebble
+by default, no Redis required):
+
+```bash
+codeq install
+```
+
+See [docs/15-cli-reference.md](docs/15-cli-reference.md) for the full
+CLI surface.
+
+## Contributing
+
+Issues and PRs are welcome. Before opening a PR, read
+[CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, and
+[docs/_STYLE.md](docs/_STYLE.md) for the documentation style.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,27 +1,244 @@
 # Overview
 
-codeQ is a task scheduling and completion service built on persistent queues in KVRocks. The service exposes HTTP APIs for producers to create tasks, for workers to claim and complete tasks, and for operators to inspect and clean up queues. The system is reactive: workers pull tasks, and optionally receive webhook signals that work is available.
+> Source-of-truth for the value proposition lives in
+> [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+> Other docs may cite this overview, but the style guide wins ties.
 
-The design is inspired by Dyno Queues, which adds time-based and priority queues on top of Dynomite. Dynomite is a distributed data layer that exposes Redis semantics and provides multi-datacenter replication. codeQ applies the same motivation to KVRocks and uses Go for the implementation. The service favors availability and throughput over strict global ordering.
+## What is codeq
+
+codeq is a task queue written in Go that runs as a single process and
+stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+from CockroachDB). The hot path is bidirectional gRPC streams from
+producers and workers; under the streams sits an intra-process shard
+table (up to N independent Pebble instances) and an in-memory lease
+table. On a 12-core Linux box the single binary sustains
+**83,420 tasks/s** for the full create → claim → complete cycle and
+**136,392 creates/s** for producer-only workloads.
+
+No Redis, no broker, no coordinator required in the default mode.
+Cluster (consistent-hash ring + gRPC routing) and a legacy Redis backend
+are opt-in for HA and multi-node deployments.
 
 ## Goals
 
-- Provide a stable API for enqueue, claim, and completion.
-- Persist state on disk via KVRocks.
-- Support delayed retries, priority, and retries.
-- Allow workers to pull by event type without a worker registry.
-- Provide optional push notifications without assigning work.
+- **Single binary.** Server, persistence, lease table, HTTP + gRPC API
+  all in one process. One disk directory. One systemd unit. No external
+  database required.
+- **80k+ tasks/s on one machine.** Full create → claim → complete cycle
+  measured by `internal/bench/profile_full_cycle_test.go` with 4 Pebble
+  shards, batched producer + worker streams.
+- **gRPC streaming as a first-class API.** Long-lived bidirectional
+  streams amortize auth and middleware; multiple requests can be in
+  flight before responses arrive.
+- **Multi-tenant by construction.** Every queue key is namespaced by
+  `tenantId` extracted from the JWT. Workers can only claim tasks from
+  their own tenant. No application code required to keep tenants
+  isolated.
+- **Cluster opt-in.** When one machine is no longer enough, run a
+  consistent-hash cluster (no consensus, no coordinator — static
+  membership + gRPC routing).
+- **Configurable durability.** `fsyncOnCommit` is a per-deployment knob.
+  Off by default for throughput; turn it on when your SLO demands it.
 
 ## Non-goals
 
-- Exactly-once processing.
-- Global FIFO across all commands.
-- Automatic worker discovery or scheduling.
+- **Kafka-scale event streaming.** codeq is a task queue, not a
+  partitioned log. If you want millions of messages/s with consumer
+  groups, use Kafka.
+- **Distributed consensus by default.** No Raft, no Paxos. Cluster mode
+  uses a static consistent-hash ring; node membership is configured at
+  startup, not gossiped.
+- **HA without explicit setup.** A single Pebble process loses
+  availability while it restarts. HA requires either the Redis backend
+  (legacy, multi-node) or running a cluster of Pebble nodes — each is a
+  trade-off the operator picks consciously.
+- **Exactly-once delivery.** Delivery is at-least-once. A worker that
+  crashes between completion and ACK will see the task re-delivered
+  after the lease expires.
+- **Global FIFO across all commands.** Ordering is per-(command,
+  tenant, priority) within a Pebble shard. Cross-shard ordering is not
+  defined.
+- **Worker discovery or scheduling.** codeq does not register workers
+  or assign work; workers pull when they are ready.
 
-## High-level data model
+## Data model summary
 
-- Task: unit of work, identified by UUID.
-- Message: queue element containing metadata used by the scheduler.
-- Result: completion record stored independently of the task body.
-- Command (event type): routing key for tasks.
-- Shard: not implemented; queues are single-shard in the current service.
+- **Task** — unit of work. Identified by UUID. Carries `command`
+  (routing key), `payload` (opaque JSON bytes), `priority` (0-9),
+  optional `webhook` URL, and lifecycle state.
+- **Result** — completion record. Stored separately from the task body
+  so completion can be GC'd on a different schedule than the task
+  metadata.
+- **Subscription** — webhook registration. A worker (or coordinator)
+  registers a callback URL for one or more event types; codeq pings it
+  when new work appears.
+
+Task lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> FAILED: SubmitResult(err)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DELAYED: Nack(backoff)
+  DELAYED --> PENDING: MoveDueDelayed
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  FAILED --> [*]
+  DLQ --> [*]
+```
+
+Full schema and state semantics in
+[02-domain-model.md](./02-domain-model.md).
+
+## Architecture summary
+
+```mermaid
+graph TB
+  subgraph Clients
+    SDK[Producer / Worker SDKs]
+    HTTPCLI[HTTP clients -- curl, browsers]
+  end
+  subgraph Server[codeq server]
+    API[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+    SCHED[Scheduler core]
+  end
+  subgraph Storage[Embedded persistence -- default]
+    P[Pebble shards 0..N-1]
+  end
+  subgraph OptIn[Opt-in modes]
+    CL[Cluster -- consistent-hash + gRPC routing]
+    REDIS[Redis backend -- legacy, HA]
+  end
+  SDK --> PGRPC
+  SDK --> WGRPC
+  HTTPCLI --> API
+  API --> SCHED
+  PGRPC --> SCHED
+  WGRPC --> SCHED
+  SCHED --> LEASE
+  SCHED --> P
+  Server -.-> CL
+  Server -.-> REDIS
+```
+
+Request flow at a glance:
+
+1. Producer or worker opens a gRPC stream (or sends an HTTP request).
+2. The middleware chain validates the JWT, extracts `tenantId`, and
+   applies rate limits.
+3. The scheduler routes the operation to its Pebble shard
+   (`hash(taskID) % numShards`) and updates the in-memory lease table.
+4. Pebble commits the batch; the group-commit coalescer (Phase 1.1)
+   merges concurrent writers into one fsync.
+5. On worker stream, ready tasks are pushed back through the same long-
+   lived connection — no per-claim handshake.
+
+Package-level breakdown in [03-architecture.md](./03-architecture.md).
+
+## When to use codeq
+
+- **Single-node task queue for a backend service.** You want claims,
+  leases, retries, DLQ, and results without standing up Redis or a
+  broker.
+- **Embedded sidecar in your own Go binary.** Import `pkg/app` and run
+  codeq in-process alongside your application.
+- **Multi-tenant SaaS background jobs.** Per-tenant queue isolation is
+  built in; you do not have to namespace keys yourself.
+- **High-throughput producers with small payloads.** The batched
+  producer stream sustains 100k+ creates/s on commodity hardware.
+- **Polyglot worker fleets.** Workers in Go, Java, Node, or Python can
+  all share the same queue via the official SDKs.
+- **Local development without external services.** `docker run codeq`
+  is enough; no Redis container, no compose dance.
+
+## When NOT to use codeq
+
+- **Kafka-scale event streaming.** Millions of events/s with consumer
+  groups, replay, and a retention window measured in days — use Kafka.
+- **Distributed transactions.** codeq has no two-phase commit and no
+  cross-shard transactions. If your business logic needs atomic updates
+  across multiple tasks, build it above codeq with an outbox pattern or
+  pick a workflow engine.
+- **HA without Redis or cluster mode.** A single Pebble process is
+  unavailable during restart. If your SLO does not tolerate a few
+  seconds of unavailability, you need the Redis backend (multi-node) or
+  a Pebble cluster.
+- **Workflow orchestration with branching, child tasks, timers, and
+  long-running state.** Use Temporal, Cadence, or Step Functions — they
+  are purpose-built for that. codeq is a queue.
+- **Exactly-once delivery semantics.** codeq is at-least-once. Idempotent
+  handlers are the operator's responsibility.
+
+## Performance baselines
+
+Measured on a 12-core Linux box, Go 1.25.0, loopback gRPC, Pebble with
+`fsyncOnCommit=false`, 20s measurement window after a 2s warm-up.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle, 4 shards, batched | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (32 goroutines, batch=16) |
+| Worker-only, batched stream | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep | 1 shard: 42k; 2: 65k; **4: 83k**; 6: 68k; 8: 67k | same as full cycle, `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on this hardware. Past that, the cost of more
+commit pipelines + compaction loops outweighs the parallelism win. See
+[30-performance-baselines.md](./30-performance-baselines.md) for raw
+output, allocator stats, and the per-release history.
+
+## Comparativos resumidos
+
+| Dimension | codeq | Asynq | BullMQ | Kafka |
+|---|---|---|---|---|
+| External dependency | **None** | Redis | Redis | ZooKeeper / KRaft |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k | ~5k | n/a (no task semantics) |
+| Language | Go server, multi-language SDKs | Go | Node | Polyglot |
+| Multi-tenant native | **Yes** | DIY | DIY | DIY |
+| HA model | Cluster or Redis (opt-in) | Redis | Redis | Replicated log |
+
+Full table with Sidekiq, Celery, and Temporal lives in
+[_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## What changed (Phases 1-8 summary)
+
+codeq has been through a sequence of refactors that shifted its
+positioning from "Redis-backed queue" to "embedded high-performance
+queue". The short version:
+
+| Phase | Theme | Effect |
+|---|---|---|
+| 0 | kvrocks-primary | First version: KVRocks (Redis protocol) as the only backend. ~1.5-2k tasks/s. |
+| 1 | Pebble embedded backend | Pebble added as a pluggable persistence provider. Single-binary deployment becomes possible. Single-shard throughput ~42k tasks/s. |
+| 1.1 | Pebble fast-paths + group-commit coalescer | `MoveDueDelayed` fast-path; concurrent writers coalesce into one fsync. |
+| 2 | Streaming groundwork | gRPC streaming surfaces designed. Auth amortized across stream lifetime. |
+| 5 | Cluster mode | Consistent-hash ring + gRPC routing between Pebble nodes. No consensus; static membership. |
+| 6 | Batched stream paths | Producer and worker streams gain batch APIs. `PHASE6_BATCH` / `PHASE6_PROD_BATCH` env knobs. |
+| 8 | Intra-process Pebble sharding | `numShards` opens N independent Pebble instances under one process. 4 shards → ~83k tasks/s on a 12-core box. **Mutually exclusive with cluster mode.** |
+
+PRs #527-#547 landed Phases 1.1, 6, and 8. The Redis backend remains
+supported for HA scenarios but is no longer the default.
+
+## See also
+
+- [_STYLE.md](./_STYLE.md) — documentation voice, numbers, diagrams.
+- [Architecture](./03-architecture.md) — package layout and request
+  flows.
+- [HTTP API](./04-http-api.md) — REST surface.
+- [Streaming API guide](./34-streaming-api-guide.md) — gRPC producer
+  and worker streams.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and per-release history.
+- [Performance tuning](./17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Cluster architecture](./05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Storage layout (Pebble)](./07b-storage-pebble.md) — keyspace and
+  sharding internals.
+- [Persistence plugin system](./27-persistence-plugin-system.md) —
+  choosing and configuring backends.

--- a/docs/26-load-testing.md
+++ b/docs/26-load-testing.md
@@ -1,14 +1,254 @@
-# Load Testing
+# Load testing
 
-This document describes the load testing harness shipped with the repository (Issue #30).
+codeq ships two load-testing surfaces. They answer two different
+questions.
 
-## What’s Included
+| Surface | Question it answers | Where it lives |
+|---|---|---|
+| k6 HTTP scenarios | What does the REST API do under realistic mixed traffic on a real network? | `loadtest/k6/01..06_*.js` |
+| In-process Go bench harnesses | What is the single-process ceiling for each transport, with the network removed? | `internal/bench/*_test.go` |
 
-- **k6 HTTP scenarios** in `loadtest/k6/` for producer + worker traffic.
-- **Go benchmarks** in `internal/bench/` for quick perf regression checks.
-- **Observability stack** via the local Compose profile `obs` (Prometheus + Grafana) to view `/metrics`.
+The Go harnesses are how every throughput number in the rest of the
+docs is produced. The k6 scenarios are for regression and for showing
+the REST surface in isolation; they are not the path you cite when
+quoting peak numbers.
 
-## Running k6 Scenarios (Local)
+> **Note**: every number in this document is reproducible. Each table
+> cites the exact test name, env knobs, and run command. The reference
+> box is 12-core Linux (kernel 5.15, WSL2-compatible), Go 1.25, local
+> Pebble, loopback gRPC, no fsync. Numbers come from
+> `internal/bench/*_test.go` runs unless otherwise stated.
+
+## Harness layout
+
+```mermaid
+graph TB
+  subgraph k6[k6 scenarios - loadtest/k6/]
+    K1[01_sustained_throughput.js]
+    K2[02_burst_10k_10s.js]
+    K3[03_many_workers.js]
+    K4[04_prefill_queue.js]
+    K5[05_mixed_priorities.js]
+    K6[06_delayed_tasks.js]
+  end
+  subgraph bench[Go bench harnesses - internal/bench/]
+    PVR[producer_stream_vs_rest_test.go]
+    PSAT[producer_stream_saturation_test.go]
+    WVR[worker_stream_vs_rest_bench_test.go]
+    WSAT[worker_stream_saturation_test.go]
+    PROF[profile_full_cycle_test.go]
+  end
+  subgraph srv[codeq Application]
+    HTTP[Gin HTTP /v1/codeq/tasks]
+    GP[gRPC producer stream]
+    GW[gRPC worker stream]
+    PEB[Pebble shards]
+  end
+  K1 --> HTTP
+  K2 --> HTTP
+  K3 --> HTTP
+  K4 --> HTTP
+  K5 --> HTTP
+  K6 --> HTTP
+  PVR --> HTTP
+  PVR --> GP
+  PSAT --> GP
+  WVR --> HTTP
+  WVR --> GW
+  WSAT --> GW
+  PROF --> GP
+  PROF --> GW
+  HTTP --> PEB
+  GP --> PEB
+  GW --> PEB
+```
+
+## Numbers at a glance
+
+All numbers below are from `internal/bench/*_test.go`. Run command:
+
+```bash
+go test -v -run='^TestProducerThroughput|^TestThroughput_|^TestProfile_FullCycle|^TestSaturation_' \
+  -count=1 -timeout=300s ./internal/bench/...
+```
+
+| Workload | Path | Result | Harness |
+|---|---|---|---|
+| Producer-only | REST `POST /v1/codeq/tasks` | 16,447 creates/s | `producer_stream_vs_rest_test.go::TestProducerThroughput_RESTPath` |
+| Producer-only | gRPC stream, single | 73,031 creates/s | `producer_stream_vs_rest_test.go::TestProducerThroughput_StreamPath` |
+| Producer-only | gRPC stream, batch=16 | 136,392 creates/s | `producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| Worker full cycle | REST claim + complete | ~5,500 tasks/s | `worker_stream_vs_rest_bench_test.go::TestThroughput_RESTPath` |
+| Worker full cycle | gRPC stream, c=32 | 16,118 tasks/s | `worker_stream_vs_rest_bench_test.go::TestThroughput_StreamPath` |
+| Full cycle, 4 shards, batched | gRPC stream + sharding | 83,420 tasks/s | `profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+
+## REST vs stream — what the numbers say
+
+```mermaid
+graph LR
+  subgraph Producer[Producer creates/s]
+    PR[REST 16,447]
+    PS[Stream single 73,031]
+    PB[Stream batch=16 136,392]
+  end
+  subgraph Worker[Worker tasks/s]
+    WR[REST 5,500]
+    WS[Stream c=32 16,118]
+    WP[Full cycle shards=4 83,420]
+  end
+  PR --> PS --> PB
+  WR --> WS --> WP
+```
+
+Read as a progression: each arrow is the next transport mode. The
+order is producer-REST → stream → batched stream, then worker-REST →
+stream → full sharded cycle.
+
+Three concrete deltas:
+
+- **Producer REST → stream single**: 4.4x. The REST handler pays per-
+  request HTTP framing, per-request JWT validation, per-request Gin
+  context allocation. The stream amortizes the auth handshake across
+  the session lifetime and reuses one HTTP/2 connection.
+- **Stream single → stream batch=16**: 1.87x. The batch path is the
+  Phase 6 producer batch API (`ProduceBatch`); one stream message
+  carries 16 creates and one Pebble write batch persists them. The
+  ceiling here is Pebble's group-commit coalescer, not the wire.
+- **Worker REST → worker stream**: ~2.9x. REST does two round trips
+  per task (`POST /tasks/claim`, then `POST /tasks/:id/result`). The
+  stream collapses both into one bidirectional session and uses
+  `BatchSize` to claim and complete in groups.
+
+The headline 83,420 tasks/s for the full create→claim→complete cycle
+requires three things together: producer stream batch, worker stream
+batch, and `PHASE8_SHARDS=4`. Drop any one of them and the number
+falls back to the matching row above.
+
+## Running the in-process bench harnesses
+
+Prerequisites: Go 1.25, write access to `$TMPDIR` (Pebble shards land
+in `t.TempDir()`), and a free TCP loopback port range.
+
+### Producer-only — REST vs stream
+
+```bash
+go test -v -run='^TestProducerThroughput' \
+  -count=1 -timeout=180s ./internal/bench/...
+```
+
+This runs all three producer paths in
+[`internal/bench/producer_stream_vs_rest_test.go`](../internal/bench/producer_stream_vs_rest_test.go).
+Each path runs `phase3Duration = 6 * time.Second` with
+`phase3Concurrency = 32` goroutines.
+
+Output ends with `t.Logf` lines like:
+
+```
+REST:    created=98682  duration=6.0s  rate=16447 creates/s
+STREAM:  created=438187 duration=6.0s  rate=73031 creates/s
+STREAM-BATCH (size=16): created=818355 duration=6.0s  rate=136392 creates/s
+```
+
+### Worker full cycle — REST vs stream
+
+```bash
+go test -v -run='^TestThroughput_' \
+  -count=1 -timeout=180s ./internal/bench/...
+```
+
+This is [`internal/bench/worker_stream_vs_rest_bench_test.go`](../internal/bench/worker_stream_vs_rest_bench_test.go).
+Both tests share `runProducer()` to keep the queue topped up while a
+worker pool drains. Concurrency is `phase2WorkerConcurrency = 32` and
+window is `phase2RunDuration = 6 * time.Second`.
+
+REST does two HTTP calls per task; the stream worker uses the
+`workerclient` SDK with one persistent session.
+
+### Saturation sweeps — find the per-process ceiling
+
+Producer saturation:
+
+```bash
+go test -v -run='^TestSaturation_ProducerStreamPath' \
+  -count=1 -timeout=300s ./internal/bench/...
+```
+
+Worker saturation:
+
+```bash
+PHASE6_BATCH=32 go test -v -run='^TestSaturation_StreamPath' \
+  -count=1 -timeout=300s ./internal/bench/...
+```
+
+Both sweep concurrencies `{1, 4, 16, 32, 64, 128, 256, 512}` and log
+one row per step. Use them to find where the curve plateaus on your
+hardware — the plateau location identifies the bottleneck (claim path,
+Pebble write loop, or gRPC framing).
+
+See [`internal/bench/producer_stream_saturation_test.go`](../internal/bench/producer_stream_saturation_test.go)
+and [`internal/bench/worker_stream_saturation_test.go`](../internal/bench/worker_stream_saturation_test.go).
+
+### Full cycle with profiling
+
+The canonical "everything wired, profiles attached" harness is
+[`internal/bench/profile_full_cycle_test.go`](../internal/bench/profile_full_cycle_test.go).
+It runs producer stream + worker stream at saturation for a 20 s
+window after a 2 s warmup, then writes CPU, alloc, heap, block, mutex,
+and goroutine pprof profiles to `/tmp/codeq-profiles/`.
+
+```bash
+PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8 \
+  go test -v -run='^TestProfile_FullCycle' \
+  -count=1 -timeout=180s ./internal/bench/...
+```
+
+Inspect the profiles:
+
+```bash
+go tool pprof -top -cum /tmp/codeq-profiles/cpu.pb.gz
+go tool pprof -alloc_space -top -cum /tmp/codeq-profiles/alloc.pb.gz
+go tool pprof -top -cum /tmp/codeq-profiles/block.pb.gz
+go tool pprof -top -cum /tmp/codeq-profiles/mutex.pb.gz
+```
+
+Env knobs the harness reads:
+
+- `PHASE8_SHARDS` — number of independent Pebble shards (Phase 8
+  sharding). Unset or `1` means single-shard.
+- `PHASE6_BATCH` — worker `BatchSize`. `0` means single-task.
+- `PHASE6_PROD_BATCH` — producer `ProduceBatch` size per goroutine.
+  `0` or `1` means `Produce` (one create per send).
+
+## Phase 8 sharding sweep
+
+`numShards > 1` opens N independent Pebble instances inside one
+process, hashing tasks by ID across them. Phase 8 added this as a
+single-machine scale-out path (cluster mode is the multi-machine
+counterpart and is mutually exclusive with shards).
+
+Sweep results, full cycle, batched stream paths, 20 s window:
+
+| `PHASE8_SHARDS` | Throughput | Notes |
+|---|---|---|
+| 1 | 42,000 tasks/s | Single Pebble instance. Group-commit coalescer carries the write side. |
+| 2 | 65,000 tasks/s | 1.55x over single shard. Write loop contention starts to ease. |
+| 4 | **83,000 tasks/s** | Sweet spot on a 12-core box. Producer and worker batch paths both saturate. |
+| 6 | 68,000 tasks/s | Past the knee. Worker scheduling overhead climbs. |
+| 8 | 67,000 tasks/s | Diminishing returns. CPU is now shared across more compaction goroutines. |
+
+Reproduce one step:
+
+```bash
+PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8 \
+  go test -v -run='^TestProfile_FullCycle' \
+  -count=1 -timeout=180s ./internal/bench/...
+```
+
+The recommended single-node default is `numShards: 4`. Going higher
+costs more compaction CPU than it returns in throughput on a 12-core
+box. On bigger machines (24+ cores) the knee shifts right — re-run
+the sweep before changing the default.
+
+## Running k6 scenarios (local)
 
 Start a local stack:
 
@@ -33,11 +273,17 @@ docker compose \
   --profile loadtest run --rm k6 run /scripts/01_sustained_throughput.js
 ```
 
-### Environment Variables
+### Environment variables
 
-The k6 scripts in `loadtest/k6/` default `CODEQ_BASE_URL` to `http://localhost:8080` when run directly. When you run k6 via the local Compose stack, the `k6` service in `deploy/docker-compose/local-dev/compose.yaml` sets `CODEQ_BASE_URL` to `http://codeq:8080` so the container can reach the `codeq` service on the compose network. You can override these by setting the env vars before running `docker compose`:
+Scripts in [`loadtest/k6/`](../loadtest/k6/) default `CODEQ_BASE_URL`
+to `http://localhost:8080`. When you run k6 via the local Compose
+stack, the `k6` service in `deploy/docker-compose/local-dev/compose.yaml`
+sets `CODEQ_BASE_URL` to `http://codeq:8080` so the container can
+reach the `codeq` service on the compose network. Override by setting
+env vars before running `docker compose`:
 
-- `CODEQ_BASE_URL` (script default: `http://localhost:8080`; docker-compose default inside loadtest container: `http://codeq:8080`)
+- `CODEQ_BASE_URL` (script default: `http://localhost:8080`; compose
+  default inside loadtest container: `http://codeq:8080`)
 - `CODEQ_PRODUCER_TOKEN` (default: `dev-token`)
 - `CODEQ_WORKER_TOKEN` (default: `dev-token`)
 - `CODEQ_COMMANDS` (default: `GENERATE_MASTER`)
@@ -49,50 +295,59 @@ Scenario scripts also accept:
 - `CLAIM_P99_MS` (used by `01_sustained_throughput.js`)
 - `TASKS`, `VUS` (used by `04_prefill_queue.js`)
 
-## Scenarios
+### Scenarios
 
-The following scripts map directly to the scenarios listed in Issue #30:
+| Script | What it exercises |
+|---|---|
+| [`01_sustained_throughput.js`](../loadtest/k6/01_sustained_throughput.js) | Constant `RATE` for `DURATION`, mixed producers + workers. p95 SLO via `CLAIM_P99_MS`. |
+| [`02_burst_10k_10s.js`](../loadtest/k6/02_burst_10k_10s.js) | 10,000 tasks injected in 10 s; measures drain latency. |
+| [`03_many_workers.js`](../loadtest/k6/03_many_workers.js) | High `WORKER_VUS`; surfaces claim-path contention. |
+| [`04_prefill_queue.js`](../loadtest/k6/04_prefill_queue.js) | Pre-load `TASKS` items, then start workers. Cold start drain. |
+| [`05_mixed_priorities.js`](../loadtest/k6/05_mixed_priorities.js) | High/normal/low priority mix; checks priority ordering. |
+| [`06_delayed_tasks.js`](../loadtest/k6/06_delayed_tasks.js) | Schedule-then-deliver path via `MoveDueDelayed`. |
 
-- Sustained throughput: `loadtest/k6/01_sustained_throughput.js`
-- Burst load: `loadtest/k6/02_burst_10k_10s.js`
-- Many workers: `loadtest/k6/03_many_workers.js`
-- Large queue depth: `loadtest/k6/04_prefill_queue.js`
-- Mixed priorities: `loadtest/k6/05_mixed_priorities.js`
-- Delayed tasks: `loadtest/k6/06_delayed_tasks.js`
+> **Note**: k6 tops out at ~2k req/s in the published baselines
+> ([`docs/30-performance-baselines.md`](./30-performance-baselines.md)).
+> That is the HTTP path on a 4-vCPU host with a Redis backend. For
+> peak Pebble + stream numbers use the Go harnesses above.
 
-## Measuring and Interpreting Results
+## Measuring and interpreting results
 
-- Use k6 output for request latency percentiles and error rates.
-- Use `/metrics` (Prometheus) to correlate:
+- k6 reports request latency percentiles and error rates directly.
+- `/metrics` (Prometheus) gives the server-side view; correlate
+  k6 traffic with:
   - `codeq_task_created_total`
   - `codeq_task_claimed_total`
   - `codeq_task_completed_total`
   - `codeq_queue_depth{command=...,queue=...}`
-- Use `/v1/codeq/admin/queues/:command` to validate queue depth and backlog behavior during tests.
+- `/v1/codeq/admin/queues/:command` validates queue depth and backlog
+  behavior during a run.
 
-## Baseline Performance Results
+For the Go harnesses, the only output is the `t.Logf` line at the end
+of each test. There is no Prometheus scrape because the harness runs
+in-process; use the profile cycle test if you need pprof data.
 
-Baseline results from running all six scenarios are documented in
-[`docs/30-performance-baselines.md`](30-performance-baselines.md). Key highlights:
+## Where each number in the docs comes from
 
-| Scenario               | Throughput (req/s) | Avg Latency | p95 Latency | Error Rate |
-|------------------------|--------------------|-------------|-------------|------------|
-| Sustained throughput   | 1,082              | 5.69 ms     | 10.94 ms    | 0.00%      |
-| Burst load             | 1,610              | 18.43 ms    | 33.46 ms    | 0.00%      |
-| Many workers           | 1,647              | 12.82 ms    | 22.79 ms    | 0.00%      |
-| Prefill queue          | 2,081              | 23.52 ms    | 32.95 ms    | 0.00%      |
-| Mixed priorities       | 1,854              | 22.24 ms    | 39.05 ms    | 0.00%      |
-| Delayed tasks          | 1,124              | 6.62 ms     | 15.10 ms    | 0.00%      |
+| Claim | Source |
+|---|---|
+| 83k tasks/s full cycle | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| 136k creates/s producer batch | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| 16k tasks/s worker stream | `internal/bench/worker_stream_vs_rest_bench_test.go::TestThroughput_StreamPath` |
+| Shard sweep 42k/65k/83k/68k/67k | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=1,2,4,6,8`) |
+| k6 1-2k req/s envelope | [`docs/30-performance-baselines.md`](./30-performance-baselines.md) |
 
-See the baselines document for full per-scenario breakdowns, Go benchmark data, and
-regression testing guidance.
+Add a new number to this catalog whenever you cite one in another
+doc. Estimates and "blazing fast" are forbidden — see
+[`_STYLE.md` § 7](./_STYLE.md#7-numbers-must-come-from-measurement).
 
-## Go Benchmarks
+## See also
 
-Run benchmarks:
-
-```bash
-go test ./internal/bench -bench . -benchtime=30s
-```
-
-These benchmarks run in-process (Gin engine + miniredis) and are intended to catch regressions and compare branches.
+- [Performance tuning](./17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and per-release history.
+- [Streaming API guide](./34-streaming-api-guide.md) — producer and
+  worker gRPC stream contracts that the bench harnesses drive.
+- [Troubleshooting](./28-troubleshooting.md) — when numbers regress,
+  start here.

--- a/docs/_STYLE.md
+++ b/docs/_STYLE.md
@@ -1,0 +1,291 @@
+# codeq documentation style guide
+
+This is the canonical style guide for codeq documentation. Every doc in
+`docs/` and the root `README.md` must follow it. Subsequent waves of doc
+revisions cite this file verbatim where relevant (especially the value
+proposition and comparativos). If you change the value proposition here,
+you must update the docs that quote it.
+
+## 1. Value proposition
+
+### One-line
+
+> codeq is an embedded high-performance task queue: a single Go binary,
+> Pebble for persistence, gRPC streaming for the wire — 83k tasks/s on
+> one machine with zero external dependencies.
+
+### One-paragraph
+
+> codeq is a task queue written in Go that runs as a single process and
+> stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+> from CockroachDB). The hot path is bidirectional gRPC streams from
+> producers and workers; under the streams sits an intra-process shard
+> table (up to N independent Pebble instances) and an in-memory lease
+> table. The result on a 12-core Linux box is 83,420 tasks/s for the
+> full create → claim → complete cycle, or 136,392 creates/s producer-
+> only. No Redis, no broker, no coordinator required in the default
+> mode. Cluster (consistent-hash + gRPC routing) and a legacy Redis
+> backend are opt-in for HA and multi-node deployments.
+
+### Comparativos (use verbatim or as a base)
+
+| Dimension | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | None (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper or KRaft cluster |
+| Throughput (single node, full cycle) | 83k tasks/s | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | 100k+ msgs/s, but no task semantics |
+| Language affinity | Go (HTTP + gRPC; SDKs for Java, Node, Python, Go) | Go | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant native | Yes (JWT tenantId namespacing built in) | No | No | No | No |
+| Learning curve | One binary, HTTP + curl in minutes | Moderate (Redis ops) | Moderate (Node + Redis) | High (broker + result backend) | High (broker, consumer groups, schema registry) |
+
+When citing this table in a doc, link back here:
+
+> See [_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## 2. Audience profile
+
+Primary reader: **backend engineer evaluating alternatives to Redis-backed
+task queues**. They are typically deciding between Asynq (Go + Redis),
+BullMQ (Node + Redis), Celery (Python + broker), Sidekiq (Ruby + Redis),
+Temporal (workflow engine), and Kafka (event log used as a queue).
+
+What they care about, ranked:
+
+1. **Throughput** — concrete numbers, harness names, and the box they
+   were measured on. No "blazing fast", no "10x". Cite the benchmark.
+2. **Operational cost** — how many processes, how many config knobs, how
+   long until they can `curl` a task.
+3. **Language affinity** — Go server, but with first-class SDKs for the
+   reader's stack.
+4. **Durability and at-least-once** — what survives a crash, and how
+   they prove it.
+5. **Multi-tenant** — whether they can run one queue server for many
+   customers without writing isolation themselves.
+6. **HA and scaling story** — single-node first, but with a credible
+   path to multi-node.
+
+Write for someone who already understands queues. Skip onboarding to
+basic concepts like "what is a task". Do define codeq-specific terms
+(shard, lease table, ring, scatter-gather) the first time they appear.
+
+## 3. Voice and tone
+
+### Numbers first, narrative second
+
+Bad:
+
+> codeq is blazing fast and can handle massive workloads.
+
+Good:
+
+> codeq sustains 83,420 tasks/s for a full create → claim → complete
+> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
+> batch=8, 128 worker slots, 20s measurement window
+> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
+
+Every throughput claim cites:
+
+- The exact test name in `internal/bench/`.
+- The env vars used to parameterize it.
+- The hardware class (cores, OS).
+- The measurement window.
+
+### Honest about limitations
+
+Always name the trade-offs. Examples to use as templates:
+
+- "HA is only available via the Redis backend or by running a cluster of
+  Pebble nodes. A single Pebble process loses availability while it
+  restarts; recovery is fast (in-memory lease table rebuilt from the
+  `KeyInprog` scan at Open) but not instantaneous."
+- "Cluster mode and intra-process sharding (`numShards > 1`) are
+  mutually exclusive — startup panics if both are enabled. Pick one:
+  multi-node across machines, or multi-shard inside one process."
+- "Delivery is at-least-once, not exactly-once. A worker that crashes
+  between completion and ACK will see its task re-delivered after the
+  lease expires."
+
+### No marketing fluff
+
+Banned words: blazing, massive, lightning, seamless, robust,
+cutting-edge, world-class, next-gen, revolutionary.
+
+Replace adjectives with measurements. If you cannot measure it, do not
+claim it.
+
+### Opinionated
+
+Tell the reader what to pick:
+
+- "For single-node deployments use Pebble with `numShards: 4`."
+- "Do not enable `fsyncOnCommit` unless you have measured the latency
+  impact in your workload — it costs ~20% throughput in our harness."
+- "Use Redis only if you need multi-node HA today and cannot deploy the
+  cluster mode."
+
+## 4. Markdown conventions
+
+- **Headings**: ATX style (`#`), single `#` per file (the title), then
+  `##` for top-level sections, `###` for subsections. Do not skip
+  levels.
+- **Code blocks**: always tag the language.
+  - `bash` for shell, `go` for Go, `yaml` for config, `json` for JSON,
+    `protobuf` for `.proto`, `mermaid` for diagrams.
+  - Untagged blocks are forbidden — they break syntax highlighting on
+    GitHub.
+- **Admonitions** (GitHub-flavored):
+
+  ```markdown
+  > **Note**: a normal aside.
+  > **Warning**: a footgun. Always for irreversible operations or
+  > silent data loss.
+  > **Performance**: a tuning hint with a number.
+  ```
+
+- **Tables**: pipe-aligned, header row separator `---`. Always have a
+  header row. Cells with multi-word values stay on one line.
+- **Inline code**: backticks for file paths, env vars, config keys,
+  function names, and protocol constants.
+- **Lists**: `-` for unordered, `1.` for ordered. Two spaces of
+  indentation for nested items.
+- **Links**: prefer descriptive text over "click here". Relative links
+  for in-repo references (see §6).
+
+## 5. Mermaid conventions
+
+All diagrams must render on the GitHub default theme in both light and
+dark mode. **Never set inline colors or styles** — let the renderer
+pick.
+
+### Flow diagrams
+
+Use `graph TB` for top-to-bottom layered architecture, `graph LR` for
+left-to-right pipelines. Always use `subgraph` to delimit logical
+layers.
+
+```mermaid
+graph TB
+  subgraph Producers
+    P1[Producer SDK]
+  end
+  subgraph Server[codeq server]
+    HTTP[HTTP API]
+    GRPC[gRPC stream]
+  end
+  subgraph Storage
+    PEB[Pebble shards]
+  end
+  P1 --> GRPC
+  GRPC --> PEB
+  HTTP --> PEB
+```
+
+Aim for 8 to 12 nodes max in a single diagram. If it grows past that,
+split it.
+
+### Sequence diagrams
+
+Use `sequenceDiagram` for flows over time. Participant names start
+capitalized.
+
+```mermaid
+sequenceDiagram
+  participant Producer
+  participant Server
+  participant Pebble
+  Producer->>Server: Produce(task)
+  Server->>Pebble: BatchCommit
+  Pebble-->>Server: ack
+  Server-->>Producer: TaskID
+```
+
+### State machines
+
+Use `stateDiagram-v2` for task lifecycle. Transition labels describe
+the **trigger action**, not the resulting state.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  DLQ --> [*]
+```
+
+### No inline colors
+
+Bad:
+
+```text
+style P1 fill:#f9f,stroke:#333
+```
+
+Good: nothing — let the theme decide.
+
+## 6. Cross-link policy
+
+Every doc ends with a `## See also` section enumerating related docs.
+Example:
+
+```markdown
+## See also
+
+- [Architecture](./03-architecture.md)
+- [Storage layout (Pebble)](./07b-storage-pebble.md)
+- [Performance tuning](./17-performance-tuning.md)
+```
+
+Path conventions:
+
+- **Inside `docs/`** (doc-to-doc): use relative paths starting with
+  `./`, e.g. `[Overview](./01-overview.md)`.
+- **From root `README.md`** (or other root-level files): use paths
+  rooted at `docs/`, e.g. `[Overview](docs/01-overview.md)`.
+- **To source files**: use repo-rooted paths, e.g.
+  `[application.go](../pkg/app/application.go)` from inside `docs/`, or
+  `pkg/app/application.go` from `README.md`.
+- **Anchors**: lowercase, hyphen-separated, match GitHub's slug
+  algorithm.
+
+When you cite the value prop, link to this file:
+
+```markdown
+See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+```
+
+## 7. Numbers must come from measurement
+
+Every throughput, latency, or memory claim in any doc must be traceable
+to a test in `internal/bench/`. The format is:
+
+> N tasks/s (`internal/bench/<file>.go::<TestName>`, env: `KEY=VAL`,
+> hardware: 12-core Linux).
+
+Catalog of canonical benchmarks (use these names, do not invent new
+ones):
+
+| Workload | Harness | Result on reference box |
+|---|---|---|
+| Full cycle, 4 shards, batched | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) | 83,420 tasks/s |
+| Producer-only, batched stream | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` | 136,392 creates/s |
+| Worker-only, batched stream | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) | 23,518 tasks/s |
+| Shard sweep | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=1,2,4,6,8`) | 42k / 65k / 83k / 68k / 67k |
+
+Reference box: 12-core Linux (kernel 5.15, WSL2-compatible), Go 1.25.0,
+local Pebble, loopback gRPC, no fsync.
+
+If you need a number that is not in this table, run the bench, add the
+row here, then cite it in your doc. Do not estimate.
+
+## See also
+
+- [README](../README.md) — applies this style guide at the entry point.
+- [Overview](./01-overview.md) — the canonical statement of what codeq
+  is.
+- [Architecture](./03-architecture.md) — package-level breakdown.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and historical numbers.


### PR DESCRIPTION
## Summary

Expands `docs/26-load-testing.md` from 98 to 353 lines, aligning it with the `_STYLE.md` numbers-first voice and Mermaid conventions established in Wave 1.

- Adds Phase 2 worker stream, Phase 3 producer stream, and Phase 6 batch numbers with exact ratios (REST 16k -> stream 73k -> batch 136k creates/s for producer; REST 5.5k -> stream 16k -> sharded full cycle 83k tasks/s for the worker side).
- Documents the Phase 8 intra-process sharding sweep (1=42k, 2=65k, 4=83k, 6=68k, 8=67k) and calls out 4 shards as the single-node default.
- Adds two Mermaid diagrams: harness layout (`graph TB`) and REST vs stream evolution (`graph LR`).
- Documents how to run each in-process harness in `internal/bench/`, including the env knobs `PHASE8_SHARDS`, `PHASE6_BATCH`, `PHASE6_PROD_BATCH` for the profile cycle test.
- Keeps the existing k6 scenario section but rescopes it to "REST surface in isolation" and points peak-number readers at the Go harnesses.
- Adds `## See also` footer linking 17, 28, 30, 34.

Branch base: `docs/wave1-u1-foundation` (Wave 1 U1 foundation).

## Test plan

- [ ] Review numbers against `internal/bench/*_test.go` test names and env vars.
- [ ] Render Mermaid in GitHub UI to confirm both diagrams display in light and dark themes.
- [ ] Confirm all relative links resolve in the rendered preview.