### PR TITLE
docs(wave3-u9): worker streaming SDK guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,108 @@
-# codeQ
+# codeq
 
-Reactive scheduling and completion system backed by persistent queues. Choose your storage: KVRocks (distributed) or Pebble (embedded).
+> Embedded high-performance task queue. One Go binary, Pebble for
+> storage, gRPC streams on the wire. 83k tasks/s on a single 12-core
+> box with zero external dependencies.
 
-This repository contains the core runtime, HTTP API wiring, and a Helm chart for small clusters.
-The production service wrapper lives at:
-https://github.com/codecompany/codeq-service
+[![Go Reference](https://pkg.go.dev/badge/github.com/osvaldoandrade/codeq.svg)](https://pkg.go.dev/github.com/osvaldoandrade/codeq)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Issues](https://img.shields.io/github/issues/osvaldoandrade/codeq.svg)](https://github.com/osvaldoandrade/codeq/issues)
 
-## Links
+## What is codeq?
 
-- GitHub: https://github.com/osvaldoandrade/codeq
-- Issues: https://github.com/osvaldoandrade/codeq/issues
-- Specs index: `docs/README.md`
+codeq is a task queue written in Go. The default deployment is a single
+process: the server, the persistence layer (Pebble, the RocksDB-style
+LSM from CockroachDB), the lease table, and the gRPC + HTTP API all
+share one binary and one disk directory. There is no Redis to run, no
+broker to babysit, no consensus to coordinate.
 
-## Why codeQ
+On a 12-core Linux box, that single binary sustains **83,420 tasks/s**
+for the full create → claim → complete cycle and **136,392 creates/s**
+for producer-only workloads — measured by the in-tree benchmarks in
+`internal/bench/`. When one machine is no longer enough, cluster mode
+(consistent-hash ring + gRPC routing between nodes) and a legacy Redis
+backend are opt-in.
 
-codeQ provides:
+## Architecture overview
 
-- Persistent queues with pluggable storage backends:
-  - **Redis/KVRocks** (distributed, cluster-capable)
-  - **Pebble** (embedded, zero-dependency, ideal for local development)
-- Pull-based worker claims with leases.
-- **Multi-tenant queue isolation** with automatic tenant ID extraction from JWT claims.
-- **Horizontal scaling with queue sharding**: Optional pluggable `ShardSupplier` interface for routing commands/tenants across multiple KVRocks instances.
-- **Pluggable persistence backends**: Redis, memory (testing), and extensible plugin architecture for custom storage (PostgreSQL, DynamoDB, Cassandra, etc.).
-- NACK + backoff + delayed queues.
-- DLQ for tasks that exceed `maxAttempts`.
-- Result storage and optional callbacks (webhooks).
-- Worker auth via JWT (JWKS), producer auth via Tikti access tokens (JWKS).
-- **Official SDKs** for Java and Node.js/TypeScript with framework integrations.
-- **Distributed tracing** with OpenTelemetry support for end-to-end observability.
-- **Optimized performance**: O(1) queue operations with pipelined lease repair for low-latency claims even under high load.
-- **Load testing framework**: Comprehensive k6 scenarios and Go benchmarks for performance validation and regression testing.
+```mermaid
+graph TB
+  subgraph Clients
+    PSDK[Producer SDK]
+    WSDK[Worker SDK]
+    CURL[HTTP / curl]
+  end
+  subgraph Server[codeq server -- single binary]
+    HTTP[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+  end
+  subgraph Storage[Embedded persistence]
+    P0[Pebble shard 0]
+    P1[Pebble shard 1]
+    PN[Pebble shard N-1]
+  end
+  subgraph Optional[Opt-in scaling]
+    CL[Cluster -- consistent-hash + gRPC]
+    REDIS[Redis backend -- legacy HA]
+  end
+  PSDK --> PGRPC
+  WSDK --> WGRPC
+  CURL --> HTTP
+  HTTP --> LEASE
+  PGRPC --> LEASE
+  WGRPC --> LEASE
+  LEASE --> P0
+  LEASE --> P1
+  LEASE --> PN
+  Server -.-> CL
+  Server -.-> REDIS
+```
 
-## Get started
+Producers and workers connect over long-lived bidirectional gRPC
+streams. Each request hits the in-memory lease table first, then commits
+to a Pebble shard chosen by `hash(taskID) % N`. Each shard runs its own
+commit pipeline and compaction loop, which is what lets a 4-shard
+configuration roughly double the single-shard throughput on the same
+hardware.
 
-### Local development with Docker Compose
+## Performance
 
-The quickest way to try codeQ locally:
+All numbers measured on a 12-core Linux box, Go 1.25.0, loopback gRPC,
+Pebble with `fsyncOnCommit=false`. Full bench harness lives in
+`internal/bench/`.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle (create + claim + complete), 4 Pebble shards | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| Worker-only, batched claim+complete | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep (full cycle, 1 / 2 / 4 / 6 / 8 shards) | 42k / 65k / **83k** / 68k / 67k tasks/s | same as full cycle harness with `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on a 12-core box; past that, write
+amplification and goroutine contention start to dominate. See
+[docs/30-performance-baselines.md](docs/30-performance-baselines.md)
+for raw output and per-release history.
+
+## Why codeq vs alternatives
+
+| Feature | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | **None** (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper / KRaft cluster |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | n/a (no task semantics) |
+| Language affinity | Go server, SDKs for Java, Node, Python, Go | Go only | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant isolation | **Built in** (JWT tenantId namespacing) | DIY | DIY | DIY | DIY |
+| Time-to-first-task | `docker run` + `curl` | Run Redis + Asynq | Run Redis + worker | Run broker + workers + result backend | Multi-step cluster bootstrap |
+
+codeq is the right call when you want task-queue semantics (claims,
+leases, retries, DLQ, results) without standing up a broker. It is the
+wrong call if you need Kafka-scale event streaming, distributed
+consensus by default, or HA without configuring the Redis backend or
+cluster mode.
+
+## Quick start (5 minutes)
 
 ```bash
 git clone https://github.com/osvaldoandrade/codeq
@@ -47,125 +113,10 @@ docker compose \
   up -d
 ```
 
-This starts KVRocks, the codeQ API server, and seeds example tasks. Access at `http://localhost:8080`.
+This brings up the codeq server on `http://localhost:8080` with the
+embedded Pebble backend (no Redis required) and seeds example tasks.
 
-See [Local Development Guide](docs/22-local-development.md) for details on hot reload, testing, and observability.
-
-### Install a server
-
-Use the console wizard to generate a Docker or Kubernetes/Helm install bundle:
-
-```bash
-codeq install
-```
-
-Non-interactive Kubernetes example:
-
-```bash
-codeq install \
-  --target kubernetes \
-  --size small \
-  --namespace codeq \
-  --identity-service-url https://issuer.example.com \
-  --worker-jwks-url https://issuer.example.com/.well-known/jwks.json \
-  --worker-issuer https://issuer.example.com
-```
-
-### Install CLI (macOS/Linux/Windows via Git Bash)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
-```
-
-Requires `git` and `go`.
-
-### Install CLI via npm (npmjs)
-
-```bash
-npm i -g @osvaldoandrade/codeq
-codeq --help
-```
-
-Upgrade:
-
-```bash
-npm i -g @osvaldoandrade/codeq@latest
-```
-
-### Use SDKs for Java, Node.js, Python, and Go
-
-Integrate codeQ into your microservices with official SDKs:
-
-**Java** (Spring Boot, Quarkus, Micronaut):
-```xml
-<dependency>
-    <groupId>io.codeq</groupId>
-    <artifactId>codeq-sdk-java</artifactId>
-    <version>1.0.0</version>
-</dependency>
-```
-
-**Node.js/TypeScript** (Express, NestJS):
-```bash
-npm install @osvaldoandrade/codeq-client
-```
-
-**Python** (FastAPI, Django, Flask):
-```bash
-pip install codeq-client
-```
-
-**Go** (Gin, Echo, stdlib):
-```bash
-go get github.com/osvaldoandrade/codeq/sdks/go
-```
-
-📚 **SDK Documentation**:
-- [SDK Overview & Quick Start](sdks/README.md)
-- [Java SDK](sdks/java/README.md)
-- [Node.js SDK](sdks/nodejs/README.md)
-- [Python SDK](sdks/python/README.md)
-- [Go SDK](sdks/go/README.md)
-- [Integration Guides](docs/integrations/)
-- [Example Applications](examples/)
-
-### Helm
-
-The chart in this repo deploys codeQ and, by default in the small profile, a single-node KVRocks instance.
-
-```bash
-git clone https://github.com/osvaldoandrade/codeq
-cd codeq
-
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-small.yaml \
-  --namespace codeq --create-namespace \
-  --set secrets.enabled=true \
-  --set secrets.webhookHmacSecret=YOUR_SECRET \
-  --set config.identityServiceUrl=https://your-auth-server.com \
-  --set config.workerJwksUrl=https://your-jwks \
-  --set config.workerIssuer=https://issuer
-```
-
-Disable embedded KVRocks and point to your own:
-
-```bash
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-medium.yaml \
-  --set kvrocks.enabled=false \
-  --set config.redisAddr=your-kvrocks:6666
-```
-
-### 2) Service runtime
-
-The API server and Dockerfile are in the service repo:
-https://github.com/codecompany/codeq-service
-
-That repo consumes this module and exposes the HTTP API.
-
-## Quick API flow
-
-Create a task (producer token):
+Create a task:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks \
@@ -174,7 +125,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"priority":3}'
 ```
 
-Claim a task (worker JWT):
+Claim a task (as a worker):
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
@@ -183,7 +134,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
   -d '{"commands":["GENERATE_MASTER"],"leaseSeconds":120,"waitSeconds":10}'
 ```
 
-Submit result:
+Submit a result:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
@@ -192,49 +143,95 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
   -d '{"status":"COMPLETED","result":{"ok":true}}'
 ```
 
-## Specs and docs
+For high-throughput producers and workers, use the gRPC streaming API
+(2-3x the HTTP throughput, amortized auth, pipelined acks): see
+[docs/34-streaming-api-guide.md](docs/34-streaming-api-guide.md).
 
-Start here: `docs/README.md`
+## Where next
 
-Key references:
+- [Getting started tutorial](docs/00-getting-started.md) — your first
+  task, end to end.
+- [Overview](docs/01-overview.md) — goals, non-goals, when (and when
+  not) to pick codeq.
+- [Architecture](docs/03-architecture.md) — package layout and request
+  flows.
+- [Performance tuning](docs/17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Operational runbooks](docs/29-operational-runbooks.md) — on-call
+  procedures for the common failure modes.
+- [Streaming API guide](docs/34-streaming-api-guide.md) — gRPC
+  producer and worker streams.
+- [Cluster architecture](docs/05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Style guide](docs/_STYLE.md) — voice, numbers, diagrams, links.
 
-- **Getting Started Tutorial**: `docs/00-getting-started.md` - **Start here for your first experience with codeQ**
-- **Overview**: `docs/01-overview.md` - System goals and design principles
-- **Architecture**: `docs/03-architecture.md` - System components and multi-tenant architecture
-- **Security**: `docs/09-security.md` - Authentication, authorization, and tenant isolation
-- **HTTP API**: `docs/04-http-api.md` - Complete API reference
-- **CLI Reference**: `docs/15-cli-reference.md` - CLI command documentation
-- **SDK Integration**: `sdks/README.md` - Official Java and Node.js SDKs
-  - [Java Integration](docs/integrations/java-integration.md) - Spring Boot, Quarkus, Micronaut
-  - [Node.js Integration](docs/integrations/nodejs-integration.md) - Express, NestJS, React
-- **Examples**: `examples/` - Working examples with Java and Node.js frameworks
-- **Developer Guide**: `docs/21-developer-guide.md` - Contributing and internal architecture
-- **Queue model**: `docs/05-queueing-model.md` - Queue semantics
-- **Storage layout**: `docs/07-storage-kvrocks.md` - KVRocks data structures
-- **Backoff and retries**: `docs/11-backoff.md` - Retry logic
-- **Webhooks**: `docs/12-webhooks.md` - Push notifications
-- **Configuration**: `docs/14-configuration.md` - Config reference
-- **Operations**: `docs/10-operations.md` - Metrics, health checks, and tracing
-- **Workflows**: `docs/16-workflows.md` - GitHub Actions automation
-- **Performance**: `docs/17-performance-tuning.md` - Optimization guide
-- **Load Testing**: `docs/26-load-testing.md` - Load testing framework and benchmarks
-- **Testing**: `docs/19-testing.md` - Test coverage and strategy
-- **Authentication Plugins**: `docs/20-authentication-plugins.md` - Plugin system for custom auth
-- **Persistence Plugins**: `docs/27-persistence-plugin-system.md` - Pluggable storage backends (Redis, Memory, and more)
-- **Design Documents**:
-  - `docs/24-queue-sharding-hld.md` - Queue sharding high-level design
-  - `docs/25-plugin-architecture-hld.md` - Plugin architecture for persistence and auth
-- **Migration**: `docs/migration.md` - Upgrade guide
-- **Contributing**: `CONTRIBUTING.md` - Contribution guidelines
+## SDKs
+
+Official client libraries for the languages most likely to talk to
+codeq from application code:
+
+- **Go** — `go get github.com/osvaldoandrade/codeq/sdks/go` ([README](sdks/go/README.md))
+- **Java** (Spring Boot, Quarkus, Micronaut) — [sdks/java/README.md](sdks/java/README.md)
+- **Node.js / TypeScript** (Express, NestJS) — [sdks/nodejs/README.md](sdks/nodejs/README.md)
+- **Python** (FastAPI, Django, Flask) — [sdks/python/README.md](sdks/python/README.md)
+
+Integration recipes per framework live under
+[docs/integrations/](docs/integrations/). End-to-end example apps live
+under [examples/](examples/).
 
 ## Repo layout
 
-- `pkg/`: public packages (`app`, `config`, `domain`)
-- `internal/`: controllers, middleware, services, repositories, providers
-- `deploy/`: Docker Compose, Kubernetes, and config examples
-- `helm/codeq`: Helm chart and size profiles
-- `docs/`: full specification
+```text
+cmd/                  CLI entrypoints (codeq install, server)
+internal/             unexported packages
+  bench/              throughput + latency benchmarks (source of truth for perf claims)
+  cluster/            consistent-hash ring, gRPC router, bloom gossip
+  controllers/        HTTP handlers (Gin)
+  middleware/         auth, tracing, rate-limit, tenant extraction
+  producer/           gRPC producer-stream server
+  worker/             gRPC worker-stream server
+  repository/         persistence implementations (Redis legacy + Pebble)
+  services/           scheduler, results, callbacks, subscriptions
+pkg/                  public packages (app, auth, config, domain,
+                      producerclient, workerclient)
+sdks/                 official SDKs (go, java, nodejs, python)
+deploy/               docker-compose and Kubernetes config
+helm/codeq/           Helm chart and size profiles
+docs/                 specifications, runbooks, performance baselines
+examples/             end-to-end example applications
+```
+
+## Install the CLI
+
+macOS, Linux, or Windows via Git Bash:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
+```
+
+Or via npm:
+
+```bash
+npm i -g @osvaldoandrade/codeq
+codeq --help
+```
+
+To generate a Docker or Kubernetes install bundle (with embedded Pebble
+by default, no Redis required):
+
+```bash
+codeq install
+```
+
+See [docs/15-cli-reference.md](docs/15-cli-reference.md) for the full
+CLI surface.
+
+## Contributing
+
+Issues and PRs are welcome. Before opening a PR, read
+[CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, and
+[docs/_STYLE.md](docs/_STYLE.md) for the documentation style.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,27 +1,244 @@
 # Overview
 
-codeQ is a task scheduling and completion service built on persistent queues in KVRocks. The service exposes HTTP APIs for producers to create tasks, for workers to claim and complete tasks, and for operators to inspect and clean up queues. The system is reactive: workers pull tasks, and optionally receive webhook signals that work is available.
+> Source-of-truth for the value proposition lives in
+> [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+> Other docs may cite this overview, but the style guide wins ties.
 
-The design is inspired by Dyno Queues, which adds time-based and priority queues on top of Dynomite. Dynomite is a distributed data layer that exposes Redis semantics and provides multi-datacenter replication. codeQ applies the same motivation to KVRocks and uses Go for the implementation. The service favors availability and throughput over strict global ordering.
+## What is codeq
+
+codeq is a task queue written in Go that runs as a single process and
+stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+from CockroachDB). The hot path is bidirectional gRPC streams from
+producers and workers; under the streams sits an intra-process shard
+table (up to N independent Pebble instances) and an in-memory lease
+table. On a 12-core Linux box the single binary sustains
+**83,420 tasks/s** for the full create → claim → complete cycle and
+**136,392 creates/s** for producer-only workloads.
+
+No Redis, no broker, no coordinator required in the default mode.
+Cluster (consistent-hash ring + gRPC routing) and a legacy Redis backend
+are opt-in for HA and multi-node deployments.
 
 ## Goals
 
-- Provide a stable API for enqueue, claim, and completion.
-- Persist state on disk via KVRocks.
-- Support delayed retries, priority, and retries.
-- Allow workers to pull by event type without a worker registry.
-- Provide optional push notifications without assigning work.
+- **Single binary.** Server, persistence, lease table, HTTP + gRPC API
+  all in one process. One disk directory. One systemd unit. No external
+  database required.
+- **80k+ tasks/s on one machine.** Full create → claim → complete cycle
+  measured by `internal/bench/profile_full_cycle_test.go` with 4 Pebble
+  shards, batched producer + worker streams.
+- **gRPC streaming as a first-class API.** Long-lived bidirectional
+  streams amortize auth and middleware; multiple requests can be in
+  flight before responses arrive.
+- **Multi-tenant by construction.** Every queue key is namespaced by
+  `tenantId` extracted from the JWT. Workers can only claim tasks from
+  their own tenant. No application code required to keep tenants
+  isolated.
+- **Cluster opt-in.** When one machine is no longer enough, run a
+  consistent-hash cluster (no consensus, no coordinator — static
+  membership + gRPC routing).
+- **Configurable durability.** `fsyncOnCommit` is a per-deployment knob.
+  Off by default for throughput; turn it on when your SLO demands it.
 
 ## Non-goals
 
-- Exactly-once processing.
-- Global FIFO across all commands.
-- Automatic worker discovery or scheduling.
+- **Kafka-scale event streaming.** codeq is a task queue, not a
+  partitioned log. If you want millions of messages/s with consumer
+  groups, use Kafka.
+- **Distributed consensus by default.** No Raft, no Paxos. Cluster mode
+  uses a static consistent-hash ring; node membership is configured at
+  startup, not gossiped.
+- **HA without explicit setup.** A single Pebble process loses
+  availability while it restarts. HA requires either the Redis backend
+  (legacy, multi-node) or running a cluster of Pebble nodes — each is a
+  trade-off the operator picks consciously.
+- **Exactly-once delivery.** Delivery is at-least-once. A worker that
+  crashes between completion and ACK will see the task re-delivered
+  after the lease expires.
+- **Global FIFO across all commands.** Ordering is per-(command,
+  tenant, priority) within a Pebble shard. Cross-shard ordering is not
+  defined.
+- **Worker discovery or scheduling.** codeq does not register workers
+  or assign work; workers pull when they are ready.
 
-## High-level data model
+## Data model summary
 
-- Task: unit of work, identified by UUID.
-- Message: queue element containing metadata used by the scheduler.
-- Result: completion record stored independently of the task body.
-- Command (event type): routing key for tasks.
-- Shard: not implemented; queues are single-shard in the current service.
+- **Task** — unit of work. Identified by UUID. Carries `command`
+  (routing key), `payload` (opaque JSON bytes), `priority` (0-9),
+  optional `webhook` URL, and lifecycle state.
+- **Result** — completion record. Stored separately from the task body
+  so completion can be GC'd on a different schedule than the task
+  metadata.
+- **Subscription** — webhook registration. A worker (or coordinator)
+  registers a callback URL for one or more event types; codeq pings it
+  when new work appears.
+
+Task lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> FAILED: SubmitResult(err)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DELAYED: Nack(backoff)
+  DELAYED --> PENDING: MoveDueDelayed
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  FAILED --> [*]
+  DLQ --> [*]
+```
+
+Full schema and state semantics in
+[02-domain-model.md](./02-domain-model.md).
+
+## Architecture summary
+
+```mermaid
+graph TB
+  subgraph Clients
+    SDK[Producer / Worker SDKs]
+    HTTPCLI[HTTP clients -- curl, browsers]
+  end
+  subgraph Server[codeq server]
+    API[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+    SCHED[Scheduler core]
+  end
+  subgraph Storage[Embedded persistence -- default]
+    P[Pebble shards 0..N-1]
+  end
+  subgraph OptIn[Opt-in modes]
+    CL[Cluster -- consistent-hash + gRPC routing]
+    REDIS[Redis backend -- legacy, HA]
+  end
+  SDK --> PGRPC
+  SDK --> WGRPC
+  HTTPCLI --> API
+  API --> SCHED
+  PGRPC --> SCHED
+  WGRPC --> SCHED
+  SCHED --> LEASE
+  SCHED --> P
+  Server -.-> CL
+  Server -.-> REDIS
+```
+
+Request flow at a glance:
+
+1. Producer or worker opens a gRPC stream (or sends an HTTP request).
+2. The middleware chain validates the JWT, extracts `tenantId`, and
+   applies rate limits.
+3. The scheduler routes the operation to its Pebble shard
+   (`hash(taskID) % numShards`) and updates the in-memory lease table.
+4. Pebble commits the batch; the group-commit coalescer (Phase 1.1)
+   merges concurrent writers into one fsync.
+5. On worker stream, ready tasks are pushed back through the same long-
+   lived connection — no per-claim handshake.
+
+Package-level breakdown in [03-architecture.md](./03-architecture.md).
+
+## When to use codeq
+
+- **Single-node task queue for a backend service.** You want claims,
+  leases, retries, DLQ, and results without standing up Redis or a
+  broker.
+- **Embedded sidecar in your own Go binary.** Import `pkg/app` and run
+  codeq in-process alongside your application.
+- **Multi-tenant SaaS background jobs.** Per-tenant queue isolation is
+  built in; you do not have to namespace keys yourself.
+- **High-throughput producers with small payloads.** The batched
+  producer stream sustains 100k+ creates/s on commodity hardware.
+- **Polyglot worker fleets.** Workers in Go, Java, Node, or Python can
+  all share the same queue via the official SDKs.
+- **Local development without external services.** `docker run codeq`
+  is enough; no Redis container, no compose dance.
+
+## When NOT to use codeq
+
+- **Kafka-scale event streaming.** Millions of events/s with consumer
+  groups, replay, and a retention window measured in days — use Kafka.
+- **Distributed transactions.** codeq has no two-phase commit and no
+  cross-shard transactions. If your business logic needs atomic updates
+  across multiple tasks, build it above codeq with an outbox pattern or
+  pick a workflow engine.
+- **HA without Redis or cluster mode.** A single Pebble process is
+  unavailable during restart. If your SLO does not tolerate a few
+  seconds of unavailability, you need the Redis backend (multi-node) or
+  a Pebble cluster.
+- **Workflow orchestration with branching, child tasks, timers, and
+  long-running state.** Use Temporal, Cadence, or Step Functions — they
+  are purpose-built for that. codeq is a queue.
+- **Exactly-once delivery semantics.** codeq is at-least-once. Idempotent
+  handlers are the operator's responsibility.
+
+## Performance baselines
+
+Measured on a 12-core Linux box, Go 1.25.0, loopback gRPC, Pebble with
+`fsyncOnCommit=false`, 20s measurement window after a 2s warm-up.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle, 4 shards, batched | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (32 goroutines, batch=16) |
+| Worker-only, batched stream | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep | 1 shard: 42k; 2: 65k; **4: 83k**; 6: 68k; 8: 67k | same as full cycle, `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on this hardware. Past that, the cost of more
+commit pipelines + compaction loops outweighs the parallelism win. See
+[30-performance-baselines.md](./30-performance-baselines.md) for raw
+output, allocator stats, and the per-release history.
+
+## Comparativos resumidos
+
+| Dimension | codeq | Asynq | BullMQ | Kafka |
+|---|---|---|---|---|
+| External dependency | **None** | Redis | Redis | ZooKeeper / KRaft |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k | ~5k | n/a (no task semantics) |
+| Language | Go server, multi-language SDKs | Go | Node | Polyglot |
+| Multi-tenant native | **Yes** | DIY | DIY | DIY |
+| HA model | Cluster or Redis (opt-in) | Redis | Redis | Replicated log |
+
+Full table with Sidekiq, Celery, and Temporal lives in
+[_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## What changed (Phases 1-8 summary)
+
+codeq has been through a sequence of refactors that shifted its
+positioning from "Redis-backed queue" to "embedded high-performance
+queue". The short version:
+
+| Phase | Theme | Effect |
+|---|---|---|
+| 0 | kvrocks-primary | First version: KVRocks (Redis protocol) as the only backend. ~1.5-2k tasks/s. |
+| 1 | Pebble embedded backend | Pebble added as a pluggable persistence provider. Single-binary deployment becomes possible. Single-shard throughput ~42k tasks/s. |
+| 1.1 | Pebble fast-paths + group-commit coalescer | `MoveDueDelayed` fast-path; concurrent writers coalesce into one fsync. |
+| 2 | Streaming groundwork | gRPC streaming surfaces designed. Auth amortized across stream lifetime. |
+| 5 | Cluster mode | Consistent-hash ring + gRPC routing between Pebble nodes. No consensus; static membership. |
+| 6 | Batched stream paths | Producer and worker streams gain batch APIs. `PHASE6_BATCH` / `PHASE6_PROD_BATCH` env knobs. |
+| 8 | Intra-process Pebble sharding | `numShards` opens N independent Pebble instances under one process. 4 shards → ~83k tasks/s on a 12-core box. **Mutually exclusive with cluster mode.** |
+
+PRs #527-#547 landed Phases 1.1, 6, and 8. The Redis backend remains
+supported for HA scenarios but is no longer the default.
+
+## See also
+
+- [_STYLE.md](./_STYLE.md) — documentation voice, numbers, diagrams.
+- [Architecture](./03-architecture.md) — package layout and request
+  flows.
+- [HTTP API](./04-http-api.md) — REST surface.
+- [Streaming API guide](./34-streaming-api-guide.md) — gRPC producer
+  and worker streams.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and per-release history.
+- [Performance tuning](./17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Cluster architecture](./05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Storage layout (Pebble)](./07b-storage-pebble.md) — keyspace and
+  sharding internals.
+- [Persistence plugin system](./27-persistence-plugin-system.md) —
+  choosing and configuring backends.

--- a/docs/36-worker-streaming-sdk.md
+++ b/docs/36-worker-streaming-sdk.md
@@ -1,0 +1,521 @@
+# Worker streaming SDK (Go)
+
+The Go worker SDK at [`pkg/workerclient/`](../pkg/workerclient/client.go)
+is the recommended way to consume tasks from a codeq server. It opens
+**one** long-lived bidirectional gRPC stream per process, authenticates
+once, and dispatches claimed tasks to a user-supplied handler running on
+a configurable number of concurrent slots.
+
+For the wider streaming protocol see
+[gRPC streaming API guide](./34-streaming-api-guide.md). For the
+producer-side equivalent see
+[Producer streaming SDK](./35-producer-streaming-sdk.md). The value
+proposition for streaming versus REST is in
+[_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+
+## What and why
+
+The REST worker path requires three round-trips per task:
+
+1. `POST /claim` — authenticate, claim, return one task.
+2. `POST /tasks/<id>/result` — authenticate, write COMPLETED.
+3. Optional `POST /tasks/<id>/heartbeat` — authenticate, extend lease.
+
+Each request pays the full HTTP middleware tax (TLS handshake reuse
+aside): bearer-token parse, JWT verify, tenant resolution, request log,
+metrics, panic recovery. Under load this dominates CPU — Phase 1
+profiling showed >40% of worker-side cycles spent above the scheduler.
+
+The streaming SDK collapses all three round-trips into a single
+bidirectional stream:
+
+- One `Hello` at stream open authenticates for the lifetime of the
+  connection.
+- `Ready` / `Task` / `Result` / `ResultAck` flow as oneof events on the
+  same stream — no new TCP, no new TLS, no new JWT verify.
+- N slot goroutines pipeline work across the same stream so the wire
+  is never idle.
+
+Measured speedup on the reference 12-core Linux box:
+
+| Path | Test | Rate |
+|---|---|---|
+| REST `/claim` + `/result` | `internal/bench/worker_stream_vs_rest_bench_test.go::TestThroughput_RESTPath` | 5,500 tasks/s |
+| Stream, c=32, batch=0 | `internal/bench/worker_stream_vs_rest_bench_test.go::TestThroughput_StreamPath` | 16,000 tasks/s |
+
+That is **2.9x at c=32 with no batching**. Enabling `BatchSize >= 16`
+(see [Batch mode](#batch-mode-q2)) extends the ratio further — the
+saturation harness reports up to 9.5x speedup at c=1 with `BatchSize=32`
+versus c=1 unbatched.
+
+> **Note**: rates are full claim → handle → complete cycles, not just
+> claims. The handler in the benchmark returns `Completed(nil)` with no
+> business logic; real workloads will be bounded by handler latency
+> first, SDK overhead second.
+
+## Architecture
+
+The SDK is a thin client over [`internal/worker/server.go`](../internal/worker/server.go).
+One stream maps to one [`streamSession`](../internal/worker/server.go).
+The client's [`session`](../pkg/workerclient/client.go) holds the
+mirror state.
+
+```mermaid
+graph TB
+  subgraph ClientProc[Worker process]
+    H[Handler func]
+    SL[Slot 0..N-1]
+    SE[session<br/>sendCh writer]
+    RD[readLoop]
+  end
+  subgraph Wire[gRPC bidi stream]
+    EV[WorkerEvent / ServerEvent oneofs]
+  end
+  subgraph ServerProc[codeq server]
+    SS[streamSession<br/>writer goroutine]
+    HR[handleReady]
+    HRB[handleReadyBatch]
+    HRES[handleResult / handleResultBatch]
+    SCH[SchedulerService<br/>ClaimTask / ClaimManyTasks]
+    LT[leaseTable<br/>in-memory]
+    PEB[Pebble TaskRepository]
+  end
+  H --> SL
+  SL --> SE
+  SE --> EV
+  EV --> SS
+  SS --> HR
+  SS --> HRB
+  SS --> HRES
+  HR --> SCH
+  HRB --> SCH
+  HRES --> SCH
+  SCH --> LT
+  SCH --> PEB
+  PEB --> EV
+  EV --> RD
+  RD --> SL
+```
+
+Key invariants the diagram encodes:
+
+- **One writer per direction**: the client's `writeLoop` is the only
+  goroutine calling `stream.Send`; same on the server side. Profile
+  (Phase 6 / M1) showed the previous mutex-around-Send accounted for
+  ~74% of the server's mutex profile under 128-slot load.
+- **Lease lives in memory**: the server's `leaseTable` is the source
+  of truth for claim ownership; the Pebble `KeyLease` index was
+  retired in Phase 6 / M2. See [Lease management](#lease-management).
+- **Slots fan out, single sendCh writer**: N goroutines on the client
+  push events into the same buffered channel; the writer drains it
+  in FIFO order.
+
+## Ready / Task / Result loop
+
+The unbatched path is the lifecycle of one task:
+
+```mermaid
+sequenceDiagram
+  participant Slot as Client slot
+  participant CW as Client writer
+  participant SS as Server stream
+  participant Sched as Scheduler
+  participant Pebble
+  Note over Slot,SS: Hello + HelloAck (once per stream)
+  Slot->>CW: Ready{count=1}
+  CW->>SS: WorkerEvent.Ready
+  SS->>Sched: ClaimTask(workerID, cmds, lease)
+  Sched->>Pebble: pop hint + Get(KeyTask)
+  Pebble-->>Sched: task body
+  Sched->>Sched: leaseTable.Set
+  Sched-->>SS: task
+  SS-->>CW: ServerEvent.Task
+  CW-->>Slot: Task
+  Slot->>Slot: Handler(ctx, task)
+  Slot->>CW: Result{COMPLETED}
+  CW->>SS: WorkerEvent.Result
+  SS->>Sched: Submit(taskID, result)
+  Sched->>Pebble: BatchCommit (status, body, ttl)
+  Sched->>Sched: leaseTable.Drop
+  SS-->>CW: ServerEvent.ResultAck
+  CW-->>Slot: (ack dropped — MVP)
+  Note over Slot: loop: send next Ready
+```
+
+`ResultAck` is intentionally dropped on the client side
+([`session.readLoop`](../pkg/workerclient/client.go) drops
+`ResultAck`/`HeartbeatAck`/`NackAck`/`AbandonAck`). The slot doesn't
+block on confirmation; correlation would add overhead with no
+measurable benefit at the throughputs we care about. If you need
+per-task durability guarantees beyond at-least-once, use the
+synchronous REST path.
+
+## Batch mode (Q2)
+
+Setting `Config.BatchSize > 1` flips the slot loop from "one Ready, one
+Task" to "one Ready, up to N Tasks". Each slot pulls a `TaskBatch`,
+runs the handler N times serially, and submits one `ResultBatch`.
+
+```mermaid
+sequenceDiagram
+  participant Slot as Client slot
+  participant CW as Client writer
+  participant SS as Server stream
+  participant Sched as Scheduler
+  participant Pebble
+  Slot->>CW: Ready{count=32}
+  CW->>SS: WorkerEvent.Ready
+  SS->>Sched: ClaimManyTasks(32)
+  Sched->>Pebble: pop up to 32 hints
+  Pebble->>Pebble: one Batch (state + lease + ttl) for all 32
+  Pebble-->>Sched: 32 task bodies
+  Sched-->>SS: tasks[32]
+  SS-->>CW: ServerEvent.TaskBatch
+  CW-->>Slot: []Task (32)
+  loop 32 times
+    Slot->>Slot: Handler(ctx, task[i])
+  end
+  Slot->>CW: ResultBatch[32]
+  CW->>SS: WorkerEvent.ResultBatch
+  SS->>Sched: ResultsService.BatchSubmit
+  Sched->>Pebble: one Batch (status + body + ttl) for all 32
+  SS-->>CW: ServerEvent.ResultAckBatch
+```
+
+The server collapses N `Submit` calls into one `BatchSubmit` —
+internally one `GetTasksBatch` followed by
+`BatchUpdateTasksOnComplete`, one Pebble batch, one commit. On the
+claim side the Phase 7 swap in
+[`internal/repository/pebble/task_repository.go::ClaimMany`](../internal/repository/pebble/task_repository.go)
+drains the per-(cmd, tenant, priority) channels in one pop loop, writes
+all state transitions into a single Pebble batch, and commits once. The
+asymptotic win is the elimination of (N-1) batch.Close + (N-1) commit
+trips through the coalescer.
+
+The amortised costs are illustrated by
+`internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath`:
+
+| Config | Result on reference box |
+|---|---|
+| c=1, BatchSize=0 | ~1,700 tasks/s |
+| c=1, BatchSize=32 | ~16,000 tasks/s |
+| c=4, BatchSize=32 | 23,518 tasks/s |
+| c=32, BatchSize=0 | ~16,000 tasks/s |
+
+The single-slot batched run matches a 32-slot unbatched run because the
+client-side fan-out is already absorbed by the server's claim path
+inside `ClaimMany`. See [Batch sizing guidance](#batch-sizing-guidance)
+for picking a value.
+
+> **Performance**: `Nack` and `Abandon` are **not** routed through
+> `BatchSubmit`. The client (`dispatchBatch`) falls back to per-message
+> sends for non-`Completed`/`Failed` results inside a batch — these are
+> rare paths under load and the batched server handler only supports
+> Submit.
+
+## API reference
+
+The full surface is four types plus four constructors.
+
+### `Config`
+
+Defined in [`pkg/workerclient/client.go`](../pkg/workerclient/client.go):
+
+```go
+type Config struct {
+    Addr         string         // required, gRPC dial target e.g. "localhost:9091"
+    Token        string         // required, bearer token sent in Hello
+    WorkerID     string         // optional, defaults to JWT subject
+    Commands     []string       // optional, defaults to claims.eventTypes
+    Concurrency  int            // slot count, default 1
+    LeaseSeconds int            // lease per Ready, 0 = server default
+    BatchSize    int            // 0/1 = legacy single-task, >1 = Q2 batch
+    IdleBackoff  time.Duration  // unused on the hot path; default 50ms
+    DialOptions  []grpc.DialOption
+    Logger       *slog.Logger
+}
+```
+
+Required fields are checked in `New`; everything else takes a
+documented default via `Config.defaults()`.
+
+### `Client`
+
+```go
+type Client struct { /* unexported */ }
+func New(cfg Config) (*Client, error)
+func (c *Client) Run(ctx context.Context, h Handler) error
+func (c *Client) Close() error
+```
+
+- `New` dials the server (`grpc.NewClient`, insecure by default — set
+  `DialOptions` for TLS/mTLS) and returns immediately. The TCP/HTTP/2
+  handshake is lazy; the actual stream opens in `Run`.
+- `Run` opens the stream, completes the Hello handshake, then fans out
+  `Concurrency` slot goroutines. It blocks until ctx is cancelled, the
+  stream errors, or the server cleanly closes.
+- `Close` releases the underlying connection. Safe to call multiple
+  times; safe to defer.
+
+### `Handler`
+
+```go
+type Handler func(ctx context.Context, t Task) Result
+```
+
+Must be safe for concurrent invocation — up to `Concurrency` instances
+run in parallel. The `ctx` passed in is derived from the `Run` ctx;
+when the parent cancels, in-flight handlers receive cancellation but
+the SDK waits for them to return before exiting.
+
+### `Task`
+
+```go
+type Task struct {
+    ID          string
+    Command     string
+    Payload     []byte
+    Priority    int
+    Attempts    int
+    MaxAttempts int
+    TenantID    string
+    Webhook     string
+    LeaseUntil  string  // RFC3339
+}
+```
+
+`Payload` is whatever bytes the producer enqueued — codeq does not
+interpret it.
+
+### `Result` builders
+
+```go
+func Completed(body map[string]any) Result
+func Failed(err string) Result
+func Nack(delaySeconds int, reason string) Result
+func Abandon() Result
+```
+
+- `Completed(nil)` is the no-payload success case (most common).
+  Non-nil body is JSON-encoded by the SDK with `sonic.Marshal` and
+  stored as the task's `result_json`.
+- `Failed(err)` records a permanent failure. The scheduler respects
+  `MaxAttempts`; failures past the limit go to the DLQ.
+- `Nack(delay, reason)` returns the task to the queue. `delay=0` means
+  "re-claimable immediately"; `delay>0` writes a delayed entry that the
+  Pebble fast-path `MoveDueDelayed` will promote when due.
+- `Abandon()` drops the lease without nacking. The task goes straight
+  back to pending and another worker can grab it immediately. Use this
+  when the worker is shutting down cleanly mid-task.
+
+The zero `Result` value is invalid — the SDK returns an error rather
+than guessing. Always return one of the four builders from your
+handler.
+
+## Concurrency model
+
+Inside one `Run` call:
+
+1. The reader goroutine owns `stream.Recv()`. It dispatches Tasks /
+   TaskBatches into `batchCh`, drops acks, and forwards
+   `ServerEvent_Error` to the logger.
+2. `Concurrency` slot goroutines loop `Ready → recv batch → handle →
+   Result`. Each slot is independent — there is no cross-slot
+   coordination beyond the shared `batchCh` and `sendCh`.
+3. One writer goroutine owns `stream.Send()`. All slot goroutines push
+   `WorkerEvent`s into the buffered `sendCh` (capacity 256); the
+   writer drains it in FIFO order.
+
+The single-writer pattern is intentional. Before Phase 6 / M1, slots
+acquired a mutex around `stream.Send`. Under 128-slot load the lock
+showed up at the top of the mutex profile; replacing it with a channel
++ dedicated writer dropped contention to negligible and freed about
+8% of CPU on the worker host.
+
+When the writer hits a send error, it stores the error in
+`sendErr atomic.Pointer[error]` and drains the remaining channel
+without sending. Subsequent calls to `send` short-circuit on the
+atomic load. The slots notice via `ctx.Err()` or the next failed
+`send` and exit cleanly.
+
+## Lease management
+
+Lease state lives in an in-memory `leaseTable` on the server (Phase 6
+/ M2 — see commits in
+[`internal/repository/pebble/task_repository.go`](../internal/repository/pebble/task_repository.go)).
+The retired `KeyLease` index is gone; the table is rebuilt at startup
+by scanning `KeyInprog` once during Open.
+
+Consequences for the SDK consumer:
+
+- **Heartbeat is cheap**. The SDK's heartbeat path (sent for long-
+  running handlers via the rare `Heartbeat` event) writes the in-memory
+  table and one Pebble row for the task body — there is no separate
+  `KeyLease` to update. Heartbeating every 5 seconds for a 5-minute
+  lease costs essentially nothing.
+- **Lease expiry is detected by the reaper**, not the SDK. The
+  server's reaper scans `leaseTable` for expired entries and requeues
+  them (writes a new pending hint, drops the in-progress state). If
+  your handler exceeds the lease, expect the task to be re-delivered.
+- **Stream death drops the lease conceptually but not immediately**.
+  The lease entry survives until its TTL expires. If a worker crashes
+  mid-handler, the task is unavailable to other workers until the
+  reaper runs.
+
+> **Warning**: do not assume Heartbeat will save you from a stuck
+> handler. If your handler can hang, set a watchdog ctx and call
+> `Abandon` on timeout. Heartbeat extends the lease only — it does
+> not detect that the handler is wedged.
+
+## Error handling
+
+The SDK distinguishes three failure modes:
+
+1. **Stream dead**: `grpc.NewClient` reconnects on its own, but the
+   active `Stream` rpc is gone. `Run` returns the underlying gRPC
+   error (`codes.Unavailable`, `codes.Canceled`, etc). Callers should
+   re-call `Run` with a fresh ctx; the existing `Client` is reusable
+   (the gRPC connection persists).
+2. **Lease expired**: the SDK doesn't observe lease expiry directly.
+   The reaper requeues the task and another worker picks it up. If you
+   need to detect this from inside your handler, watch `ctx.Done()`
+   (the SDK does not currently cancel the handler ctx on lease
+   expiry — future work).
+3. **Result rejected**: if `Submit` fails on the server (not-found,
+   not-owner, not-in-progress), the server sends `ResultAck{ok=false}`
+   with an error message. The SDK currently logs nothing at warn for
+   acks; downgrade the logger to debug in development if you want to
+   see them.
+
+There is **no built-in retry budget** in the SDK. Retries are the
+scheduler's job — every time a worker `Nack`s or fails to
+`SubmitResult` before the lease expires, the task's `Attempts`
+counter advances. Once `Attempts >= MaxAttempts` the task moves to
+the DLQ. See [Backoff and retries](./11-backoff.md) for the policy.
+
+## Full working example
+
+This is a minimal worker that processes `send_email` tasks with 32
+concurrent slots and a batch of 16:
+
+```go
+package main
+
+import (
+    "context"
+    "errors"
+    "log"
+    "log/slog"
+    "os"
+    "os/signal"
+    "syscall"
+    "time"
+
+    "github.com/osvaldoandrade/codeq/pkg/workerclient"
+)
+
+type payload struct {
+    To      string `json:"to"`
+    Subject string `json:"subject"`
+}
+
+func main() {
+    logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+    cli, err := workerclient.New(workerclient.Config{
+        Addr:         "codeq.internal:9091",
+        Token:        os.Getenv("CODEQ_WORKER_TOKEN"),
+        WorkerID:     "mail-worker-" + os.Getenv("HOSTNAME"),
+        Commands:     []string{"send_email"},
+        Concurrency:  32,
+        BatchSize:    16,
+        LeaseSeconds: 60,
+        Logger:       logger,
+    })
+    if err != nil {
+        log.Fatalf("workerclient.New: %v", err)
+    }
+    defer cli.Close()
+
+    handler := func(ctx context.Context, t workerclient.Task) workerclient.Result {
+        if t.Attempts > t.MaxAttempts/2 {
+            logger.Warn("retrying task", "id", t.ID, "attempts", t.Attempts)
+        }
+        ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+        defer cancel()
+
+        if err := sendEmail(ctx, t.Payload); err != nil {
+            if errors.Is(err, context.DeadlineExceeded) {
+                // SMTP hung. Hand back so another worker can try.
+                return workerclient.Nack(5, "smtp timeout")
+            }
+            if isPermanent(err) {
+                return workerclient.Failed(err.Error())
+            }
+            return workerclient.Nack(10, err.Error())
+        }
+        return workerclient.Completed(map[string]any{
+            "queued_at": time.Now().UTC().Format(time.RFC3339),
+        })
+    }
+
+    ctx, stop := signal.NotifyContext(context.Background(),
+        syscall.SIGINT, syscall.SIGTERM)
+    defer stop()
+
+    if err := cli.Run(ctx, handler); err != nil && !errors.Is(err, context.Canceled) {
+        log.Fatalf("worker run: %v", err)
+    }
+    logger.Info("worker shut down cleanly")
+}
+
+func sendEmail(ctx context.Context, p []byte) error  { /* ... */ return nil }
+func isPermanent(err error) bool                      { /* ... */ return false }
+```
+
+Operational notes for this example:
+
+- The 30 s handler timeout sits well under the 60 s `LeaseSeconds`. A
+  handler that exceeds the timeout returns `Nack` and the lease
+  expires naturally; the reaper requeues. Do not set the handler
+  timeout above the lease.
+- `signal.NotifyContext` gives clean shutdown: on SIGTERM the slot
+  loops see `ctx.Done()` after their current handler returns and the
+  SDK waits for them via `sync.WaitGroup` before `Run` exits.
+- `BatchSize=16` is conservative; production workloads with cheap
+  handlers can push to 32 or 64. See below.
+
+## Batch sizing guidance
+
+The decision boils down to: how much latency are you willing to add
+per-task in exchange for amortising the per-batch fixed costs?
+
+| `BatchSize` | When to pick it |
+|---|---|
+| 0 / 1 | Legacy single-task path. Use when your handler latency is high (>100 ms) and you want minimum per-task tail latency. Each task is sent and acked individually. |
+| 16 - 32 | The sweet spot for typical workloads (fast handlers, mixed payloads). At c=1 BatchSize=32 the saturation harness shows ~9.5x speedup vs c=1 BatchSize=0; at c=4 BatchSize=32 it reaches 23,518 tasks/s. |
+| 64 - 128 | Saturates the queue. Only useful when you have a constant backlog and don't mind handler-start latency being bounded by N handler runs. Diminishing returns beyond ~64 in the saturation sweep. |
+| 256+ | Avoid. The TaskBatch carries 256 full task bodies, the gRPC frame grows, and the slot blocks on serial handler execution for the full batch. You're trading throughput for nothing past the queue's natural width. |
+
+Two specific tunings to remember:
+
+- `Concurrency * BatchSize` should be roughly the production rate of
+  the producer fleet divided by the handler-rate-per-task. If you
+  pull more tasks than you can process the leases expire and the
+  reaper churns.
+- `BatchSize` only helps if the queue has at least N tasks pending
+  when the slot sends `Ready`. On a near-empty queue the server
+  returns whatever it has (down to one task) — there is no penalty
+  for asking for more than is available.
+
+## See also
+
+- [Producer streaming SDK](./35-producer-streaming-sdk.md) — the
+  producer side of the same protocol.
+- [gRPC streaming API guide](./34-streaming-api-guide.md) — the
+  protocol spec, REST equivalents, and language-agnostic semantics.
+- [Lease management](./06b-lease-management.md) — what happens when a
+  lease expires, how the reaper requeues, and how to size
+  `LeaseSeconds`.
+- [Backoff and retries](./11-backoff.md) — the scheduler's policy for
+  `Nack` delays and DLQ promotion.

--- a/docs/_STYLE.md
+++ b/docs/_STYLE.md
@@ -1,0 +1,291 @@
+# codeq documentation style guide
+
+This is the canonical style guide for codeq documentation. Every doc in
+`docs/` and the root `README.md` must follow it. Subsequent waves of doc
+revisions cite this file verbatim where relevant (especially the value
+proposition and comparativos). If you change the value proposition here,
+you must update the docs that quote it.
+
+## 1. Value proposition
+
+### One-line
+
+> codeq is an embedded high-performance task queue: a single Go binary,
+> Pebble for persistence, gRPC streaming for the wire — 83k tasks/s on
+> one machine with zero external dependencies.
+
+### One-paragraph
+
+> codeq is a task queue written in Go that runs as a single process and
+> stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+> from CockroachDB). The hot path is bidirectional gRPC streams from
+> producers and workers; under the streams sits an intra-process shard
+> table (up to N independent Pebble instances) and an in-memory lease
+> table. The result on a 12-core Linux box is 83,420 tasks/s for the
+> full create → claim → complete cycle, or 136,392 creates/s producer-
+> only. No Redis, no broker, no coordinator required in the default
+> mode. Cluster (consistent-hash + gRPC routing) and a legacy Redis
+> backend are opt-in for HA and multi-node deployments.
+
+### Comparativos (use verbatim or as a base)
+
+| Dimension | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | None (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper or KRaft cluster |
+| Throughput (single node, full cycle) | 83k tasks/s | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | 100k+ msgs/s, but no task semantics |
+| Language affinity | Go (HTTP + gRPC; SDKs for Java, Node, Python, Go) | Go | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant native | Yes (JWT tenantId namespacing built in) | No | No | No | No |
+| Learning curve | One binary, HTTP + curl in minutes | Moderate (Redis ops) | Moderate (Node + Redis) | High (broker + result backend) | High (broker, consumer groups, schema registry) |
+
+When citing this table in a doc, link back here:
+
+> See [_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## 2. Audience profile
+
+Primary reader: **backend engineer evaluating alternatives to Redis-backed
+task queues**. They are typically deciding between Asynq (Go + Redis),
+BullMQ (Node + Redis), Celery (Python + broker), Sidekiq (Ruby + Redis),
+Temporal (workflow engine), and Kafka (event log used as a queue).
+
+What they care about, ranked:
+
+1. **Throughput** — concrete numbers, harness names, and the box they
+   were measured on. No "blazing fast", no "10x". Cite the benchmark.
+2. **Operational cost** — how many processes, how many config knobs, how
+   long until they can `curl` a task.
+3. **Language affinity** — Go server, but with first-class SDKs for the
+   reader's stack.
+4. **Durability and at-least-once** — what survives a crash, and how
+   they prove it.
+5. **Multi-tenant** — whether they can run one queue server for many
+   customers without writing isolation themselves.
+6. **HA and scaling story** — single-node first, but with a credible
+   path to multi-node.
+
+Write for someone who already understands queues. Skip onboarding to
+basic concepts like "what is a task". Do define codeq-specific terms
+(shard, lease table, ring, scatter-gather) the first time they appear.
+
+## 3. Voice and tone
+
+### Numbers first, narrative second
+
+Bad:
+
+> codeq is blazing fast and can handle massive workloads.
+
+Good:
+
+> codeq sustains 83,420 tasks/s for a full create → claim → complete
+> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
+> batch=8, 128 worker slots, 20s measurement window
+> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
+
+Every throughput claim cites:
+
+- The exact test name in `internal/bench/`.
+- The env vars used to parameterize it.
+- The hardware class (cores, OS).
+- The measurement window.
+
+### Honest about limitations
+
+Always name the trade-offs. Examples to use as templates:
+
+- "HA is only available via the Redis backend or by running a cluster of
+  Pebble nodes. A single Pebble process loses availability while it
+  restarts; recovery is fast (in-memory lease table rebuilt from the
+  `KeyInprog` scan at Open) but not instantaneous."
+- "Cluster mode and intra-process sharding (`numShards > 1`) are
+  mutually exclusive — startup panics if both are enabled. Pick one:
+  multi-node across machines, or multi-shard inside one process."
+- "Delivery is at-least-once, not exactly-once. A worker that crashes
+  between completion and ACK will see its task re-delivered after the
+  lease expires."
+
+### No marketing fluff
+
+Banned words: blazing, massive, lightning, seamless, robust,
+cutting-edge, world-class, next-gen, revolutionary.
+
+Replace adjectives with measurements. If you cannot measure it, do not
+claim it.
+
+### Opinionated
+
+Tell the reader what to pick:
+
+- "For single-node deployments use Pebble with `numShards: 4`."
+- "Do not enable `fsyncOnCommit` unless you have measured the latency
+  impact in your workload — it costs ~20% throughput in our harness."
+- "Use Redis only if you need multi-node HA today and cannot deploy the
+  cluster mode."
+
+## 4. Markdown conventions
+
+- **Headings**: ATX style (`#`), single `#` per file (the title), then
+  `##` for top-level sections, `###` for subsections. Do not skip
+  levels.
+- **Code blocks**: always tag the language.
+  - `bash` for shell, `go` for Go, `yaml` for config, `json` for JSON,
+    `protobuf` for `.proto`, `mermaid` for diagrams.
+  - Untagged blocks are forbidden — they break syntax highlighting on
+    GitHub.
+- **Admonitions** (GitHub-flavored):
+
+  ```markdown
+  > **Note**: a normal aside.
+  > **Warning**: a footgun. Always for irreversible operations or
+  > silent data loss.
+  > **Performance**: a tuning hint with a number.
+  ```
+
+- **Tables**: pipe-aligned, header row separator `---`. Always have a
+  header row. Cells with multi-word values stay on one line.
+- **Inline code**: backticks for file paths, env vars, config keys,
+  function names, and protocol constants.
+- **Lists**: `-` for unordered, `1.` for ordered. Two spaces of
+  indentation for nested items.
+- **Links**: prefer descriptive text over "click here". Relative links
+  for in-repo references (see §6).
+
+## 5. Mermaid conventions
+
+All diagrams must render on the GitHub default theme in both light and
+dark mode. **Never set inline colors or styles** — let the renderer
+pick.
+
+### Flow diagrams
+
+Use `graph TB` for top-to-bottom layered architecture, `graph LR` for
+left-to-right pipelines. Always use `subgraph` to delimit logical
+layers.
+
+```mermaid
+graph TB
+  subgraph Producers
+    P1[Producer SDK]
+  end
+  subgraph Server[codeq server]
+    HTTP[HTTP API]
+    GRPC[gRPC stream]
+  end
+  subgraph Storage
+    PEB[Pebble shards]
+  end
+  P1 --> GRPC
+  GRPC --> PEB
+  HTTP --> PEB
+```
+
+Aim for 8 to 12 nodes max in a single diagram. If it grows past that,
+split it.
+
+### Sequence diagrams
+
+Use `sequenceDiagram` for flows over time. Participant names start
+capitalized.
+
+```mermaid
+sequenceDiagram
+  participant Producer
+  participant Server
+  participant Pebble
+  Producer->>Server: Produce(task)
+  Server->>Pebble: BatchCommit
+  Pebble-->>Server: ack
+  Server-->>Producer: TaskID
+```
+
+### State machines
+
+Use `stateDiagram-v2` for task lifecycle. Transition labels describe
+the **trigger action**, not the resulting state.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  DLQ --> [*]
+```
+
+### No inline colors
+
+Bad:
+
+```text
+style P1 fill:#f9f,stroke:#333
+```
+
+Good: nothing — let the theme decide.
+
+## 6. Cross-link policy
+
+Every doc ends with a `## See also` section enumerating related docs.
+Example:
+
+```markdown
+## See also
+
+- [Architecture](./03-architecture.md)
+- [Storage layout (Pebble)](./07b-storage-pebble.md)
+- [Performance tuning](./17-performance-tuning.md)
+```
+
+Path conventions:
+
+- **Inside `docs/`** (doc-to-doc): use relative paths starting with
+  `./`, e.g. `[Overview](./01-overview.md)`.
+- **From root `README.md`** (or other root-level files): use paths
+  rooted at `docs/`, e.g. `[Overview](docs/01-overview.md)`.
+- **To source files**: use repo-rooted paths, e.g.
+  `[application.go](../pkg/app/application.go)` from inside `docs/`, or
+  `pkg/app/application.go` from `README.md`.
+- **Anchors**: lowercase, hyphen-separated, match GitHub's slug
+  algorithm.
+
+When you cite the value prop, link to this file:
+
+```markdown
+See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+```
+
+## 7. Numbers must come from measurement
+
+Every throughput, latency, or memory claim in any doc must be traceable
+to a test in `internal/bench/`. The format is:
+
+> N tasks/s (`internal/bench/<file>.go::<TestName>`, env: `KEY=VAL`,
+> hardware: 12-core Linux).
+
+Catalog of canonical benchmarks (use these names, do not invent new
+ones):
+
+| Workload | Harness | Result on reference box |
+|---|---|---|
+| Full cycle, 4 shards, batched | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) | 83,420 tasks/s |
+| Producer-only, batched stream | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` | 136,392 creates/s |
+| Worker-only, batched stream | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) | 23,518 tasks/s |
+| Shard sweep | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=1,2,4,6,8`) | 42k / 65k / 83k / 68k / 67k |
+
+Reference box: 12-core Linux (kernel 5.15, WSL2-compatible), Go 1.25.0,
+local Pebble, loopback gRPC, no fsync.
+
+If you need a number that is not in this table, run the bench, add the
+row here, then cite it in your doc. Do not estimate.
+
+## See also
+
+- [README](../README.md) — applies this style guide at the entry point.
+- [Overview](./01-overview.md) — the canonical statement of what codeq
+  is.
+- [Architecture](./03-architecture.md) — package-level breakdown.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and historical numbers.


