### PR TITLE
docs(wave3-u12): cluster gRPC protocol reference (19b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,108 @@
-# codeQ
+# codeq
 
-Reactive scheduling and completion system backed by persistent queues. Choose your storage: KVRocks (distributed) or Pebble (embedded).
+> Embedded high-performance task queue. One Go binary, Pebble for
+> storage, gRPC streams on the wire. 83k tasks/s on a single 12-core
+> box with zero external dependencies.
 
-This repository contains the core runtime, HTTP API wiring, and a Helm chart for small clusters.
-The production service wrapper lives at:
-https://github.com/codecompany/codeq-service
+[![Go Reference](https://pkg.go.dev/badge/github.com/osvaldoandrade/codeq.svg)](https://pkg.go.dev/github.com/osvaldoandrade/codeq)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Issues](https://img.shields.io/github/issues/osvaldoandrade/codeq.svg)](https://github.com/osvaldoandrade/codeq/issues)
 
-## Links
+## What is codeq?
 
-- GitHub: https://github.com/osvaldoandrade/codeq
-- Issues: https://github.com/osvaldoandrade/codeq/issues
-- Specs index: `docs/README.md`
+codeq is a task queue written in Go. The default deployment is a single
+process: the server, the persistence layer (Pebble, the RocksDB-style
+LSM from CockroachDB), the lease table, and the gRPC + HTTP API all
+share one binary and one disk directory. There is no Redis to run, no
+broker to babysit, no consensus to coordinate.
 
-## Why codeQ
+On a 12-core Linux box, that single binary sustains **83,420 tasks/s**
+for the full create → claim → complete cycle and **136,392 creates/s**
+for producer-only workloads — measured by the in-tree benchmarks in
+`internal/bench/`. When one machine is no longer enough, cluster mode
+(consistent-hash ring + gRPC routing between nodes) and a legacy Redis
+backend are opt-in.
 
-codeQ provides:
+## Architecture overview
 
-- Persistent queues with pluggable storage backends:
-  - **Redis/KVRocks** (distributed, cluster-capable)
-  - **Pebble** (embedded, zero-dependency, ideal for local development)
-- Pull-based worker claims with leases.
-- **Multi-tenant queue isolation** with automatic tenant ID extraction from JWT claims.
-- **Horizontal scaling with queue sharding**: Optional pluggable `ShardSupplier` interface for routing commands/tenants across multiple KVRocks instances.
-- **Pluggable persistence backends**: Redis, memory (testing), and extensible plugin architecture for custom storage (PostgreSQL, DynamoDB, Cassandra, etc.).
-- NACK + backoff + delayed queues.
-- DLQ for tasks that exceed `maxAttempts`.
-- Result storage and optional callbacks (webhooks).
-- Worker auth via JWT (JWKS), producer auth via Tikti access tokens (JWKS).
-- **Official SDKs** for Java and Node.js/TypeScript with framework integrations.
-- **Distributed tracing** with OpenTelemetry support for end-to-end observability.
-- **Optimized performance**: O(1) queue operations with pipelined lease repair for low-latency claims even under high load.
-- **Load testing framework**: Comprehensive k6 scenarios and Go benchmarks for performance validation and regression testing.
+```mermaid
+graph TB
+  subgraph Clients
+    PSDK[Producer SDK]
+    WSDK[Worker SDK]
+    CURL[HTTP / curl]
+  end
+  subgraph Server[codeq server -- single binary]
+    HTTP[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+  end
+  subgraph Storage[Embedded persistence]
+    P0[Pebble shard 0]
+    P1[Pebble shard 1]
+    PN[Pebble shard N-1]
+  end
+  subgraph Optional[Opt-in scaling]
+    CL[Cluster -- consistent-hash + gRPC]
+    REDIS[Redis backend -- legacy HA]
+  end
+  PSDK --> PGRPC
+  WSDK --> WGRPC
+  CURL --> HTTP
+  HTTP --> LEASE
+  PGRPC --> LEASE
+  WGRPC --> LEASE
+  LEASE --> P0
+  LEASE --> P1
+  LEASE --> PN
+  Server -.-> CL
+  Server -.-> REDIS
+```
 
-## Get started
+Producers and workers connect over long-lived bidirectional gRPC
+streams. Each request hits the in-memory lease table first, then commits
+to a Pebble shard chosen by `hash(taskID) % N`. Each shard runs its own
+commit pipeline and compaction loop, which is what lets a 4-shard
+configuration roughly double the single-shard throughput on the same
+hardware.
 
-### Local development with Docker Compose
+## Performance
 
-The quickest way to try codeQ locally:
+All numbers measured on a 12-core Linux box, Go 1.25.0, loopback gRPC,
+Pebble with `fsyncOnCommit=false`. Full bench harness lives in
+`internal/bench/`.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle (create + claim + complete), 4 Pebble shards | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| Worker-only, batched claim+complete | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep (full cycle, 1 / 2 / 4 / 6 / 8 shards) | 42k / 65k / **83k** / 68k / 67k tasks/s | same as full cycle harness with `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on a 12-core box; past that, write
+amplification and goroutine contention start to dominate. See
+[docs/30-performance-baselines.md](docs/30-performance-baselines.md)
+for raw output and per-release history.
+
+## Why codeq vs alternatives
+
+| Feature | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | **None** (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper / KRaft cluster |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | n/a (no task semantics) |
+| Language affinity | Go server, SDKs for Java, Node, Python, Go | Go only | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant isolation | **Built in** (JWT tenantId namespacing) | DIY | DIY | DIY | DIY |
+| Time-to-first-task | `docker run` + `curl` | Run Redis + Asynq | Run Redis + worker | Run broker + workers + result backend | Multi-step cluster bootstrap |
+
+codeq is the right call when you want task-queue semantics (claims,
+leases, retries, DLQ, results) without standing up a broker. It is the
+wrong call if you need Kafka-scale event streaming, distributed
+consensus by default, or HA without configuring the Redis backend or
+cluster mode.
+
+## Quick start (5 minutes)
 
 ```bash
 git clone https://github.com/osvaldoandrade/codeq
@@ -47,125 +113,10 @@ docker compose \
   up -d
 ```
 
-This starts KVRocks, the codeQ API server, and seeds example tasks. Access at `http://localhost:8080`.
+This brings up the codeq server on `http://localhost:8080` with the
+embedded Pebble backend (no Redis required) and seeds example tasks.
 
-See [Local Development Guide](docs/22-local-development.md) for details on hot reload, testing, and observability.
-
-### Install a server
-
-Use the console wizard to generate a Docker or Kubernetes/Helm install bundle:
-
-```bash
-codeq install
-```
-
-Non-interactive Kubernetes example:
-
-```bash
-codeq install \
-  --target kubernetes \
-  --size small \
-  --namespace codeq \
-  --identity-service-url https://issuer.example.com \
-  --worker-jwks-url https://issuer.example.com/.well-known/jwks.json \
-  --worker-issuer https://issuer.example.com
-```
-
-### Install CLI (macOS/Linux/Windows via Git Bash)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
-```
-
-Requires `git` and `go`.
-
-### Install CLI via npm (npmjs)
-
-```bash
-npm i -g @osvaldoandrade/codeq
-codeq --help
-```
-
-Upgrade:
-
-```bash
-npm i -g @osvaldoandrade/codeq@latest
-```
-
-### Use SDKs for Java, Node.js, Python, and Go
-
-Integrate codeQ into your microservices with official SDKs:
-
-**Java** (Spring Boot, Quarkus, Micronaut):
-```xml
-<dependency>
-    <groupId>io.codeq</groupId>
-    <artifactId>codeq-sdk-java</artifactId>
-    <version>1.0.0</version>
-</dependency>
-```
-
-**Node.js/TypeScript** (Express, NestJS):
-```bash
-npm install @osvaldoandrade/codeq-client
-```
-
-**Python** (FastAPI, Django, Flask):
-```bash
-pip install codeq-client
-```
-
-**Go** (Gin, Echo, stdlib):
-```bash
-go get github.com/osvaldoandrade/codeq/sdks/go
-```
-
-📚 **SDK Documentation**:
-- [SDK Overview & Quick Start](sdks/README.md)
-- [Java SDK](sdks/java/README.md)
-- [Node.js SDK](sdks/nodejs/README.md)
-- [Python SDK](sdks/python/README.md)
-- [Go SDK](sdks/go/README.md)
-- [Integration Guides](docs/integrations/)
-- [Example Applications](examples/)
-
-### Helm
-
-The chart in this repo deploys codeQ and, by default in the small profile, a single-node KVRocks instance.
-
-```bash
-git clone https://github.com/osvaldoandrade/codeq
-cd codeq
-
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-small.yaml \
-  --namespace codeq --create-namespace \
-  --set secrets.enabled=true \
-  --set secrets.webhookHmacSecret=YOUR_SECRET \
-  --set config.identityServiceUrl=https://your-auth-server.com \
-  --set config.workerJwksUrl=https://your-jwks \
-  --set config.workerIssuer=https://issuer
-```
-
-Disable embedded KVRocks and point to your own:
-
-```bash
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-medium.yaml \
-  --set kvrocks.enabled=false \
-  --set config.redisAddr=your-kvrocks:6666
-```
-
-### 2) Service runtime
-
-The API server and Dockerfile are in the service repo:
-https://github.com/codecompany/codeq-service
-
-That repo consumes this module and exposes the HTTP API.
-
-## Quick API flow
-
-Create a task (producer token):
+Create a task:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks \
@@ -174,7 +125,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"priority":3}'
 ```
 
-Claim a task (worker JWT):
+Claim a task (as a worker):
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
@@ -183,7 +134,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
   -d '{"commands":["GENERATE_MASTER"],"leaseSeconds":120,"waitSeconds":10}'
 ```
 
-Submit result:
+Submit a result:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
@@ -192,49 +143,95 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
   -d '{"status":"COMPLETED","result":{"ok":true}}'
 ```
 
-## Specs and docs
+For high-throughput producers and workers, use the gRPC streaming API
+(2-3x the HTTP throughput, amortized auth, pipelined acks): see
+[docs/34-streaming-api-guide.md](docs/34-streaming-api-guide.md).
 
-Start here: `docs/README.md`
+## Where next
 
-Key references:
+- [Getting started tutorial](docs/00-getting-started.md) — your first
+  task, end to end.
+- [Overview](docs/01-overview.md) — goals, non-goals, when (and when
+  not) to pick codeq.
+- [Architecture](docs/03-architecture.md) — package layout and request
+  flows.
+- [Performance tuning](docs/17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Operational runbooks](docs/29-operational-runbooks.md) — on-call
+  procedures for the common failure modes.
+- [Streaming API guide](docs/34-streaming-api-guide.md) — gRPC
+  producer and worker streams.
+- [Cluster architecture](docs/05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Style guide](docs/_STYLE.md) — voice, numbers, diagrams, links.
 
-- **Getting Started Tutorial**: `docs/00-getting-started.md` - **Start here for your first experience with codeQ**
-- **Overview**: `docs/01-overview.md` - System goals and design principles
-- **Architecture**: `docs/03-architecture.md` - System components and multi-tenant architecture
-- **Security**: `docs/09-security.md` - Authentication, authorization, and tenant isolation
-- **HTTP API**: `docs/04-http-api.md` - Complete API reference
-- **CLI Reference**: `docs/15-cli-reference.md` - CLI command documentation
-- **SDK Integration**: `sdks/README.md` - Official Java and Node.js SDKs
-  - [Java Integration](docs/integrations/java-integration.md) - Spring Boot, Quarkus, Micronaut
-  - [Node.js Integration](docs/integrations/nodejs-integration.md) - Express, NestJS, React
-- **Examples**: `examples/` - Working examples with Java and Node.js frameworks
-- **Developer Guide**: `docs/21-developer-guide.md` - Contributing and internal architecture
-- **Queue model**: `docs/05-queueing-model.md` - Queue semantics
-- **Storage layout**: `docs/07-storage-kvrocks.md` - KVRocks data structures
-- **Backoff and retries**: `docs/11-backoff.md` - Retry logic
-- **Webhooks**: `docs/12-webhooks.md` - Push notifications
-- **Configuration**: `docs/14-configuration.md` - Config reference
-- **Operations**: `docs/10-operations.md` - Metrics, health checks, and tracing
-- **Workflows**: `docs/16-workflows.md` - GitHub Actions automation
-- **Performance**: `docs/17-performance-tuning.md` - Optimization guide
-- **Load Testing**: `docs/26-load-testing.md` - Load testing framework and benchmarks
-- **Testing**: `docs/19-testing.md` - Test coverage and strategy
-- **Authentication Plugins**: `docs/20-authentication-plugins.md` - Plugin system for custom auth
-- **Persistence Plugins**: `docs/27-persistence-plugin-system.md` - Pluggable storage backends (Redis, Memory, and more)
-- **Design Documents**:
-  - `docs/24-queue-sharding-hld.md` - Queue sharding high-level design
-  - `docs/25-plugin-architecture-hld.md` - Plugin architecture for persistence and auth
-- **Migration**: `docs/migration.md` - Upgrade guide
-- **Contributing**: `CONTRIBUTING.md` - Contribution guidelines
+## SDKs
+
+Official client libraries for the languages most likely to talk to
+codeq from application code:
+
+- **Go** — `go get github.com/osvaldoandrade/codeq/sdks/go` ([README](sdks/go/README.md))
+- **Java** (Spring Boot, Quarkus, Micronaut) — [sdks/java/README.md](sdks/java/README.md)
+- **Node.js / TypeScript** (Express, NestJS) — [sdks/nodejs/README.md](sdks/nodejs/README.md)
+- **Python** (FastAPI, Django, Flask) — [sdks/python/README.md](sdks/python/README.md)
+
+Integration recipes per framework live under
+[docs/integrations/](docs/integrations/). End-to-end example apps live
+under [examples/](examples/).
 
 ## Repo layout
 
-- `pkg/`: public packages (`app`, `config`, `domain`)
-- `internal/`: controllers, middleware, services, repositories, providers
-- `deploy/`: Docker Compose, Kubernetes, and config examples
-- `helm/codeq`: Helm chart and size profiles
-- `docs/`: full specification
+```text
+cmd/                  CLI entrypoints (codeq install, server)
+internal/             unexported packages
+  bench/              throughput + latency benchmarks (source of truth for perf claims)
+  cluster/            consistent-hash ring, gRPC router, bloom gossip
+  controllers/        HTTP handlers (Gin)
+  middleware/         auth, tracing, rate-limit, tenant extraction
+  producer/           gRPC producer-stream server
+  worker/             gRPC worker-stream server
+  repository/         persistence implementations (Redis legacy + Pebble)
+  services/           scheduler, results, callbacks, subscriptions
+pkg/                  public packages (app, auth, config, domain,
+                      producerclient, workerclient)
+sdks/                 official SDKs (go, java, nodejs, python)
+deploy/               docker-compose and Kubernetes config
+helm/codeq/           Helm chart and size profiles
+docs/                 specifications, runbooks, performance baselines
+examples/             end-to-end example applications
+```
+
+## Install the CLI
+
+macOS, Linux, or Windows via Git Bash:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
+```
+
+Or via npm:
+
+```bash
+npm i -g @osvaldoandrade/codeq
+codeq --help
+```
+
+To generate a Docker or Kubernetes install bundle (with embedded Pebble
+by default, no Redis required):
+
+```bash
+codeq install
+```
+
+See [docs/15-cli-reference.md](docs/15-cli-reference.md) for the full
+CLI surface.
+
+## Contributing
+
+Issues and PRs are welcome. Before opening a PR, read
+[CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, and
+[docs/_STYLE.md](docs/_STYLE.md) for the documentation style.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,27 +1,244 @@
 # Overview
 
-codeQ is a task scheduling and completion service built on persistent queues in KVRocks. The service exposes HTTP APIs for producers to create tasks, for workers to claim and complete tasks, and for operators to inspect and clean up queues. The system is reactive: workers pull tasks, and optionally receive webhook signals that work is available.
+> Source-of-truth for the value proposition lives in
+> [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+> Other docs may cite this overview, but the style guide wins ties.
 
-The design is inspired by Dyno Queues, which adds time-based and priority queues on top of Dynomite. Dynomite is a distributed data layer that exposes Redis semantics and provides multi-datacenter replication. codeQ applies the same motivation to KVRocks and uses Go for the implementation. The service favors availability and throughput over strict global ordering.
+## What is codeq
+
+codeq is a task queue written in Go that runs as a single process and
+stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+from CockroachDB). The hot path is bidirectional gRPC streams from
+producers and workers; under the streams sits an intra-process shard
+table (up to N independent Pebble instances) and an in-memory lease
+table. On a 12-core Linux box the single binary sustains
+**83,420 tasks/s** for the full create → claim → complete cycle and
+**136,392 creates/s** for producer-only workloads.
+
+No Redis, no broker, no coordinator required in the default mode.
+Cluster (consistent-hash ring + gRPC routing) and a legacy Redis backend
+are opt-in for HA and multi-node deployments.
 
 ## Goals
 
-- Provide a stable API for enqueue, claim, and completion.
-- Persist state on disk via KVRocks.
-- Support delayed retries, priority, and retries.
-- Allow workers to pull by event type without a worker registry.
-- Provide optional push notifications without assigning work.
+- **Single binary.** Server, persistence, lease table, HTTP + gRPC API
+  all in one process. One disk directory. One systemd unit. No external
+  database required.
+- **80k+ tasks/s on one machine.** Full create → claim → complete cycle
+  measured by `internal/bench/profile_full_cycle_test.go` with 4 Pebble
+  shards, batched producer + worker streams.
+- **gRPC streaming as a first-class API.** Long-lived bidirectional
+  streams amortize auth and middleware; multiple requests can be in
+  flight before responses arrive.
+- **Multi-tenant by construction.** Every queue key is namespaced by
+  `tenantId` extracted from the JWT. Workers can only claim tasks from
+  their own tenant. No application code required to keep tenants
+  isolated.
+- **Cluster opt-in.** When one machine is no longer enough, run a
+  consistent-hash cluster (no consensus, no coordinator — static
+  membership + gRPC routing).
+- **Configurable durability.** `fsyncOnCommit` is a per-deployment knob.
+  Off by default for throughput; turn it on when your SLO demands it.
 
 ## Non-goals
 
-- Exactly-once processing.
-- Global FIFO across all commands.
-- Automatic worker discovery or scheduling.
+- **Kafka-scale event streaming.** codeq is a task queue, not a
+  partitioned log. If you want millions of messages/s with consumer
+  groups, use Kafka.
+- **Distributed consensus by default.** No Raft, no Paxos. Cluster mode
+  uses a static consistent-hash ring; node membership is configured at
+  startup, not gossiped.
+- **HA without explicit setup.** A single Pebble process loses
+  availability while it restarts. HA requires either the Redis backend
+  (legacy, multi-node) or running a cluster of Pebble nodes — each is a
+  trade-off the operator picks consciously.
+- **Exactly-once delivery.** Delivery is at-least-once. A worker that
+  crashes between completion and ACK will see the task re-delivered
+  after the lease expires.
+- **Global FIFO across all commands.** Ordering is per-(command,
+  tenant, priority) within a Pebble shard. Cross-shard ordering is not
+  defined.
+- **Worker discovery or scheduling.** codeq does not register workers
+  or assign work; workers pull when they are ready.
 
-## High-level data model
+## Data model summary
 
-- Task: unit of work, identified by UUID.
-- Message: queue element containing metadata used by the scheduler.
-- Result: completion record stored independently of the task body.
-- Command (event type): routing key for tasks.
-- Shard: not implemented; queues are single-shard in the current service.
+- **Task** — unit of work. Identified by UUID. Carries `command`
+  (routing key), `payload` (opaque JSON bytes), `priority` (0-9),
+  optional `webhook` URL, and lifecycle state.
+- **Result** — completion record. Stored separately from the task body
+  so completion can be GC'd on a different schedule than the task
+  metadata.
+- **Subscription** — webhook registration. A worker (or coordinator)
+  registers a callback URL for one or more event types; codeq pings it
+  when new work appears.
+
+Task lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> FAILED: SubmitResult(err)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DELAYED: Nack(backoff)
+  DELAYED --> PENDING: MoveDueDelayed
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  FAILED --> [*]
+  DLQ --> [*]
+```
+
+Full schema and state semantics in
+[02-domain-model.md](./02-domain-model.md).
+
+## Architecture summary
+
+```mermaid
+graph TB
+  subgraph Clients
+    SDK[Producer / Worker SDKs]
+    HTTPCLI[HTTP clients -- curl, browsers]
+  end
+  subgraph Server[codeq server]
+    API[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+    SCHED[Scheduler core]
+  end
+  subgraph Storage[Embedded persistence -- default]
+    P[Pebble shards 0..N-1]
+  end
+  subgraph OptIn[Opt-in modes]
+    CL[Cluster -- consistent-hash + gRPC routing]
+    REDIS[Redis backend -- legacy, HA]
+  end
+  SDK --> PGRPC
+  SDK --> WGRPC
+  HTTPCLI --> API
+  API --> SCHED
+  PGRPC --> SCHED
+  WGRPC --> SCHED
+  SCHED --> LEASE
+  SCHED --> P
+  Server -.-> CL
+  Server -.-> REDIS
+```
+
+Request flow at a glance:
+
+1. Producer or worker opens a gRPC stream (or sends an HTTP request).
+2. The middleware chain validates the JWT, extracts `tenantId`, and
+   applies rate limits.
+3. The scheduler routes the operation to its Pebble shard
+   (`hash(taskID) % numShards`) and updates the in-memory lease table.
+4. Pebble commits the batch; the group-commit coalescer (Phase 1.1)
+   merges concurrent writers into one fsync.
+5. On worker stream, ready tasks are pushed back through the same long-
+   lived connection — no per-claim handshake.
+
+Package-level breakdown in [03-architecture.md](./03-architecture.md).
+
+## When to use codeq
+
+- **Single-node task queue for a backend service.** You want claims,
+  leases, retries, DLQ, and results without standing up Redis or a
+  broker.
+- **Embedded sidecar in your own Go binary.** Import `pkg/app` and run
+  codeq in-process alongside your application.
+- **Multi-tenant SaaS background jobs.** Per-tenant queue isolation is
+  built in; you do not have to namespace keys yourself.
+- **High-throughput producers with small payloads.** The batched
+  producer stream sustains 100k+ creates/s on commodity hardware.
+- **Polyglot worker fleets.** Workers in Go, Java, Node, or Python can
+  all share the same queue via the official SDKs.
+- **Local development without external services.** `docker run codeq`
+  is enough; no Redis container, no compose dance.
+
+## When NOT to use codeq
+
+- **Kafka-scale event streaming.** Millions of events/s with consumer
+  groups, replay, and a retention window measured in days — use Kafka.
+- **Distributed transactions.** codeq has no two-phase commit and no
+  cross-shard transactions. If your business logic needs atomic updates
+  across multiple tasks, build it above codeq with an outbox pattern or
+  pick a workflow engine.
+- **HA without Redis or cluster mode.** A single Pebble process is
+  unavailable during restart. If your SLO does not tolerate a few
+  seconds of unavailability, you need the Redis backend (multi-node) or
+  a Pebble cluster.
+- **Workflow orchestration with branching, child tasks, timers, and
+  long-running state.** Use Temporal, Cadence, or Step Functions — they
+  are purpose-built for that. codeq is a queue.
+- **Exactly-once delivery semantics.** codeq is at-least-once. Idempotent
+  handlers are the operator's responsibility.
+
+## Performance baselines
+
+Measured on a 12-core Linux box, Go 1.25.0, loopback gRPC, Pebble with
+`fsyncOnCommit=false`, 20s measurement window after a 2s warm-up.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle, 4 shards, batched | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (32 goroutines, batch=16) |
+| Worker-only, batched stream | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep | 1 shard: 42k; 2: 65k; **4: 83k**; 6: 68k; 8: 67k | same as full cycle, `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on this hardware. Past that, the cost of more
+commit pipelines + compaction loops outweighs the parallelism win. See
+[30-performance-baselines.md](./30-performance-baselines.md) for raw
+output, allocator stats, and the per-release history.
+
+## Comparativos resumidos
+
+| Dimension | codeq | Asynq | BullMQ | Kafka |
+|---|---|---|---|---|
+| External dependency | **None** | Redis | Redis | ZooKeeper / KRaft |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k | ~5k | n/a (no task semantics) |
+| Language | Go server, multi-language SDKs | Go | Node | Polyglot |
+| Multi-tenant native | **Yes** | DIY | DIY | DIY |
+| HA model | Cluster or Redis (opt-in) | Redis | Redis | Replicated log |
+
+Full table with Sidekiq, Celery, and Temporal lives in
+[_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## What changed (Phases 1-8 summary)
+
+codeq has been through a sequence of refactors that shifted its
+positioning from "Redis-backed queue" to "embedded high-performance
+queue". The short version:
+
+| Phase | Theme | Effect |
+|---|---|---|
+| 0 | kvrocks-primary | First version: KVRocks (Redis protocol) as the only backend. ~1.5-2k tasks/s. |
+| 1 | Pebble embedded backend | Pebble added as a pluggable persistence provider. Single-binary deployment becomes possible. Single-shard throughput ~42k tasks/s. |
+| 1.1 | Pebble fast-paths + group-commit coalescer | `MoveDueDelayed` fast-path; concurrent writers coalesce into one fsync. |
+| 2 | Streaming groundwork | gRPC streaming surfaces designed. Auth amortized across stream lifetime. |
+| 5 | Cluster mode | Consistent-hash ring + gRPC routing between Pebble nodes. No consensus; static membership. |
+| 6 | Batched stream paths | Producer and worker streams gain batch APIs. `PHASE6_BATCH` / `PHASE6_PROD_BATCH` env knobs. |
+| 8 | Intra-process Pebble sharding | `numShards` opens N independent Pebble instances under one process. 4 shards → ~83k tasks/s on a 12-core box. **Mutually exclusive with cluster mode.** |
+
+PRs #527-#547 landed Phases 1.1, 6, and 8. The Redis backend remains
+supported for HA scenarios but is no longer the default.
+
+## See also
+
+- [_STYLE.md](./_STYLE.md) — documentation voice, numbers, diagrams.
+- [Architecture](./03-architecture.md) — package layout and request
+  flows.
+- [HTTP API](./04-http-api.md) — REST surface.
+- [Streaming API guide](./34-streaming-api-guide.md) — gRPC producer
+  and worker streams.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and per-release history.
+- [Performance tuning](./17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Cluster architecture](./05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Storage layout (Pebble)](./07b-storage-pebble.md) — keyspace and
+  sharding internals.
+- [Persistence plugin system](./27-persistence-plugin-system.md) —
+  choosing and configuring backends.

--- a/docs/19b-cluster-grpc-protocol.md
+++ b/docs/19b-cluster-grpc-protocol.md
@@ -1,0 +1,385 @@
+# Cluster gRPC protocol
+
+This is the reference for `internal/cluster/proto/clusterpb.proto` — the
+internal wire protocol codeq nodes speak to each other in cluster mode.
+
+> **Note**: this is **not** a client SDK protocol. Producers and workers
+> still speak the public HTTP and gRPC stream APIs documented in
+> [04-http-api](./04-http-api.md) and [34-streaming-api-guide](./34-streaming-api-guide.md).
+> The surface described here is only reachable on the cluster-internal
+> network, between codeq nodes.
+
+See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition) for
+the broader product context.
+
+## 1. What this is
+
+`clusterpb` is a single gRPC service — `TaskNode` — that lets one codeq
+node delegate ID-routed work (Enqueue, GetTask, Heartbeat, SaveResult,
+etc.) and fan-out aggregates (Claim, PendingLength, AdminQueues) to its
+peers. Membership is static: every node knows the full peer list at
+startup from config and dials lazily on first use.
+
+The protocol is intentionally minimal:
+
+- Operations that already know a task ID resolve the owner via consistent
+  hash (`Ring.Owner(id)`) and call that one peer directly.
+- Operations that do not (a worker asking "is there work for me?") get
+  fanned out to every node by the caller — the server side handles only
+  its own local shard.
+- A separate `BloomSnapshot` RPC lets nodes gossip a bloom of locally-
+  stored IDs so the router can skip the gRPC entirely for IDs that are
+  definitely not on a given peer.
+
+Source files cited throughout:
+
+- [`internal/cluster/proto/clusterpb.proto`](../internal/cluster/proto/clusterpb.proto)
+- [`internal/cluster/server.go`](../internal/cluster/server.go)
+- [`internal/cluster/router.go`](../internal/cluster/router.go)
+- [`internal/cluster/ring.go`](../internal/cluster/ring.go)
+- [`internal/cluster/bloom.go`](../internal/cluster/bloom.go)
+- [`internal/cluster/bloom_cache.go`](../internal/cluster/bloom_cache.go)
+- [`internal/cluster/client.go`](../internal/cluster/client.go)
+
+## 2. Topology
+
+Every node runs three listeners on the wire and one `TaskNode` server
+internally. The cluster-internal traffic is the bottom plane; client
+SDKs never touch it.
+
+```mermaid
+graph TB
+  subgraph Clients
+    SDK[Producer / Worker SDK]
+  end
+  subgraph NodeA[Node A]
+    HA[HTTP API]
+    SA[gRPC stream listener]
+    CA[Cluster gRPC server]
+    RA[TaskRouter + ClientPool]
+    PA[(Local Pebble shard)]
+  end
+  subgraph NodeB[Node B]
+    HB[HTTP API]
+    SB[gRPC stream listener]
+    CB[Cluster gRPC server]
+    RB[TaskRouter + ClientPool]
+    PB[(Local Pebble shard)]
+  end
+  subgraph NodeC[Node C]
+    HC[HTTP API]
+    SC[gRPC stream listener]
+    CC[Cluster gRPC server]
+    RC[TaskRouter + ClientPool]
+    PC[(Local Pebble shard)]
+  end
+  SDK --> HA
+  SDK --> SA
+  HA --> RA
+  SA --> RA
+  RA --> PA
+  RA -.peer RPC.-> CB
+  RA -.peer RPC.-> CC
+  RB -.peer RPC.-> CA
+  RC -.peer RPC.-> CA
+  CB --> PB
+  CC --> PC
+```
+
+Cluster mode and intra-process sharding (`numShards > 1`) are mutually
+exclusive — startup panics if both are enabled. See
+[05-cluster-architecture](./05-cluster-architecture.md) for the
+deployment model.
+
+## 3. RPC catalog
+
+Every RPC is defined in
+[`internal/cluster/proto/clusterpb.proto`](../internal/cluster/proto/clusterpb.proto).
+Server handlers live in
+[`internal/cluster/server.go`](../internal/cluster/server.go); the
+router that decides local-vs-remote lives in
+[`internal/cluster/router.go`](../internal/cluster/router.go).
+
+### 3.1 ID-routed RPCs
+
+The caller hashes the task ID, resolves the owner via `Ring.Owner`, and
+either calls the local Pebble repo (if `IsLocal`) or dials the owner
+peer via `ClientPool.Client(owner)`.
+
+| RPC | Request | Response | When called | Caller code path |
+|---|---|---|---|---|
+| `Enqueue` | `EnqueueRequest` | `EnqueueResponse` | Producer hot path. The router pre-picks the ID via `LocalRing.GenerateLocalID` to bias toward local ownership (Phase 5). | `TaskRouter.EnqueueWithReady` |
+| `GetTask` | `GetTaskRequest` | `GetTaskResponse{Task, NotFound}` | HTTP `GET /tasks/:id`, scheduler lookups, controllers. | `TaskRouter.Get`, `ResultRouter.GetTask` |
+| `Heartbeat` | `HeartbeatRequest` | `HeartbeatResponse{NotFound, NotOwner}` | Worker keeping its lease alive. | `TaskRouter.Heartbeat` |
+| `Abandon` | `AbandonRequest` | `AbandonResponse{NotFound, NotOwner, NotInProgress}` | Worker releases a task back to pending. | `TaskRouter.Abandon` |
+| `Nack` | `NackRequest` | `NackResponse{AppliedDelaySeconds, Dlq, NotFound, NotOwner, NotInProgress}` | Worker reports a failure with optional retry delay. | `TaskRouter.Nack` |
+| `SaveResult` | `SaveResultRequest{Record, Command, TenantId}` | `SaveResultResponse{NotFound}` | Worker submits a result; `UpdateOnComplete` follows. | `ResultRouter.SaveResult` |
+| `GetResult` | `GetResultRequest` | `GetResultResponse{Record, NotFound}` | HTTP `GET /tasks/:id/result`. Cross-node routed if hash points away. | `ResultRouter.GetResult` |
+| `UpdateOnComplete` | `UpdateOnCompleteRequest` | `UpdateOnCompleteResponse{NotFound}` | Worker finalises a task (COMPLETED / FAILED / DLQ). | `ResultRouter.UpdateTaskOnComplete` |
+
+Owner-resolution is identical for all of them:
+
+```go
+if r.ring.IsLocal(taskID) {
+    return r.local.<Op>(ctx, taskID, ...)
+}
+owner := r.ring.Owner(taskID)
+if !r.peerHasLikely(owner.ID, taskID) {
+    return errors.New("not-found")  // bloom short-circuit
+}
+c, _ := r.pool.Client(owner)
+return c.<Op>(ctx, &clusterpb.<Op>Request{...})
+```
+
+Response flags (`NotFound`, `NotOwner`, `NotInProgress`) are translated
+back into the same string sentinels (`"not-found"`, `"not-owner"`,
+`"not-in-progress"`) the rest of the codebase already inspects. We
+encode them as fields rather than gRPC status codes so callers can
+distinguish them without unwrapping status messages.
+
+### 3.2 Scatter-gather RPCs
+
+The caller (`TaskRouter`) broadcasts to every peer in parallel via
+`ClientPool.CallEach` and either picks the first non-empty winner
+(Claim) or sums the responses (length / stats / admin).
+
+| RPC | Request | Response | Aggregation | Caller code path |
+|---|---|---|---|---|
+| `LocalClaim` | `LocalClaimRequest{WorkerId, Commands, LeaseSeconds, InspectLimit, MaxAttemptsDefault, TenantId}` | `LocalClaimResponse{Task, Empty}` | First non-empty wins; remaining calls cancelled via `context.WithCancel`. | `TaskRouter.Claim` |
+| `PendingLength` | `PendingLengthRequest{Command}` | `PendingLengthResponse{Length}` | Sum across nodes. | `TaskRouter.PendingLength` |
+| `QueueStats` | `QueueStatsRequest{Command, TenantId}` | `QueueStatsResponse{Ready, Delayed, InProgress, Dlq}` | Field-wise sum. | `TaskRouter.QueueStats` |
+| `AdminQueues` | `AdminQueuesRequest{}` | `AdminQueuesResponse{Counts map<string,int64>}` | Map merge: per-key sum. | `TaskRouter.AdminQueues` |
+
+`Claim` queries the local Pebble shard first (synchronously, no gRPC)
+and only fans out to peers when the local shard returns empty. With
+producer-local IDs (see §6) the local shard is usually non-empty for
+the worker pool co-located with the producers, so most claims never
+touch the network.
+
+### 3.3 Bloom gossip
+
+| RPC | Request | Response | Purpose |
+|---|---|---|---|
+| `BloomSnapshot` | `BloomSnapshotRequest{}` | `BloomSnapshotResponse{MBits, NumHashes, NumItems, Sequence, NodeId}` | Polled by `Gossiper.pollAll` once per second; replaces the local `BloomCache` entry for the responding peer. |
+
+See §4 for the gossip flow.
+
+## 4. Bloom gossip
+
+Each node maintains a local `*Bloom` of every task ID it currently holds
+in its Pebble shard. `Bloom.Add` is called on the Enqueue success path
+in both `Server.Enqueue` and `TaskRouter.EnqueueWithReady` (whichever
+landed on the local node). The filter is concurrent-safe via
+`atomic.OrUint64` on the bit-word slice and exposes a `Snapshot()`
+method that serialises the bits to little-endian bytes plus the
+parameters `(k, count, seq)`.
+
+A `Gossiper` (one goroutine per node) polls every peer once per
+`gossipInterval` (default 1s). The poll runs as a scatter-gather
+`BloomSnapshot` call, and each response is restored into the
+`BloomCache` keyed by `NodeId`.
+
+```mermaid
+sequenceDiagram
+  participant A as Node A (Gossiper)
+  participant B as Node B (Server)
+  participant C as Node C (Server)
+  participant CacheA as Node A BloomCache
+  loop every gossipInterval (1s)
+    A->>B: BloomSnapshot()
+    A->>C: BloomSnapshot()
+    B-->>A: {mBits, k, count, seq, nodeId=B}
+    C-->>A: {mBits, k, count, seq, nodeId=C}
+    A->>CacheA: Replace("B", bits, k, count, seq)
+    A->>CacheA: Replace("C", bits, k, count, seq)
+  end
+```
+
+Replace is no-op if the incoming `seq` is older than the cached one, so
+out-of-order responses don't poison the cache. Bloom shape
+(`expectedItems`, `fpRate`) is uniform across the cluster — mismatched
+sizes are silently rejected by `Bloom.Restore`, which makes rolling
+reconfigurations safe.
+
+> **Note**: gossip is **purely an optimisation**. If a peer has not yet
+> gossiped (`BloomCache.MaybeHas` returns `true` for an unknown peer),
+> the router falls back to the gRPC call. The bloom never produces a
+> false negative for the writer node — `Bloom.Add` is on the same code
+> path as the local Pebble write — but a peer's bloom can lag by up to
+> `gossipInterval` for IDs that were just enqueued elsewhere.
+
+## 5. Routing rules: a cross-node GetTask
+
+The router calls `r.ring.IsLocal(taskID)` first. If false, it consults
+`BloomCache.MaybeHas(owner, taskID)` and short-circuits to `not-found`
+when the bloom says definitely not. Otherwise it dials the owner.
+
+```mermaid
+sequenceDiagram
+  participant HTTP as HTTP / gRPC API (Node A)
+  participant RA as TaskRouter (Node A)
+  participant Cache as BloomCache (Node A)
+  participant Pool as ClientPool
+  participant SB as TaskNode Server (Node B)
+  participant PB as Pebble shard (Node B)
+  HTTP->>RA: Get(taskID)
+  RA->>RA: ring.IsLocal(taskID) = false
+  RA->>RA: owner = ring.Owner(taskID) = NodeB
+  RA->>Cache: MaybeHas("B", taskID)
+  alt bloom says "definitely not"
+    Cache-->>RA: false
+    RA-->>HTTP: not-found (no RPC)
+  else bloom says "maybe"
+    Cache-->>RA: true
+    RA->>Pool: Client(NodeB)
+    Pool-->>RA: TaskNodeClient
+    RA->>SB: GetTask(taskID)
+    SB->>PB: Tasks.Get(taskID)
+    PB-->>SB: *domain.Task or not-found
+    SB-->>RA: GetTaskResponse{Task or NotFound=true}
+    RA-->>HTTP: *domain.Task or "not-found"
+  end
+```
+
+The bloom is checked on **every** ID-routed RPC that has to leave the
+local node — not just GetTask. Heartbeat, Abandon, Nack, GetResult, and
+SaveResult-when-the-task-isn't-here all go through `peerHasLikely`.
+
+## 6. Phase 5: producer-local IDs
+
+In Phase 4 every Enqueue picked a UUID with random hash placement.
+Across N nodes that meant `(N-1)/N` of all `Enqueue` calls forwarded to
+a peer — for a 4-node cluster, 75% of creates paid a gRPC RTT before
+hitting durable storage.
+
+Phase 5 introduced `LocalRing.GenerateLocalID` ([`internal/cluster/ring.go`](../internal/cluster/ring.go)):
+
+```go
+func (l *LocalRing) GenerateLocalID(genID func() string) string {
+    const maxTries = 64
+    for range maxTries {
+        id := genID()
+        if l.IsLocal(id) {
+            return id
+        }
+    }
+    return genID()  // statistical fallback
+}
+```
+
+With a uniformly distributed 256-vnode ring, the expected number of
+candidate UUIDs before one hashes to the local node is `N` (one per
+cluster node). On a 4-node cluster that's an average of ~4 calls to
+`uuid.NewString` — negligible compared to the gRPC RTT it eliminates.
+
+`TaskRouter.EnqueueWithReady` calls `GenerateLocalID` before deciding
+local-vs-remote, so the local-branch is now hit on essentially every
+producer call:
+
+```go
+id := r.ring.GenerateLocalID(uuid.NewString)
+if r.ring.IsLocal(id) {
+    // hot path: no gRPC
+    return r.local.EnqueueWithID(ctx, id, ...)
+}
+// fallback: still correct, just rare
+owner := r.ring.Owner(id)
+c, _ := r.pool.Client(owner)
+return c.Enqueue(ctx, &clusterpb.EnqueueRequest{Id: id, ...})
+```
+
+Net effect on the cluster profile: the cross-node `Enqueue` count went
+from ~75% of creates to under 1% in our 4-node bench. The Claim fast
+path (already local-first) benefits as well — work produced on a node
+is overwhelmingly stored on the same node, so the same node's worker
+pool finds it without scatter-gather.
+
+## 7. Error handling
+
+The cluster has three classes of failures and one each of corresponding
+behaviour:
+
+### 7.1 Dial failure
+
+`ClientPool.Client(node)` calls `grpc.NewClient` lazily on first use. A
+dial failure returns `fmt.Errorf("dial %s (%s): %w", node.ID, node.GRPCAddr, err)`
+and the calling router propagates it to the caller. The connection is
+**not** cached, so the next call retries.
+
+ID-routed RPCs fail loud — the producer or worker sees the error and
+applies its own retry policy. Scatter-gather RPCs swallow per-node
+errors and continue with the remaining responses:
+
+```go
+for _, res := range results {
+    if res.Err != nil {
+        continue  // best-effort aggregate
+    }
+    // accumulate res.Value
+}
+```
+
+### 7.2 Peer down (context timeout)
+
+gRPC clients honour the caller's `context.Context` deadline. The HTTP
+handler that invoked the router typically wraps a per-request timeout
+(see [10-operations](./10-operations.md) for the timeout matrix).
+A peer that stops responding shows up as a `context.DeadlineExceeded`
+on the router side; same handling as a dial failure.
+
+For scatter-gather, the router uses `context.WithCancel(ctx)` so that
+once a winner is selected (Claim) the remaining in-flight RPCs get
+their context cancelled and stop waiting. Without that, a slow peer
+would block the response on the fastest one.
+
+### 7.3 Serialization errors
+
+The wire types in `clusterpb.proto` are intentionally narrow:
+
+- Task payloads travel as `bytes` (the producer-side JSON, opaque to the
+  proto layer).
+- Result bodies travel as `bytes result_json` — same shape — and are
+  unmarshalled lazily by `decodeResultJSON` on the receiver side.
+  Malformed JSON yields an empty `Result` map and the rest of the
+  record still propagates.
+- Timestamps use `google.protobuf.Timestamp`; zero values map to nil on
+  the wire and `time.Time{}` on the receiving side.
+
+There is no schema versioning yet — the cluster assumes a uniform
+binary across nodes. Rolling upgrades work as long as no proto field is
+deleted between adjacent versions; new fields are additive and
+proto3-default for older readers.
+
+## 8. Adding a new RPC
+
+The full path, in order:
+
+1. Add the request/response messages and `rpc` line to
+   [`internal/cluster/proto/clusterpb.proto`](../internal/cluster/proto/clusterpb.proto).
+   Decide upfront whether it's ID-routed (one peer) or scatter-gather
+   (every peer + aggregator).
+2. Re-run codegen (`make proto` or the project's `buf generate`
+   equivalent) to refresh `clusterpb.pb.go` and `clusterpb_grpc.pb.go`.
+3. Implement the server-side handler on `*Server` in
+   [`internal/cluster/server.go`](../internal/cluster/server.go) —
+   purely against the local Pebble repo, no fan-out.
+4. Implement the routing decision in
+   [`internal/cluster/router.go`](../internal/cluster/router.go) (or
+   `result_router.go` for the result side):
+   - ID-routed: `IsLocal` check, bloom short-circuit, `pool.Client`,
+     translate response flags to error sentinels.
+   - Scatter-gather: `pool.CallEach`, aggregate results.
+5. Cover both branches in `router_test.go` — there's a bufconn-based
+   harness that spins up a fake peer.
+6. Update this doc's catalog table.
+
+## See also
+
+- [Cluster architecture](./05-cluster-architecture.md) — deployment
+  model, membership, failover.
+- [Sharding](./06-sharding.md) — intra-process shards (the mutually
+  exclusive alternative to cluster mode).
+- [Pebble sharding internals](./08b-pebble-sharding-internals.md) —
+  what each shard stores and how the local repo is structured.
+- [Queue sharding HLD](./24-queue-sharding-hld.md) — the higher-level
+  design doc this protocol implements.

--- a/docs/_STYLE.md
+++ b/docs/_STYLE.md
@@ -1,0 +1,291 @@
+# codeq documentation style guide
+
+This is the canonical style guide for codeq documentation. Every doc in
+`docs/` and the root `README.md` must follow it. Subsequent waves of doc
+revisions cite this file verbatim where relevant (especially the value
+proposition and comparativos). If you change the value proposition here,
+you must update the docs that quote it.
+
+## 1. Value proposition
+
+### One-line
+
+> codeq is an embedded high-performance task queue: a single Go binary,
+> Pebble for persistence, gRPC streaming for the wire — 83k tasks/s on
+> one machine with zero external dependencies.
+
+### One-paragraph
+
+> codeq is a task queue written in Go that runs as a single process and
+> stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+> from CockroachDB). The hot path is bidirectional gRPC streams from
+> producers and workers; under the streams sits an intra-process shard
+> table (up to N independent Pebble instances) and an in-memory lease
+> table. The result on a 12-core Linux box is 83,420 tasks/s for the
+> full create → claim → complete cycle, or 136,392 creates/s producer-
+> only. No Redis, no broker, no coordinator required in the default
+> mode. Cluster (consistent-hash + gRPC routing) and a legacy Redis
+> backend are opt-in for HA and multi-node deployments.
+
+### Comparativos (use verbatim or as a base)
+
+| Dimension | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | None (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper or KRaft cluster |
+| Throughput (single node, full cycle) | 83k tasks/s | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | 100k+ msgs/s, but no task semantics |
+| Language affinity | Go (HTTP + gRPC; SDKs for Java, Node, Python, Go) | Go | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant native | Yes (JWT tenantId namespacing built in) | No | No | No | No |
+| Learning curve | One binary, HTTP + curl in minutes | Moderate (Redis ops) | Moderate (Node + Redis) | High (broker + result backend) | High (broker, consumer groups, schema registry) |
+
+When citing this table in a doc, link back here:
+
+> See [_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## 2. Audience profile
+
+Primary reader: **backend engineer evaluating alternatives to Redis-backed
+task queues**. They are typically deciding between Asynq (Go + Redis),
+BullMQ (Node + Redis), Celery (Python + broker), Sidekiq (Ruby + Redis),
+Temporal (workflow engine), and Kafka (event log used as a queue).
+
+What they care about, ranked:
+
+1. **Throughput** — concrete numbers, harness names, and the box they
+   were measured on. No "blazing fast", no "10x". Cite the benchmark.
+2. **Operational cost** — how many processes, how many config knobs, how
+   long until they can `curl` a task.
+3. **Language affinity** — Go server, but with first-class SDKs for the
+   reader's stack.
+4. **Durability and at-least-once** — what survives a crash, and how
+   they prove it.
+5. **Multi-tenant** — whether they can run one queue server for many
+   customers without writing isolation themselves.
+6. **HA and scaling story** — single-node first, but with a credible
+   path to multi-node.
+
+Write for someone who already understands queues. Skip onboarding to
+basic concepts like "what is a task". Do define codeq-specific terms
+(shard, lease table, ring, scatter-gather) the first time they appear.
+
+## 3. Voice and tone
+
+### Numbers first, narrative second
+
+Bad:
+
+> codeq is blazing fast and can handle massive workloads.
+
+Good:
+
+> codeq sustains 83,420 tasks/s for a full create → claim → complete
+> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
+> batch=8, 128 worker slots, 20s measurement window
+> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
+
+Every throughput claim cites:
+
+- The exact test name in `internal/bench/`.
+- The env vars used to parameterize it.
+- The hardware class (cores, OS).
+- The measurement window.
+
+### Honest about limitations
+
+Always name the trade-offs. Examples to use as templates:
+
+- "HA is only available via the Redis backend or by running a cluster of
+  Pebble nodes. A single Pebble process loses availability while it
+  restarts; recovery is fast (in-memory lease table rebuilt from the
+  `KeyInprog` scan at Open) but not instantaneous."
+- "Cluster mode and intra-process sharding (`numShards > 1`) are
+  mutually exclusive — startup panics if both are enabled. Pick one:
+  multi-node across machines, or multi-shard inside one process."
+- "Delivery is at-least-once, not exactly-once. A worker that crashes
+  between completion and ACK will see its task re-delivered after the
+  lease expires."
+
+### No marketing fluff
+
+Banned words: blazing, massive, lightning, seamless, robust,
+cutting-edge, world-class, next-gen, revolutionary.
+
+Replace adjectives with measurements. If you cannot measure it, do not
+claim it.
+
+### Opinionated
+
+Tell the reader what to pick:
+
+- "For single-node deployments use Pebble with `numShards: 4`."
+- "Do not enable `fsyncOnCommit` unless you have measured the latency
+  impact in your workload — it costs ~20% throughput in our harness."
+- "Use Redis only if you need multi-node HA today and cannot deploy the
+  cluster mode."
+
+## 4. Markdown conventions
+
+- **Headings**: ATX style (`#`), single `#` per file (the title), then
+  `##` for top-level sections, `###` for subsections. Do not skip
+  levels.
+- **Code blocks**: always tag the language.
+  - `bash` for shell, `go` for Go, `yaml` for config, `json` for JSON,
+    `protobuf` for `.proto`, `mermaid` for diagrams.
+  - Untagged blocks are forbidden — they break syntax highlighting on
+    GitHub.
+- **Admonitions** (GitHub-flavored):
+
+  ```markdown
+  > **Note**: a normal aside.
+  > **Warning**: a footgun. Always for irreversible operations or
+  > silent data loss.
+  > **Performance**: a tuning hint with a number.
+  ```
+
+- **Tables**: pipe-aligned, header row separator `---`. Always have a
+  header row. Cells with multi-word values stay on one line.
+- **Inline code**: backticks for file paths, env vars, config keys,
+  function names, and protocol constants.
+- **Lists**: `-` for unordered, `1.` for ordered. Two spaces of
+  indentation for nested items.
+- **Links**: prefer descriptive text over "click here". Relative links
+  for in-repo references (see §6).
+
+## 5. Mermaid conventions
+
+All diagrams must render on the GitHub default theme in both light and
+dark mode. **Never set inline colors or styles** — let the renderer
+pick.
+
+### Flow diagrams
+
+Use `graph TB` for top-to-bottom layered architecture, `graph LR` for
+left-to-right pipelines. Always use `subgraph` to delimit logical
+layers.
+
+```mermaid
+graph TB
+  subgraph Producers
+    P1[Producer SDK]
+  end
+  subgraph Server[codeq server]
+    HTTP[HTTP API]
+    GRPC[gRPC stream]
+  end
+  subgraph Storage
+    PEB[Pebble shards]
+  end
+  P1 --> GRPC
+  GRPC --> PEB
+  HTTP --> PEB
+```
+
+Aim for 8 to 12 nodes max in a single diagram. If it grows past that,
+split it.
+
+### Sequence diagrams
+
+Use `sequenceDiagram` for flows over time. Participant names start
+capitalized.
+
+```mermaid
+sequenceDiagram
+  participant Producer
+  participant Server
+  participant Pebble
+  Producer->>Server: Produce(task)
+  Server->>Pebble: BatchCommit
+  Pebble-->>Server: ack
+  Server-->>Producer: TaskID
+```
+
+### State machines
+
+Use `stateDiagram-v2` for task lifecycle. Transition labels describe
+the **trigger action**, not the resulting state.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  DLQ --> [*]
+```
+
+### No inline colors
+
+Bad:
+
+```text
+style P1 fill:#f9f,stroke:#333
+```
+
+Good: nothing — let the theme decide.
+
+## 6. Cross-link policy
+
+Every doc ends with a `## See also` section enumerating related docs.
+Example:
+
+```markdown
+## See also
+
+- [Architecture](./03-architecture.md)
+- [Storage layout (Pebble)](./07b-storage-pebble.md)
+- [Performance tuning](./17-performance-tuning.md)
+```
+
+Path conventions:
+
+- **Inside `docs/`** (doc-to-doc): use relative paths starting with
+  `./`, e.g. `[Overview](./01-overview.md)`.
+- **From root `README.md`** (or other root-level files): use paths
+  rooted at `docs/`, e.g. `[Overview](docs/01-overview.md)`.
+- **To source files**: use repo-rooted paths, e.g.
+  `[application.go](../pkg/app/application.go)` from inside `docs/`, or
+  `pkg/app/application.go` from `README.md`.
+- **Anchors**: lowercase, hyphen-separated, match GitHub's slug
+  algorithm.
+
+When you cite the value prop, link to this file:
+
+```markdown
+See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+```
+
+## 7. Numbers must come from measurement
+
+Every throughput, latency, or memory claim in any doc must be traceable
+to a test in `internal/bench/`. The format is:
+
+> N tasks/s (`internal/bench/<file>.go::<TestName>`, env: `KEY=VAL`,
+> hardware: 12-core Linux).
+
+Catalog of canonical benchmarks (use these names, do not invent new
+ones):
+
+| Workload | Harness | Result on reference box |
+|---|---|---|
+| Full cycle, 4 shards, batched | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) | 83,420 tasks/s |
+| Producer-only, batched stream | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` | 136,392 creates/s |
+| Worker-only, batched stream | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) | 23,518 tasks/s |
+| Shard sweep | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=1,2,4,6,8`) | 42k / 65k / 83k / 68k / 67k |
+
+Reference box: 12-core Linux (kernel 5.15, WSL2-compatible), Go 1.25.0,
+local Pebble, loopback gRPC, no fsync.
+
+If you need a number that is not in this table, run the bench, add the
+row here, then cite it in your doc. Do not estimate.
+
+## See also
+
+- [README](../README.md) — applies this style guide at the entry point.
+- [Overview](./01-overview.md) — the canonical statement of what codeq
+  is.
+- [Architecture](./03-architecture.md) — package-level breakdown.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and historical numbers.


### PR DESCRIPTION
## Summary

- New `docs/19b-cluster-grpc-protocol.md` (385 lines) — reference for `internal/cluster/proto/clusterpb.proto`, the codeq-to-codeq wire protocol used between nodes in cluster mode.
- Three mermaid diagrams (cluster topology graph TB, cross-node GetTask sequenceDiagram, bloom gossip sequenceDiagram) — all GitHub light/dark safe with no inline colors per `_STYLE.md`.
- Covers RPC catalog (ID-routed and scatter-gather), bloom gossip, routing rules, Phase 5 producer-local IDs (`LocalRing.GenerateLocalID` — eliminated ~75% of cross-node Enqueue calls), error handling, and an "adding a new RPC" runbook.
- Cites `internal/cluster/proto/clusterpb.proto`, `server.go`, `router.go`, `ring.go`, `bloom.go`, `bloom_cache.go`, `client.go`.
- See-also: 05-cluster-architecture, 06-sharding, 08b-pebble-sharding-internals (cited per task even if produced by a sibling wave), 24-queue-sharding-hld.

Base branch: `docs/wave1-u1-foundation` (Wave 1 foundation; will be retargeted to `main` when the wave merges).

## Test plan

- [ ] `_STYLE.md` compliance: ATX headings, language-tagged code blocks, no banned marketing words, relative `./` links inside `docs/`.
- [ ] All three mermaid blocks render on GitHub default theme (light + dark).
- [ ] RPC catalog tables match `internal/cluster/proto/clusterpb.proto` field names and `internal/cluster/server.go` / `router.go` code paths.
- [ ] Phase 5 producer-local IDs section accurately describes `LocalRing.GenerateLocalID` (64-try cap, statistical fallback).
- [ ] Cross-links resolve (anchors lowercase-hyphenated).

Reviewer focus: technical accuracy of the catalog tables vs the live proto + handlers.

Generated with [Claude Code](https://claude.com/claude-code)