### PR TITLE
docs(wave4-u20): add 3 Mermaid diagrams to 07b-storage-pebble

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,108 @@
-# codeQ
+# codeq
 
-Reactive scheduling and completion system backed by persistent queues. Choose your storage: KVRocks (distributed) or Pebble (embedded).
+> Embedded high-performance task queue. One Go binary, Pebble for
+> storage, gRPC streams on the wire. 83k tasks/s on a single 12-core
+> box with zero external dependencies.
 
-This repository contains the core runtime, HTTP API wiring, and a Helm chart for small clusters.
-The production service wrapper lives at:
-https://github.com/codecompany/codeq-service
+[![Go Reference](https://pkg.go.dev/badge/github.com/osvaldoandrade/codeq.svg)](https://pkg.go.dev/github.com/osvaldoandrade/codeq)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Issues](https://img.shields.io/github/issues/osvaldoandrade/codeq.svg)](https://github.com/osvaldoandrade/codeq/issues)
 
-## Links
+## What is codeq?
 
-- GitHub: https://github.com/osvaldoandrade/codeq
-- Issues: https://github.com/osvaldoandrade/codeq/issues
-- Specs index: `docs/README.md`
+codeq is a task queue written in Go. The default deployment is a single
+process: the server, the persistence layer (Pebble, the RocksDB-style
+LSM from CockroachDB), the lease table, and the gRPC + HTTP API all
+share one binary and one disk directory. There is no Redis to run, no
+broker to babysit, no consensus to coordinate.
 
-## Why codeQ
+On a 12-core Linux box, that single binary sustains **83,420 tasks/s**
+for the full create → claim → complete cycle and **136,392 creates/s**
+for producer-only workloads — measured by the in-tree benchmarks in
+`internal/bench/`. When one machine is no longer enough, cluster mode
+(consistent-hash ring + gRPC routing between nodes) and a legacy Redis
+backend are opt-in.
 
-codeQ provides:
+## Architecture overview
 
-- Persistent queues with pluggable storage backends:
-  - **Redis/KVRocks** (distributed, cluster-capable)
-  - **Pebble** (embedded, zero-dependency, ideal for local development)
-- Pull-based worker claims with leases.
-- **Multi-tenant queue isolation** with automatic tenant ID extraction from JWT claims.
-- **Horizontal scaling with queue sharding**: Optional pluggable `ShardSupplier` interface for routing commands/tenants across multiple KVRocks instances.
-- **Pluggable persistence backends**: Redis, memory (testing), and extensible plugin architecture for custom storage (PostgreSQL, DynamoDB, Cassandra, etc.).
-- NACK + backoff + delayed queues.
-- DLQ for tasks that exceed `maxAttempts`.
-- Result storage and optional callbacks (webhooks).
-- Worker auth via JWT (JWKS), producer auth via Tikti access tokens (JWKS).
-- **Official SDKs** for Java and Node.js/TypeScript with framework integrations.
-- **Distributed tracing** with OpenTelemetry support for end-to-end observability.
-- **Optimized performance**: O(1) queue operations with pipelined lease repair for low-latency claims even under high load.
-- **Load testing framework**: Comprehensive k6 scenarios and Go benchmarks for performance validation and regression testing.
+```mermaid
+graph TB
+  subgraph Clients
+    PSDK[Producer SDK]
+    WSDK[Worker SDK]
+    CURL[HTTP / curl]
+  end
+  subgraph Server[codeq server -- single binary]
+    HTTP[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+  end
+  subgraph Storage[Embedded persistence]
+    P0[Pebble shard 0]
+    P1[Pebble shard 1]
+    PN[Pebble shard N-1]
+  end
+  subgraph Optional[Opt-in scaling]
+    CL[Cluster -- consistent-hash + gRPC]
+    REDIS[Redis backend -- legacy HA]
+  end
+  PSDK --> PGRPC
+  WSDK --> WGRPC
+  CURL --> HTTP
+  HTTP --> LEASE
+  PGRPC --> LEASE
+  WGRPC --> LEASE
+  LEASE --> P0
+  LEASE --> P1
+  LEASE --> PN
+  Server -.-> CL
+  Server -.-> REDIS
+```
 
-## Get started
+Producers and workers connect over long-lived bidirectional gRPC
+streams. Each request hits the in-memory lease table first, then commits
+to a Pebble shard chosen by `hash(taskID) % N`. Each shard runs its own
+commit pipeline and compaction loop, which is what lets a 4-shard
+configuration roughly double the single-shard throughput on the same
+hardware.
 
-### Local development with Docker Compose
+## Performance
 
-The quickest way to try codeQ locally:
+All numbers measured on a 12-core Linux box, Go 1.25.0, loopback gRPC,
+Pebble with `fsyncOnCommit=false`. Full bench harness lives in
+`internal/bench/`.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle (create + claim + complete), 4 Pebble shards | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| Worker-only, batched claim+complete | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep (full cycle, 1 / 2 / 4 / 6 / 8 shards) | 42k / 65k / **83k** / 68k / 67k tasks/s | same as full cycle harness with `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on a 12-core box; past that, write
+amplification and goroutine contention start to dominate. See
+[docs/30-performance-baselines.md](docs/30-performance-baselines.md)
+for raw output and per-release history.
+
+## Why codeq vs alternatives
+
+| Feature | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | **None** (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper / KRaft cluster |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | n/a (no task semantics) |
+| Language affinity | Go server, SDKs for Java, Node, Python, Go | Go only | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant isolation | **Built in** (JWT tenantId namespacing) | DIY | DIY | DIY | DIY |
+| Time-to-first-task | `docker run` + `curl` | Run Redis + Asynq | Run Redis + worker | Run broker + workers + result backend | Multi-step cluster bootstrap |
+
+codeq is the right call when you want task-queue semantics (claims,
+leases, retries, DLQ, results) without standing up a broker. It is the
+wrong call if you need Kafka-scale event streaming, distributed
+consensus by default, or HA without configuring the Redis backend or
+cluster mode.
+
+## Quick start (5 minutes)
 
 ```bash
 git clone https://github.com/osvaldoandrade/codeq
@@ -47,125 +113,10 @@ docker compose \
   up -d
 ```
 
-This starts KVRocks, the codeQ API server, and seeds example tasks. Access at `http://localhost:8080`.
+This brings up the codeq server on `http://localhost:8080` with the
+embedded Pebble backend (no Redis required) and seeds example tasks.
 
-See [Local Development Guide](docs/22-local-development.md) for details on hot reload, testing, and observability.
-
-### Install a server
-
-Use the console wizard to generate a Docker or Kubernetes/Helm install bundle:
-
-```bash
-codeq install
-```
-
-Non-interactive Kubernetes example:
-
-```bash
-codeq install \
-  --target kubernetes \
-  --size small \
-  --namespace codeq \
-  --identity-service-url https://issuer.example.com \
-  --worker-jwks-url https://issuer.example.com/.well-known/jwks.json \
-  --worker-issuer https://issuer.example.com
-```
-
-### Install CLI (macOS/Linux/Windows via Git Bash)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
-```
-
-Requires `git` and `go`.
-
-### Install CLI via npm (npmjs)
-
-```bash
-npm i -g @osvaldoandrade/codeq
-codeq --help
-```
-
-Upgrade:
-
-```bash
-npm i -g @osvaldoandrade/codeq@latest
-```
-
-### Use SDKs for Java, Node.js, Python, and Go
-
-Integrate codeQ into your microservices with official SDKs:
-
-**Java** (Spring Boot, Quarkus, Micronaut):
-```xml
-<dependency>
-    <groupId>io.codeq</groupId>
-    <artifactId>codeq-sdk-java</artifactId>
-    <version>1.0.0</version>
-</dependency>
-```
-
-**Node.js/TypeScript** (Express, NestJS):
-```bash
-npm install @osvaldoandrade/codeq-client
-```
-
-**Python** (FastAPI, Django, Flask):
-```bash
-pip install codeq-client
-```
-
-**Go** (Gin, Echo, stdlib):
-```bash
-go get github.com/osvaldoandrade/codeq/sdks/go
-```
-
-📚 **SDK Documentation**:
-- [SDK Overview & Quick Start](sdks/README.md)
-- [Java SDK](sdks/java/README.md)
-- [Node.js SDK](sdks/nodejs/README.md)
-- [Python SDK](sdks/python/README.md)
-- [Go SDK](sdks/go/README.md)
-- [Integration Guides](docs/integrations/)
-- [Example Applications](examples/)
-
-### Helm
-
-The chart in this repo deploys codeQ and, by default in the small profile, a single-node KVRocks instance.
-
-```bash
-git clone https://github.com/osvaldoandrade/codeq
-cd codeq
-
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-small.yaml \
-  --namespace codeq --create-namespace \
-  --set secrets.enabled=true \
-  --set secrets.webhookHmacSecret=YOUR_SECRET \
-  --set config.identityServiceUrl=https://your-auth-server.com \
-  --set config.workerJwksUrl=https://your-jwks \
-  --set config.workerIssuer=https://issuer
-```
-
-Disable embedded KVRocks and point to your own:
-
-```bash
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-medium.yaml \
-  --set kvrocks.enabled=false \
-  --set config.redisAddr=your-kvrocks:6666
-```
-
-### 2) Service runtime
-
-The API server and Dockerfile are in the service repo:
-https://github.com/codecompany/codeq-service
-
-That repo consumes this module and exposes the HTTP API.
-
-## Quick API flow
-
-Create a task (producer token):
+Create a task:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks \
@@ -174,7 +125,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"priority":3}'
 ```
 
-Claim a task (worker JWT):
+Claim a task (as a worker):
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
@@ -183,7 +134,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
   -d '{"commands":["GENERATE_MASTER"],"leaseSeconds":120,"waitSeconds":10}'
 ```
 
-Submit result:
+Submit a result:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
@@ -192,49 +143,95 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
   -d '{"status":"COMPLETED","result":{"ok":true}}'
 ```
 
-## Specs and docs
+For high-throughput producers and workers, use the gRPC streaming API
+(2-3x the HTTP throughput, amortized auth, pipelined acks): see
+[docs/34-streaming-api-guide.md](docs/34-streaming-api-guide.md).
 
-Start here: `docs/README.md`
+## Where next
 
-Key references:
+- [Getting started tutorial](docs/00-getting-started.md) — your first
+  task, end to end.
+- [Overview](docs/01-overview.md) — goals, non-goals, when (and when
+  not) to pick codeq.
+- [Architecture](docs/03-architecture.md) — package layout and request
+  flows.
+- [Performance tuning](docs/17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Operational runbooks](docs/29-operational-runbooks.md) — on-call
+  procedures for the common failure modes.
+- [Streaming API guide](docs/34-streaming-api-guide.md) — gRPC
+  producer and worker streams.
+- [Cluster architecture](docs/05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Style guide](docs/_STYLE.md) — voice, numbers, diagrams, links.
 
-- **Getting Started Tutorial**: `docs/00-getting-started.md` - **Start here for your first experience with codeQ**
-- **Overview**: `docs/01-overview.md` - System goals and design principles
-- **Architecture**: `docs/03-architecture.md` - System components and multi-tenant architecture
-- **Security**: `docs/09-security.md` - Authentication, authorization, and tenant isolation
-- **HTTP API**: `docs/04-http-api.md` - Complete API reference
-- **CLI Reference**: `docs/15-cli-reference.md` - CLI command documentation
-- **SDK Integration**: `sdks/README.md` - Official Java and Node.js SDKs
-  - [Java Integration](docs/integrations/java-integration.md) - Spring Boot, Quarkus, Micronaut
-  - [Node.js Integration](docs/integrations/nodejs-integration.md) - Express, NestJS, React
-- **Examples**: `examples/` - Working examples with Java and Node.js frameworks
-- **Developer Guide**: `docs/21-developer-guide.md` - Contributing and internal architecture
-- **Queue model**: `docs/05-queueing-model.md` - Queue semantics
-- **Storage layout**: `docs/07-storage-kvrocks.md` - KVRocks data structures
-- **Backoff and retries**: `docs/11-backoff.md` - Retry logic
-- **Webhooks**: `docs/12-webhooks.md` - Push notifications
-- **Configuration**: `docs/14-configuration.md` - Config reference
-- **Operations**: `docs/10-operations.md` - Metrics, health checks, and tracing
-- **Workflows**: `docs/16-workflows.md` - GitHub Actions automation
-- **Performance**: `docs/17-performance-tuning.md` - Optimization guide
-- **Load Testing**: `docs/26-load-testing.md` - Load testing framework and benchmarks
-- **Testing**: `docs/19-testing.md` - Test coverage and strategy
-- **Authentication Plugins**: `docs/20-authentication-plugins.md` - Plugin system for custom auth
-- **Persistence Plugins**: `docs/27-persistence-plugin-system.md` - Pluggable storage backends (Redis, Memory, and more)
-- **Design Documents**:
-  - `docs/24-queue-sharding-hld.md` - Queue sharding high-level design
-  - `docs/25-plugin-architecture-hld.md` - Plugin architecture for persistence and auth
-- **Migration**: `docs/migration.md` - Upgrade guide
-- **Contributing**: `CONTRIBUTING.md` - Contribution guidelines
+## SDKs
+
+Official client libraries for the languages most likely to talk to
+codeq from application code:
+
+- **Go** — `go get github.com/osvaldoandrade/codeq/sdks/go` ([README](sdks/go/README.md))
+- **Java** (Spring Boot, Quarkus, Micronaut) — [sdks/java/README.md](sdks/java/README.md)
+- **Node.js / TypeScript** (Express, NestJS) — [sdks/nodejs/README.md](sdks/nodejs/README.md)
+- **Python** (FastAPI, Django, Flask) — [sdks/python/README.md](sdks/python/README.md)
+
+Integration recipes per framework live under
+[docs/integrations/](docs/integrations/). End-to-end example apps live
+under [examples/](examples/).
 
 ## Repo layout
 
-- `pkg/`: public packages (`app`, `config`, `domain`)
-- `internal/`: controllers, middleware, services, repositories, providers
-- `deploy/`: Docker Compose, Kubernetes, and config examples
-- `helm/codeq`: Helm chart and size profiles
-- `docs/`: full specification
+```text
+cmd/                  CLI entrypoints (codeq install, server)
+internal/             unexported packages
+  bench/              throughput + latency benchmarks (source of truth for perf claims)
+  cluster/            consistent-hash ring, gRPC router, bloom gossip
+  controllers/        HTTP handlers (Gin)
+  middleware/         auth, tracing, rate-limit, tenant extraction
+  producer/           gRPC producer-stream server
+  worker/             gRPC worker-stream server
+  repository/         persistence implementations (Redis legacy + Pebble)
+  services/           scheduler, results, callbacks, subscriptions
+pkg/                  public packages (app, auth, config, domain,
+                      producerclient, workerclient)
+sdks/                 official SDKs (go, java, nodejs, python)
+deploy/               docker-compose and Kubernetes config
+helm/codeq/           Helm chart and size profiles
+docs/                 specifications, runbooks, performance baselines
+examples/             end-to-end example applications
+```
+
+## Install the CLI
+
+macOS, Linux, or Windows via Git Bash:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
+```
+
+Or via npm:
+
+```bash
+npm i -g @osvaldoandrade/codeq
+codeq --help
+```
+
+To generate a Docker or Kubernetes install bundle (with embedded Pebble
+by default, no Redis required):
+
+```bash
+codeq install
+```
+
+See [docs/15-cli-reference.md](docs/15-cli-reference.md) for the full
+CLI surface.
+
+## Contributing
+
+Issues and PRs are welcome. Before opening a PR, read
+[CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, and
+[docs/_STYLE.md](docs/_STYLE.md) for the documentation style.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,27 +1,244 @@
 # Overview
 
-codeQ is a task scheduling and completion service built on persistent queues in KVRocks. The service exposes HTTP APIs for producers to create tasks, for workers to claim and complete tasks, and for operators to inspect and clean up queues. The system is reactive: workers pull tasks, and optionally receive webhook signals that work is available.
+> Source-of-truth for the value proposition lives in
+> [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+> Other docs may cite this overview, but the style guide wins ties.
 
-The design is inspired by Dyno Queues, which adds time-based and priority queues on top of Dynomite. Dynomite is a distributed data layer that exposes Redis semantics and provides multi-datacenter replication. codeQ applies the same motivation to KVRocks and uses Go for the implementation. The service favors availability and throughput over strict global ordering.
+## What is codeq
+
+codeq is a task queue written in Go that runs as a single process and
+stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+from CockroachDB). The hot path is bidirectional gRPC streams from
+producers and workers; under the streams sits an intra-process shard
+table (up to N independent Pebble instances) and an in-memory lease
+table. On a 12-core Linux box the single binary sustains
+**83,420 tasks/s** for the full create → claim → complete cycle and
+**136,392 creates/s** for producer-only workloads.
+
+No Redis, no broker, no coordinator required in the default mode.
+Cluster (consistent-hash ring + gRPC routing) and a legacy Redis backend
+are opt-in for HA and multi-node deployments.
 
 ## Goals
 
-- Provide a stable API for enqueue, claim, and completion.
-- Persist state on disk via KVRocks.
-- Support delayed retries, priority, and retries.
-- Allow workers to pull by event type without a worker registry.
-- Provide optional push notifications without assigning work.
+- **Single binary.** Server, persistence, lease table, HTTP + gRPC API
+  all in one process. One disk directory. One systemd unit. No external
+  database required.
+- **80k+ tasks/s on one machine.** Full create → claim → complete cycle
+  measured by `internal/bench/profile_full_cycle_test.go` with 4 Pebble
+  shards, batched producer + worker streams.
+- **gRPC streaming as a first-class API.** Long-lived bidirectional
+  streams amortize auth and middleware; multiple requests can be in
+  flight before responses arrive.
+- **Multi-tenant by construction.** Every queue key is namespaced by
+  `tenantId` extracted from the JWT. Workers can only claim tasks from
+  their own tenant. No application code required to keep tenants
+  isolated.
+- **Cluster opt-in.** When one machine is no longer enough, run a
+  consistent-hash cluster (no consensus, no coordinator — static
+  membership + gRPC routing).
+- **Configurable durability.** `fsyncOnCommit` is a per-deployment knob.
+  Off by default for throughput; turn it on when your SLO demands it.
 
 ## Non-goals
 
-- Exactly-once processing.
-- Global FIFO across all commands.
-- Automatic worker discovery or scheduling.
+- **Kafka-scale event streaming.** codeq is a task queue, not a
+  partitioned log. If you want millions of messages/s with consumer
+  groups, use Kafka.
+- **Distributed consensus by default.** No Raft, no Paxos. Cluster mode
+  uses a static consistent-hash ring; node membership is configured at
+  startup, not gossiped.
+- **HA without explicit setup.** A single Pebble process loses
+  availability while it restarts. HA requires either the Redis backend
+  (legacy, multi-node) or running a cluster of Pebble nodes — each is a
+  trade-off the operator picks consciously.
+- **Exactly-once delivery.** Delivery is at-least-once. A worker that
+  crashes between completion and ACK will see the task re-delivered
+  after the lease expires.
+- **Global FIFO across all commands.** Ordering is per-(command,
+  tenant, priority) within a Pebble shard. Cross-shard ordering is not
+  defined.
+- **Worker discovery or scheduling.** codeq does not register workers
+  or assign work; workers pull when they are ready.
 
-## High-level data model
+## Data model summary
 
-- Task: unit of work, identified by UUID.
-- Message: queue element containing metadata used by the scheduler.
-- Result: completion record stored independently of the task body.
-- Command (event type): routing key for tasks.
-- Shard: not implemented; queues are single-shard in the current service.
+- **Task** — unit of work. Identified by UUID. Carries `command`
+  (routing key), `payload` (opaque JSON bytes), `priority` (0-9),
+  optional `webhook` URL, and lifecycle state.
+- **Result** — completion record. Stored separately from the task body
+  so completion can be GC'd on a different schedule than the task
+  metadata.
+- **Subscription** — webhook registration. A worker (or coordinator)
+  registers a callback URL for one or more event types; codeq pings it
+  when new work appears.
+
+Task lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> FAILED: SubmitResult(err)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DELAYED: Nack(backoff)
+  DELAYED --> PENDING: MoveDueDelayed
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  FAILED --> [*]
+  DLQ --> [*]
+```
+
+Full schema and state semantics in
+[02-domain-model.md](./02-domain-model.md).
+
+## Architecture summary
+
+```mermaid
+graph TB
+  subgraph Clients
+    SDK[Producer / Worker SDKs]
+    HTTPCLI[HTTP clients -- curl, browsers]
+  end
+  subgraph Server[codeq server]
+    API[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+    SCHED[Scheduler core]
+  end
+  subgraph Storage[Embedded persistence -- default]
+    P[Pebble shards 0..N-1]
+  end
+  subgraph OptIn[Opt-in modes]
+    CL[Cluster -- consistent-hash + gRPC routing]
+    REDIS[Redis backend -- legacy, HA]
+  end
+  SDK --> PGRPC
+  SDK --> WGRPC
+  HTTPCLI --> API
+  API --> SCHED
+  PGRPC --> SCHED
+  WGRPC --> SCHED
+  SCHED --> LEASE
+  SCHED --> P
+  Server -.-> CL
+  Server -.-> REDIS
+```
+
+Request flow at a glance:
+
+1. Producer or worker opens a gRPC stream (or sends an HTTP request).
+2. The middleware chain validates the JWT, extracts `tenantId`, and
+   applies rate limits.
+3. The scheduler routes the operation to its Pebble shard
+   (`hash(taskID) % numShards`) and updates the in-memory lease table.
+4. Pebble commits the batch; the group-commit coalescer (Phase 1.1)
+   merges concurrent writers into one fsync.
+5. On worker stream, ready tasks are pushed back through the same long-
+   lived connection — no per-claim handshake.
+
+Package-level breakdown in [03-architecture.md](./03-architecture.md).
+
+## When to use codeq
+
+- **Single-node task queue for a backend service.** You want claims,
+  leases, retries, DLQ, and results without standing up Redis or a
+  broker.
+- **Embedded sidecar in your own Go binary.** Import `pkg/app` and run
+  codeq in-process alongside your application.
+- **Multi-tenant SaaS background jobs.** Per-tenant queue isolation is
+  built in; you do not have to namespace keys yourself.
+- **High-throughput producers with small payloads.** The batched
+  producer stream sustains 100k+ creates/s on commodity hardware.
+- **Polyglot worker fleets.** Workers in Go, Java, Node, or Python can
+  all share the same queue via the official SDKs.
+- **Local development without external services.** `docker run codeq`
+  is enough; no Redis container, no compose dance.
+
+## When NOT to use codeq
+
+- **Kafka-scale event streaming.** Millions of events/s with consumer
+  groups, replay, and a retention window measured in days — use Kafka.
+- **Distributed transactions.** codeq has no two-phase commit and no
+  cross-shard transactions. If your business logic needs atomic updates
+  across multiple tasks, build it above codeq with an outbox pattern or
+  pick a workflow engine.
+- **HA without Redis or cluster mode.** A single Pebble process is
+  unavailable during restart. If your SLO does not tolerate a few
+  seconds of unavailability, you need the Redis backend (multi-node) or
+  a Pebble cluster.
+- **Workflow orchestration with branching, child tasks, timers, and
+  long-running state.** Use Temporal, Cadence, or Step Functions — they
+  are purpose-built for that. codeq is a queue.
+- **Exactly-once delivery semantics.** codeq is at-least-once. Idempotent
+  handlers are the operator's responsibility.
+
+## Performance baselines
+
+Measured on a 12-core Linux box, Go 1.25.0, loopback gRPC, Pebble with
+`fsyncOnCommit=false`, 20s measurement window after a 2s warm-up.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle, 4 shards, batched | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (32 goroutines, batch=16) |
+| Worker-only, batched stream | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep | 1 shard: 42k; 2: 65k; **4: 83k**; 6: 68k; 8: 67k | same as full cycle, `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on this hardware. Past that, the cost of more
+commit pipelines + compaction loops outweighs the parallelism win. See
+[30-performance-baselines.md](./30-performance-baselines.md) for raw
+output, allocator stats, and the per-release history.
+
+## Comparativos resumidos
+
+| Dimension | codeq | Asynq | BullMQ | Kafka |
+|---|---|---|---|---|
+| External dependency | **None** | Redis | Redis | ZooKeeper / KRaft |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k | ~5k | n/a (no task semantics) |
+| Language | Go server, multi-language SDKs | Go | Node | Polyglot |
+| Multi-tenant native | **Yes** | DIY | DIY | DIY |
+| HA model | Cluster or Redis (opt-in) | Redis | Redis | Replicated log |
+
+Full table with Sidekiq, Celery, and Temporal lives in
+[_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## What changed (Phases 1-8 summary)
+
+codeq has been through a sequence of refactors that shifted its
+positioning from "Redis-backed queue" to "embedded high-performance
+queue". The short version:
+
+| Phase | Theme | Effect |
+|---|---|---|
+| 0 | kvrocks-primary | First version: KVRocks (Redis protocol) as the only backend. ~1.5-2k tasks/s. |
+| 1 | Pebble embedded backend | Pebble added as a pluggable persistence provider. Single-binary deployment becomes possible. Single-shard throughput ~42k tasks/s. |
+| 1.1 | Pebble fast-paths + group-commit coalescer | `MoveDueDelayed` fast-path; concurrent writers coalesce into one fsync. |
+| 2 | Streaming groundwork | gRPC streaming surfaces designed. Auth amortized across stream lifetime. |
+| 5 | Cluster mode | Consistent-hash ring + gRPC routing between Pebble nodes. No consensus; static membership. |
+| 6 | Batched stream paths | Producer and worker streams gain batch APIs. `PHASE6_BATCH` / `PHASE6_PROD_BATCH` env knobs. |
+| 8 | Intra-process Pebble sharding | `numShards` opens N independent Pebble instances under one process. 4 shards → ~83k tasks/s on a 12-core box. **Mutually exclusive with cluster mode.** |
+
+PRs #527-#547 landed Phases 1.1, 6, and 8. The Redis backend remains
+supported for HA scenarios but is no longer the default.
+
+## See also
+
+- [_STYLE.md](./_STYLE.md) — documentation voice, numbers, diagrams.
+- [Architecture](./03-architecture.md) — package layout and request
+  flows.
+- [HTTP API](./04-http-api.md) — REST surface.
+- [Streaming API guide](./34-streaming-api-guide.md) — gRPC producer
+  and worker streams.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and per-release history.
+- [Performance tuning](./17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Cluster architecture](./05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Storage layout (Pebble)](./07b-storage-pebble.md) — keyspace and
+  sharding internals.
+- [Persistence plugin system](./27-persistence-plugin-system.md) —
+  choosing and configuring backends.

--- a/docs/07b-storage-pebble.md
+++ b/docs/07b-storage-pebble.md
@@ -28,14 +28,56 @@ Pebble keys use a flat namespace with hierarchical prefixes optimized for LSM-tr
   - `{seq}`: 8-byte big-endian sequence number (enables FIFO ordering within priority)
   - `{id}`: Task ID (unique per task)
 - **In-progress tracking**: `codeq/q/{command}/{tenantID}/inprog/{id}`
-- **Delayed tasks**: `codeq/q/{command}/{tenantID}/delayed/{id}` (sorted by timestamp score)
+- **Delayed tasks**: `codeq/q/{command}/{tenantID}/delayed/{score}/{id}` (sorted by big-endian unix-second score)
 - **DLQ**: `codeq/q/{command}/{tenantID}/dlq/{id}`
 - **Task data**: `codeq/tasks/{id}` (JSON-encoded task metadata)
 - **Result data**: `codeq/results/{id}` (JSON-encoded result)
-- **TTL tracking**: `codeq/tasks/ttl/{id}` (retention epoch seconds)
+- **TTL tracking**: `codeq/ttl/{expire_unix}/{id}` (range-scan reaper)
 - **Leases**: `codeq/lease/{id}`
 - **Idempotency**: `codeq/idempo/{key}`
 - **Subscriptions**: `codeq/subs/{event}/{id}`
+
+### Keyspace map
+
+The diagram below groups every byte-prefix under the `codeq/` namespace by
+role. Three prefixes carry the bulk of the create → claim → complete
+cycle and are marked **hot-path** — every Enqueue writes `codeq/tasks/`
+plus `codeq/q/<cmd>/<tenant>/pending/`, and every Claim moves a key from
+`pending/` into `codeq/q/<cmd>/<tenant>/inprog/`. The remaining prefixes
+are written on slower paths (delayed delivery, DLQ promotion, TTL
+reaping, webhook subscriptions). Source of truth:
+[`internal/repository/pebble/keys.go`](../internal/repository/pebble/keys.go).
+
+```mermaid
+graph TB
+  subgraph NS[codeq/ namespace]
+    subgraph Hot[Hot-path prefixes]
+      TASKS[codeq/tasks/&lt;id&gt;<br/>task JSON]
+      PENDING[codeq/q/&lt;cmd&gt;/&lt;tenant&gt;/pending/<br/>&lt;prio_be1&gt;/&lt;seq_be8&gt;/&lt;id&gt;]
+      INPROG[codeq/q/&lt;cmd&gt;/&lt;tenant&gt;/inprog/&lt;id&gt;]
+    end
+    subgraph Results[Result and idempotency]
+      RES[codeq/r/&lt;id&gt;<br/>result JSON]
+      IDEM[codeq/idempo/&lt;key&gt;<br/>idempotency map to task id]
+    end
+    subgraph Slow[Slow-path queues]
+      DELAYED[codeq/q/&lt;cmd&gt;/&lt;tenant&gt;/delayed/<br/>&lt;score_be8&gt;/&lt;id&gt;]
+      DLQ[codeq/q/&lt;cmd&gt;/&lt;tenant&gt;/dlq/&lt;id&gt;]
+    end
+    subgraph Reapers[Indexes scanned by reapers]
+      TTL[codeq/ttl/&lt;expire_be8&gt;/&lt;id&gt;]
+      LEASE[codeq/lease/&lt;id&gt;]
+    end
+    subgraph Subs[Webhook subscriptions]
+      SUB[codeq/subs/&lt;event&gt;/&lt;id&gt;]
+    end
+  end
+  PENDING -- Claim --> INPROG
+  INPROG -- SubmitResult --> RES
+  INPROG -- maxAttempts --> DLQ
+  DELAYED -- MoveDueDelayed --> PENDING
+  TASKS -. TTL register .-> TTL
+```
 
 ## Multi-tenancy
 
@@ -61,6 +103,57 @@ Pebble commits are atomic at the batch level. A batch can contain multiple puts,
 - Task finalization (save result + remove from in-progress + delete lease + update TTL)
 - Lease repair (multiple TTL checks and requeue operations)
 - Bulk operations (batch enqueue, batch result submission)
+
+### Batch commit and the group-commit coalescer
+
+Pre-Phase 1.1, every `CommitBatch` caller contended on Pebble's internal
+commit pipeline mutex; under N concurrent goroutines this serialized N
+commits and bounded throughput by the lock wait, not the disk. The
+Phase 1.1 win replaces that contention with a single coalescer
+goroutine that owns the write side: callers hand their batch to a
+channel, the coalescer pops the first request, opportunistically drains
+up to `maxMergeBatch=64` more requests already queued, merges them with
+`Batch.Apply` into one large batch, issues a single `Commit`, and fans
+the resulting error back to every joined caller through their per-call
+`done` channel. From the caller's perspective the contract is
+unchanged — `CommitBatch` is still synchronous, still atomic, still
+returns the commit error if any — but the underlying Pebble commit
+runs once for up to 64 logically independent batches.
+
+Source: [`internal/repository/pebble/db.go`](../internal/repository/pebble/db.go)
+(`commitLoop`, `CommitBatch`, `maxMergeBatch`).
+
+```mermaid
+sequenceDiagram
+  participant G1 as Goroutine 1
+  participant G2 as Goroutine 2
+  participant GN as Goroutine N
+  participant CH as commitCh (buffered)
+  participant CO as Coalescer goroutine
+  participant PB as Pebble
+
+  G1->>CH: send commitReq{batch1, done1}
+  G2->>CH: send commitReq{batch2, done2}
+  GN->>CH: send commitReq{batchN, doneN}
+  CO->>CH: recv first req (blocking)
+  CO->>CO: merged := NewBatch; Apply(batch1)
+  loop drain up to maxMergeBatch=64
+    CO->>CH: non-blocking recv next req
+    CO->>CO: merged.Apply(batchK)
+  end
+  CO->>PB: merged.Commit(NoSync)
+  PB-->>CO: err (nil on success)
+  CO-->>G1: done1 <- err
+  CO-->>G2: done2 <- err
+  CO-->>GN: doneN <- err
+```
+
+> **Performance**: the coalescer trades a single channel hop of latency
+> for one Pebble commit shared across up to 64 callers. On `-cpu 1` the
+> extra hop is net-neutral or slightly negative; on `-cpu high` it
+> scales near-linearly until the merge cap. See
+> `BenchmarkEnqueueParallel_*` in
+> [`internal/repository/pebble/bench_test.go`](../internal/repository/pebble/bench_test.go).
 
 ## Bloom Filters and Caching
 
@@ -91,6 +184,54 @@ Pebble's embedded design means only one process may hold the database lock at a 
 - **Writes**: O(1) amortized with write batching
 - **Compaction**: Background, ~10-15% slowdown during heavy merging
 
+## Phase 8 sharded routing
+
+The single-process bottleneck after Phase 1.1 was that one Pebble DB
+still owned one commit pipeline and one compaction worker. Phase 8
+splits the Pebble layer into N independent shards, each with its own
+DB, own commit coalescer, and own compaction. The
+[`ShardedTaskRepository`](../internal/repository/pebble/sharded_task_repository.go)
+wraps the N per-shard `TaskRepository` instances and routes every
+task-keyed call by `fnv1a64(taskID) % N`. Because every key derived
+from a single task ID (`KeyTask`, `KeyPending`, `KeyInprog`, `KeyDLQ`,
+`KeyDelayed`, `KeyTTLIndex`) hashes to the same shard, each individual
+task operation still commits in one Pebble batch — there are no
+cross-shard transactions on the hot path.
+
+Cross-shard operations exist but are kept off the per-task fast path:
+`Claim`/`ClaimMany` round-robin across shards, `MoveDueDelayed` fans
+out per shard, and `AdminQueues`/`PendingLength`/`QueueStats` aggregate
+results. Idempotency lookups route on `hash(idempotencyKey) % N`, the
+same shard the original Enqueue wrote into, so replays land back on
+the right entry.
+
+```mermaid
+sequenceDiagram
+  participant Caller as Caller (producer goroutine)
+  participant Sharded as ShardedTaskRepository
+  participant Shard as shards[i].TaskRepository
+  participant Coal as Coalescer (shard i)
+  participant Pebble as Pebble (shard i)
+
+  Caller->>Sharded: Enqueue(cmd, payload, ..., taskID)
+  Sharded->>Sharded: i := fnv1a64(taskID) % N
+  Sharded->>Shard: shards[i].EnqueueWithID(taskID, ...)
+  Shard->>Shard: build batch (KeyTask + KeyPending + idempo)
+  Shard->>Coal: CommitBatch(batch) via commitCh
+  Coal->>Coal: merge with peers on shard i (cap 64)
+  Coal->>Pebble: merged.Commit(NoSync)
+  Pebble-->>Coal: err
+  Coal-->>Shard: done <- err
+  Shard-->>Sharded: task, err
+  Sharded-->>Caller: task, err
+```
+
+> **Note**: cluster mode and intra-process sharding (`numShards > 1`)
+> are mutually exclusive — startup panics if both are enabled. Pick
+> one: multi-node across machines, or multi-shard inside one process.
+> See [Pebble sharding internals](./08b-pebble-sharding-internals.md)
+> for the per-shard component layout.
+
 ## Comparison with Redis/KVRocks
 
 | Feature | Pebble | Redis/KVRocks |
@@ -116,3 +257,14 @@ Pebble's embedded design means only one process may hold the database lock at a 
 - **High availability**: Cluster replication and failover
 - **Large scale**: Horizontal scaling, sharding support
 - **Existing infrastructure**: Leverage existing Redis/KVRocks clusters
+
+## See also
+
+- [Storage layout (Redis/KVRocks)](./07-storage-kvrocks.md) — the
+  network-backed alternative with the same data model.
+- [Pebble sharding internals](./08b-pebble-sharding-internals.md) —
+  per-shard component layout behind `ShardedTaskRepository`.
+- [Persistence plugin system](./27-persistence-plugin-system.md) — how
+  Pebble plugs into the repository interface alongside Redis.
+- [Performance tuning](./17-performance-tuning.md) — knobs for shard
+  count, batch sizes, and the coalescer in the field.

--- a/docs/_STYLE.md
+++ b/docs/_STYLE.md
@@ -1,0 +1,291 @@
+# codeq documentation style guide
+
+This is the canonical style guide for codeq documentation. Every doc in
+`docs/` and the root `README.md` must follow it. Subsequent waves of doc
+revisions cite this file verbatim where relevant (especially the value
+proposition and comparativos). If you change the value proposition here,
+you must update the docs that quote it.
+
+## 1. Value proposition
+
+### One-line
+
+> codeq is an embedded high-performance task queue: a single Go binary,
+> Pebble for persistence, gRPC streaming for the wire — 83k tasks/s on
+> one machine with zero external dependencies.
+
+### One-paragraph
+
+> codeq is a task queue written in Go that runs as a single process and
+> stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+> from CockroachDB). The hot path is bidirectional gRPC streams from
+> producers and workers; under the streams sits an intra-process shard
+> table (up to N independent Pebble instances) and an in-memory lease
+> table. The result on a 12-core Linux box is 83,420 tasks/s for the
+> full create → claim → complete cycle, or 136,392 creates/s producer-
+> only. No Redis, no broker, no coordinator required in the default
+> mode. Cluster (consistent-hash + gRPC routing) and a legacy Redis
+> backend are opt-in for HA and multi-node deployments.
+
+### Comparativos (use verbatim or as a base)
+
+| Dimension | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | None (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper or KRaft cluster |
+| Throughput (single node, full cycle) | 83k tasks/s | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | 100k+ msgs/s, but no task semantics |
+| Language affinity | Go (HTTP + gRPC; SDKs for Java, Node, Python, Go) | Go | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant native | Yes (JWT tenantId namespacing built in) | No | No | No | No |
+| Learning curve | One binary, HTTP + curl in minutes | Moderate (Redis ops) | Moderate (Node + Redis) | High (broker + result backend) | High (broker, consumer groups, schema registry) |
+
+When citing this table in a doc, link back here:
+
+> See [_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## 2. Audience profile
+
+Primary reader: **backend engineer evaluating alternatives to Redis-backed
+task queues**. They are typically deciding between Asynq (Go + Redis),
+BullMQ (Node + Redis), Celery (Python + broker), Sidekiq (Ruby + Redis),
+Temporal (workflow engine), and Kafka (event log used as a queue).
+
+What they care about, ranked:
+
+1. **Throughput** — concrete numbers, harness names, and the box they
+   were measured on. No "blazing fast", no "10x". Cite the benchmark.
+2. **Operational cost** — how many processes, how many config knobs, how
+   long until they can `curl` a task.
+3. **Language affinity** — Go server, but with first-class SDKs for the
+   reader's stack.
+4. **Durability and at-least-once** — what survives a crash, and how
+   they prove it.
+5. **Multi-tenant** — whether they can run one queue server for many
+   customers without writing isolation themselves.
+6. **HA and scaling story** — single-node first, but with a credible
+   path to multi-node.
+
+Write for someone who already understands queues. Skip onboarding to
+basic concepts like "what is a task". Do define codeq-specific terms
+(shard, lease table, ring, scatter-gather) the first time they appear.
+
+## 3. Voice and tone
+
+### Numbers first, narrative second
+
+Bad:
+
+> codeq is blazing fast and can handle massive workloads.
+
+Good:
+
+> codeq sustains 83,420 tasks/s for a full create → claim → complete
+> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
+> batch=8, 128 worker slots, 20s measurement window
+> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
+
+Every throughput claim cites:
+
+- The exact test name in `internal/bench/`.
+- The env vars used to parameterize it.
+- The hardware class (cores, OS).
+- The measurement window.
+
+### Honest about limitations
+
+Always name the trade-offs. Examples to use as templates:
+
+- "HA is only available via the Redis backend or by running a cluster of
+  Pebble nodes. A single Pebble process loses availability while it
+  restarts; recovery is fast (in-memory lease table rebuilt from the
+  `KeyInprog` scan at Open) but not instantaneous."
+- "Cluster mode and intra-process sharding (`numShards > 1`) are
+  mutually exclusive — startup panics if both are enabled. Pick one:
+  multi-node across machines, or multi-shard inside one process."
+- "Delivery is at-least-once, not exactly-once. A worker that crashes
+  between completion and ACK will see its task re-delivered after the
+  lease expires."
+
+### No marketing fluff
+
+Banned words: blazing, massive, lightning, seamless, robust,
+cutting-edge, world-class, next-gen, revolutionary.
+
+Replace adjectives with measurements. If you cannot measure it, do not
+claim it.
+
+### Opinionated
+
+Tell the reader what to pick:
+
+- "For single-node deployments use Pebble with `numShards: 4`."
+- "Do not enable `fsyncOnCommit` unless you have measured the latency
+  impact in your workload — it costs ~20% throughput in our harness."
+- "Use Redis only if you need multi-node HA today and cannot deploy the
+  cluster mode."
+
+## 4. Markdown conventions
+
+- **Headings**: ATX style (`#`), single `#` per file (the title), then
+  `##` for top-level sections, `###` for subsections. Do not skip
+  levels.
+- **Code blocks**: always tag the language.
+  - `bash` for shell, `go` for Go, `yaml` for config, `json` for JSON,
+    `protobuf` for `.proto`, `mermaid` for diagrams.
+  - Untagged blocks are forbidden — they break syntax highlighting on
+    GitHub.
+- **Admonitions** (GitHub-flavored):
+
+  ```markdown
+  > **Note**: a normal aside.
+  > **Warning**: a footgun. Always for irreversible operations or
+  > silent data loss.
+  > **Performance**: a tuning hint with a number.
+  ```
+
+- **Tables**: pipe-aligned, header row separator `---`. Always have a
+  header row. Cells with multi-word values stay on one line.
+- **Inline code**: backticks for file paths, env vars, config keys,
+  function names, and protocol constants.
+- **Lists**: `-` for unordered, `1.` for ordered. Two spaces of
+  indentation for nested items.
+- **Links**: prefer descriptive text over "click here". Relative links
+  for in-repo references (see §6).
+
+## 5. Mermaid conventions
+
+All diagrams must render on the GitHub default theme in both light and
+dark mode. **Never set inline colors or styles** — let the renderer
+pick.
+
+### Flow diagrams
+
+Use `graph TB` for top-to-bottom layered architecture, `graph LR` for
+left-to-right pipelines. Always use `subgraph` to delimit logical
+layers.
+
+```mermaid
+graph TB
+  subgraph Producers
+    P1[Producer SDK]
+  end
+  subgraph Server[codeq server]
+    HTTP[HTTP API]
+    GRPC[gRPC stream]
+  end
+  subgraph Storage
+    PEB[Pebble shards]
+  end
+  P1 --> GRPC
+  GRPC --> PEB
+  HTTP --> PEB
+```
+
+Aim for 8 to 12 nodes max in a single diagram. If it grows past that,
+split it.
+
+### Sequence diagrams
+
+Use `sequenceDiagram` for flows over time. Participant names start
+capitalized.
+
+```mermaid
+sequenceDiagram
+  participant Producer
+  participant Server
+  participant Pebble
+  Producer->>Server: Produce(task)
+  Server->>Pebble: BatchCommit
+  Pebble-->>Server: ack
+  Server-->>Producer: TaskID
+```
+
+### State machines
+
+Use `stateDiagram-v2` for task lifecycle. Transition labels describe
+the **trigger action**, not the resulting state.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  DLQ --> [*]
+```
+
+### No inline colors
+
+Bad:
+
+```text
+style P1 fill:#f9f,stroke:#333
+```
+
+Good: nothing — let the theme decide.
+
+## 6. Cross-link policy
+
+Every doc ends with a `## See also` section enumerating related docs.
+Example:
+
+```markdown
+## See also
+
+- [Architecture](./03-architecture.md)
+- [Storage layout (Pebble)](./07b-storage-pebble.md)
+- [Performance tuning](./17-performance-tuning.md)
+```
+
+Path conventions:
+
+- **Inside `docs/`** (doc-to-doc): use relative paths starting with
+  `./`, e.g. `[Overview](./01-overview.md)`.
+- **From root `README.md`** (or other root-level files): use paths
+  rooted at `docs/`, e.g. `[Overview](docs/01-overview.md)`.
+- **To source files**: use repo-rooted paths, e.g.
+  `[application.go](../pkg/app/application.go)` from inside `docs/`, or
+  `pkg/app/application.go` from `README.md`.
+- **Anchors**: lowercase, hyphen-separated, match GitHub's slug
+  algorithm.
+
+When you cite the value prop, link to this file:
+
+```markdown
+See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+```
+
+## 7. Numbers must come from measurement
+
+Every throughput, latency, or memory claim in any doc must be traceable
+to a test in `internal/bench/`. The format is:
+
+> N tasks/s (`internal/bench/<file>.go::<TestName>`, env: `KEY=VAL`,
+> hardware: 12-core Linux).
+
+Catalog of canonical benchmarks (use these names, do not invent new
+ones):
+
+| Workload | Harness | Result on reference box |
+|---|---|---|
+| Full cycle, 4 shards, batched | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) | 83,420 tasks/s |
+| Producer-only, batched stream | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` | 136,392 creates/s |
+| Worker-only, batched stream | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) | 23,518 tasks/s |
+| Shard sweep | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=1,2,4,6,8`) | 42k / 65k / 83k / 68k / 67k |
+
+Reference box: 12-core Linux (kernel 5.15, WSL2-compatible), Go 1.25.0,
+local Pebble, loopback gRPC, no fsync.
+
+If you need a number that is not in this table, run the bench, add the
+row here, then cite it in your doc. Do not estimate.
+
+## See also
+
+- [README](../README.md) — applies this style guide at the entry point.
+- [Overview](./01-overview.md) — the canonical statement of what codeq
+  is.
+- [Architecture](./03-architecture.md) — package-level breakdown.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and historical numbers.