### PR DESCRIPTION
## Summary

- Adds `docs/36-worker-streaming-sdk.md` (~520 lines) — comprehensive guide for the Go worker SDK at `pkg/workerclient/`.
- Cites `internal/bench/worker_stream_vs_rest_bench_test.go::TestThroughput_StreamPath` (16k tasks/s, 2.9x over REST) and `worker_stream_saturation_test.go::TestSaturation_StreamPath` (9.5x at c=1 BatchSize=32).
- Three mermaid diagrams: architecture component (`graph TB`), single-task lifecycle sequence, batched claim+result sequence. No inline colors, GitHub light/dark safe per `_STYLE.md` section 5.

## Contents

- What and why: REST round-trip cost vs streaming.
- Architecture: Client slots -> session writer -> stream -> server.Stream -> Scheduler -> in-memory leaseTable + Pebble.
- Ready / Task / Result loop (single task).
- Batch mode (Q2): `Ready{count=N}` -> `TaskBatch` -> `ResultBatch` -> `ResultAckBatch`.
- API reference: `Config`, `Client.New/Run/Close`, `Handler`, result builders `Completed/Failed/Nack/Abandon`.
- Concurrency model: N slot goroutines, single `sendCh` writer (Phase 6 / M1 mutex profile fix).
- Lease management: in-memory `leaseTable` (Phase 6 / M2 `KeyLease` retired), Heartbeat semantics.
- Error handling: stream death, lease expiry via reaper, no built-in retry budget.
- Full working Go example with signal handling.
- Batch sizing guidance: 1 = legacy, 32 = sweet spot, 128+ saturates.

## Sources cited

- `internal/worker/server.go` (handleReady / handleReadyBatch / handleResultBatch, streamSession writer)
- `internal/worker/proto/workerpb.proto` (oneof events, batch messages)
- `pkg/workerclient/client.go` (session, slot loop, writer, dispatchBatch)
- `internal/repository/pebble/task_repository.go::ClaimMany` (Phase 7 batch claim)
- `internal/bench/worker_stream_vs_rest_bench_test.go`
- `internal/bench/worker_stream_saturation_test.go`

## Test plan

- [ ] CI doc lint passes
- [ ] Three mermaid blocks render on GitHub in light and dark modes
- [ ] All relative links resolve (35-producer-streaming-sdk pending in U8, 06b-lease-management likely pending in a later wave)

Base: `docs/wave1-u1-foundation` (Wave 1 style guide foundation). Draft until U8 producer doc lands so cross-links resolve cleanly.