### PR DESCRIPTION
## Summary

Adds three Mermaid diagrams to `docs/07b-storage-pebble.md` (Wave 4 U20):

- **Keyspace map** (`graph TB`) groups every `codeq/` prefix by role and marks the hot-path prefixes (`tasks/`, `q/<cmd>/<tenant>/pending/`, `q/<cmd>/<tenant>/inprog/`). Source of truth cited: `internal/repository/pebble/keys.go`.
- **Batch commit + group-commit coalescer** (`sequenceDiagram`) shows N goroutines fan-in through `commitCh`, the coalescer draining up to `maxMergeBatch=64` requests, one Pebble `Commit`, and per-caller err fan-out. Phase 1.1 win.
- **Phase 8 sharded routing** (`sequenceDiagram`) shows `ShardedTaskRepository.shardOf(taskID)` selecting `shards[i]` and that shard's own coalescer committing the batch.

Also adds a `## See also` cross-link block (`07-storage-kvrocks`, `08b-pebble-sharding-internals`, `27-persistence-plugin-system`, `17-performance-tuning`) per `docs/_STYLE.md` §6, and corrects two minor key-shape inaccuracies (`delayed/<score>/<id>`, `ttl/<expire>/<id>`) to match `keys.go`.

Diagrams follow `docs/_STYLE.md` §5: no inline colors, `graph TB` with subgraphs by logical layer, sequence participants capitalized, ≤12 nodes per diagram.

## Test plan

- [ ] GitHub renders all three Mermaid blocks cleanly in light and dark mode
- [ ] All four See also links resolve
- [ ] No banned-words violations vs `_STYLE.md` §3

Branch base: `docs/wave1-u1-foundation` (Wave 1 U1 foundation).