### PR TITLE
docs(wave3-u8): producer streaming SDK guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,108 @@
-# codeQ
+# codeq
 
-Reactive scheduling and completion system backed by persistent queues. Choose your storage: KVRocks (distributed) or Pebble (embedded).
+> Embedded high-performance task queue. One Go binary, Pebble for
+> storage, gRPC streams on the wire. 83k tasks/s on a single 12-core
+> box with zero external dependencies.
 
-This repository contains the core runtime, HTTP API wiring, and a Helm chart for small clusters.
-The production service wrapper lives at:
-https://github.com/codecompany/codeq-service
+[![Go Reference](https://pkg.go.dev/badge/github.com/osvaldoandrade/codeq.svg)](https://pkg.go.dev/github.com/osvaldoandrade/codeq)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Issues](https://img.shields.io/github/issues/osvaldoandrade/codeq.svg)](https://github.com/osvaldoandrade/codeq/issues)
 
-## Links
+## What is codeq?
 
-- GitHub: https://github.com/osvaldoandrade/codeq
-- Issues: https://github.com/osvaldoandrade/codeq/issues
-- Specs index: `docs/README.md`
+codeq is a task queue written in Go. The default deployment is a single
+process: the server, the persistence layer (Pebble, the RocksDB-style
+LSM from CockroachDB), the lease table, and the gRPC + HTTP API all
+share one binary and one disk directory. There is no Redis to run, no
+broker to babysit, no consensus to coordinate.
 
-## Why codeQ
+On a 12-core Linux box, that single binary sustains **83,420 tasks/s**
+for the full create → claim → complete cycle and **136,392 creates/s**
+for producer-only workloads — measured by the in-tree benchmarks in
+`internal/bench/`. When one machine is no longer enough, cluster mode
+(consistent-hash ring + gRPC routing between nodes) and a legacy Redis
+backend are opt-in.
 
-codeQ provides:
+## Architecture overview
 
-- Persistent queues with pluggable storage backends:
-  - **Redis/KVRocks** (distributed, cluster-capable)
-  - **Pebble** (embedded, zero-dependency, ideal for local development)
-- Pull-based worker claims with leases.
-- **Multi-tenant queue isolation** with automatic tenant ID extraction from JWT claims.
-- **Horizontal scaling with queue sharding**: Optional pluggable `ShardSupplier` interface for routing commands/tenants across multiple KVRocks instances.
-- **Pluggable persistence backends**: Redis, memory (testing), and extensible plugin architecture for custom storage (PostgreSQL, DynamoDB, Cassandra, etc.).
-- NACK + backoff + delayed queues.
-- DLQ for tasks that exceed `maxAttempts`.
-- Result storage and optional callbacks (webhooks).
-- Worker auth via JWT (JWKS), producer auth via Tikti access tokens (JWKS).
-- **Official SDKs** for Java and Node.js/TypeScript with framework integrations.
-- **Distributed tracing** with OpenTelemetry support for end-to-end observability.
-- **Optimized performance**: O(1) queue operations with pipelined lease repair for low-latency claims even under high load.
-- **Load testing framework**: Comprehensive k6 scenarios and Go benchmarks for performance validation and regression testing.
+```mermaid
+graph TB
+  subgraph Clients
+    PSDK[Producer SDK]
+    WSDK[Worker SDK]
+    CURL[HTTP / curl]
+  end
+  subgraph Server[codeq server -- single binary]
+    HTTP[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+  end
+  subgraph Storage[Embedded persistence]
+    P0[Pebble shard 0]
+    P1[Pebble shard 1]
+    PN[Pebble shard N-1]
+  end
+  subgraph Optional[Opt-in scaling]
+    CL[Cluster -- consistent-hash + gRPC]
+    REDIS[Redis backend -- legacy HA]
+  end
+  PSDK --> PGRPC
+  WSDK --> WGRPC
+  CURL --> HTTP
+  HTTP --> LEASE
+  PGRPC --> LEASE
+  WGRPC --> LEASE
+  LEASE --> P0
+  LEASE --> P1
+  LEASE --> PN
+  Server -.-> CL
+  Server -.-> REDIS
+```
 
-## Get started
+Producers and workers connect over long-lived bidirectional gRPC
+streams. Each request hits the in-memory lease table first, then commits
+to a Pebble shard chosen by `hash(taskID) % N`. Each shard runs its own
+commit pipeline and compaction loop, which is what lets a 4-shard
+configuration roughly double the single-shard throughput on the same
+hardware.
 
-### Local development with Docker Compose
+## Performance
 
-The quickest way to try codeQ locally:
+All numbers measured on a 12-core Linux box, Go 1.25.0, loopback gRPC,
+Pebble with `fsyncOnCommit=false`. Full bench harness lives in
+`internal/bench/`.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle (create + claim + complete), 4 Pebble shards | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| Worker-only, batched claim+complete | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep (full cycle, 1 / 2 / 4 / 6 / 8 shards) | 42k / 65k / **83k** / 68k / 67k tasks/s | same as full cycle harness with `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on a 12-core box; past that, write
+amplification and goroutine contention start to dominate. See
+[docs/30-performance-baselines.md](docs/30-performance-baselines.md)
+for raw output and per-release history.
+
+## Why codeq vs alternatives
+
+| Feature | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | **None** (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper / KRaft cluster |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | n/a (no task semantics) |
+| Language affinity | Go server, SDKs for Java, Node, Python, Go | Go only | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant isolation | **Built in** (JWT tenantId namespacing) | DIY | DIY | DIY | DIY |
+| Time-to-first-task | `docker run` + `curl` | Run Redis + Asynq | Run Redis + worker | Run broker + workers + result backend | Multi-step cluster bootstrap |
+
+codeq is the right call when you want task-queue semantics (claims,
+leases, retries, DLQ, results) without standing up a broker. It is the
+wrong call if you need Kafka-scale event streaming, distributed
+consensus by default, or HA without configuring the Redis backend or
+cluster mode.
+
+## Quick start (5 minutes)
 
 ```bash
 git clone https://github.com/osvaldoandrade/codeq
@@ -47,125 +113,10 @@ docker compose \
   up -d
 ```
 
-This starts KVRocks, the codeQ API server, and seeds example tasks. Access at `http://localhost:8080`.
+This brings up the codeq server on `http://localhost:8080` with the
+embedded Pebble backend (no Redis required) and seeds example tasks.
 
-See [Local Development Guide](docs/22-local-development.md) for details on hot reload, testing, and observability.
-
-### Install a server
-
-Use the console wizard to generate a Docker or Kubernetes/Helm install bundle:
-
-```bash
-codeq install
-```
-
-Non-interactive Kubernetes example:
-
-```bash
-codeq install \
-  --target kubernetes \
-  --size small \
-  --namespace codeq \
-  --identity-service-url https://issuer.example.com \
-  --worker-jwks-url https://issuer.example.com/.well-known/jwks.json \
-  --worker-issuer https://issuer.example.com
-```
-
-### Install CLI (macOS/Linux/Windows via Git Bash)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
-```
-
-Requires `git` and `go`.
-
-### Install CLI via npm (npmjs)
-
-```bash
-npm i -g @osvaldoandrade/codeq
-codeq --help
-```
-
-Upgrade:
-
-```bash
-npm i -g @osvaldoandrade/codeq@latest
-```
-
-### Use SDKs for Java, Node.js, Python, and Go
-
-Integrate codeQ into your microservices with official SDKs:
-
-**Java** (Spring Boot, Quarkus, Micronaut):
-```xml
-<dependency>
-    <groupId>io.codeq</groupId>
-    <artifactId>codeq-sdk-java</artifactId>
-    <version>1.0.0</version>
-</dependency>
-```
-
-**Node.js/TypeScript** (Express, NestJS):
-```bash
-npm install @osvaldoandrade/codeq-client
-```
-
-**Python** (FastAPI, Django, Flask):
-```bash
-pip install codeq-client
-```
-
-**Go** (Gin, Echo, stdlib):
-```bash
-go get github.com/osvaldoandrade/codeq/sdks/go
-```
-
-📚 **SDK Documentation**:
-- [SDK Overview & Quick Start](sdks/README.md)
-- [Java SDK](sdks/java/README.md)
-- [Node.js SDK](sdks/nodejs/README.md)
-- [Python SDK](sdks/python/README.md)
-- [Go SDK](sdks/go/README.md)
-- [Integration Guides](docs/integrations/)
-- [Example Applications](examples/)
-
-### Helm
-
-The chart in this repo deploys codeQ and, by default in the small profile, a single-node KVRocks instance.
-
-```bash
-git clone https://github.com/osvaldoandrade/codeq
-cd codeq
-
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-small.yaml \
-  --namespace codeq --create-namespace \
-  --set secrets.enabled=true \
-  --set secrets.webhookHmacSecret=YOUR_SECRET \
-  --set config.identityServiceUrl=https://your-auth-server.com \
-  --set config.workerJwksUrl=https://your-jwks \
-  --set config.workerIssuer=https://issuer
-```
-
-Disable embedded KVRocks and point to your own:
-
-```bash
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-medium.yaml \
-  --set kvrocks.enabled=false \
-  --set config.redisAddr=your-kvrocks:6666
-```
-
-### 2) Service runtime
-
-The API server and Dockerfile are in the service repo:
-https://github.com/codecompany/codeq-service
-
-That repo consumes this module and exposes the HTTP API.
-
-## Quick API flow
-
-Create a task (producer token):
+Create a task:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks \
@@ -174,7 +125,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"priority":3}'
 ```
 
-Claim a task (worker JWT):
+Claim a task (as a worker):
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
@@ -183,7 +134,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
   -d '{"commands":["GENERATE_MASTER"],"leaseSeconds":120,"waitSeconds":10}'
 ```
 
-Submit result:
+Submit a result:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
@@ -192,49 +143,95 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
   -d '{"status":"COMPLETED","result":{"ok":true}}'
 ```
 
-## Specs and docs
+For high-throughput producers and workers, use the gRPC streaming API
+(2-3x the HTTP throughput, amortized auth, pipelined acks): see
+[docs/34-streaming-api-guide.md](docs/34-streaming-api-guide.md).
 
-Start here: `docs/README.md`
+## Where next
 
-Key references:
+- [Getting started tutorial](docs/00-getting-started.md) — your first
+  task, end to end.
+- [Overview](docs/01-overview.md) — goals, non-goals, when (and when
+  not) to pick codeq.
+- [Architecture](docs/03-architecture.md) — package layout and request
+  flows.
+- [Performance tuning](docs/17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Operational runbooks](docs/29-operational-runbooks.md) — on-call
+  procedures for the common failure modes.
+- [Streaming API guide](docs/34-streaming-api-guide.md) — gRPC
+  producer and worker streams.
+- [Cluster architecture](docs/05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Style guide](docs/_STYLE.md) — voice, numbers, diagrams, links.
 
-- **Getting Started Tutorial**: `docs/00-getting-started.md` - **Start here for your first experience with codeQ**
-- **Overview**: `docs/01-overview.md` - System goals and design principles
-- **Architecture**: `docs/03-architecture.md` - System components and multi-tenant architecture
-- **Security**: `docs/09-security.md` - Authentication, authorization, and tenant isolation
-- **HTTP API**: `docs/04-http-api.md` - Complete API reference
-- **CLI Reference**: `docs/15-cli-reference.md` - CLI command documentation
-- **SDK Integration**: `sdks/README.md` - Official Java and Node.js SDKs
-  - [Java Integration](docs/integrations/java-integration.md) - Spring Boot, Quarkus, Micronaut
-  - [Node.js Integration](docs/integrations/nodejs-integration.md) - Express, NestJS, React
-- **Examples**: `examples/` - Working examples with Java and Node.js frameworks
-- **Developer Guide**: `docs/21-developer-guide.md` - Contributing and internal architecture
-- **Queue model**: `docs/05-queueing-model.md` - Queue semantics
-- **Storage layout**: `docs/07-storage-kvrocks.md` - KVRocks data structures
-- **Backoff and retries**: `docs/11-backoff.md` - Retry logic
-- **Webhooks**: `docs/12-webhooks.md` - Push notifications
-- **Configuration**: `docs/14-configuration.md` - Config reference
-- **Operations**: `docs/10-operations.md` - Metrics, health checks, and tracing
-- **Workflows**: `docs/16-workflows.md` - GitHub Actions automation
-- **Performance**: `docs/17-performance-tuning.md` - Optimization guide
-- **Load Testing**: `docs/26-load-testing.md` - Load testing framework and benchmarks
-- **Testing**: `docs/19-testing.md` - Test coverage and strategy
-- **Authentication Plugins**: `docs/20-authentication-plugins.md` - Plugin system for custom auth
-- **Persistence Plugins**: `docs/27-persistence-plugin-system.md` - Pluggable storage backends (Redis, Memory, and more)
-- **Design Documents**:
-  - `docs/24-queue-sharding-hld.md` - Queue sharding high-level design
-  - `docs/25-plugin-architecture-hld.md` - Plugin architecture for persistence and auth
-- **Migration**: `docs/migration.md` - Upgrade guide
-- **Contributing**: `CONTRIBUTING.md` - Contribution guidelines
+## SDKs
+
+Official client libraries for the languages most likely to talk to
+codeq from application code:
+
+- **Go** — `go get github.com/osvaldoandrade/codeq/sdks/go` ([README](sdks/go/README.md))
+- **Java** (Spring Boot, Quarkus, Micronaut) — [sdks/java/README.md](sdks/java/README.md)
+- **Node.js / TypeScript** (Express, NestJS) — [sdks/nodejs/README.md](sdks/nodejs/README.md)
+- **Python** (FastAPI, Django, Flask) — [sdks/python/README.md](sdks/python/README.md)
+
+Integration recipes per framework live under
+[docs/integrations/](docs/integrations/). End-to-end example apps live
+under [examples/](examples/).
 
 ## Repo layout
 
-- `pkg/`: public packages (`app`, `config`, `domain`)
-- `internal/`: controllers, middleware, services, repositories, providers
-- `deploy/`: Docker Compose, Kubernetes, and config examples
-- `helm/codeq`: Helm chart and size profiles
-- `docs/`: full specification
+```text
+cmd/                  CLI entrypoints (codeq install, server)
+internal/             unexported packages
+  bench/              throughput + latency benchmarks (source of truth for perf claims)
+  cluster/            consistent-hash ring, gRPC router, bloom gossip
+  controllers/        HTTP handlers (Gin)
+  middleware/         auth, tracing, rate-limit, tenant extraction
+  producer/           gRPC producer-stream server
+  worker/             gRPC worker-stream server
+  repository/         persistence implementations (Redis legacy + Pebble)
+  services/           scheduler, results, callbacks, subscriptions
+pkg/                  public packages (app, auth, config, domain,
+                      producerclient, workerclient)
+sdks/                 official SDKs (go, java, nodejs, python)
+deploy/               docker-compose and Kubernetes config
+helm/codeq/           Helm chart and size profiles
+docs/                 specifications, runbooks, performance baselines
+examples/             end-to-end example applications
+```
+
+## Install the CLI
+
+macOS, Linux, or Windows via Git Bash:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
+```
+
+Or via npm:
+
+```bash
+npm i -g @osvaldoandrade/codeq
+codeq --help
+```
+
+To generate a Docker or Kubernetes install bundle (with embedded Pebble
+by default, no Redis required):
+
+```bash
+codeq install
+```
+
+See [docs/15-cli-reference.md](docs/15-cli-reference.md) for the full
+CLI surface.
+
+## Contributing
+
+Issues and PRs are welcome. Before opening a PR, read
+[CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, and
+[docs/_STYLE.md](docs/_STYLE.md) for the documentation style.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,27 +1,244 @@
 # Overview
 
-codeQ is a task scheduling and completion service built on persistent queues in KVRocks. The service exposes HTTP APIs for producers to create tasks, for workers to claim and complete tasks, and for operators to inspect and clean up queues. The system is reactive: workers pull tasks, and optionally receive webhook signals that work is available.
+> Source-of-truth for the value proposition lives in
+> [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+> Other docs may cite this overview, but the style guide wins ties.
 
-The design is inspired by Dyno Queues, which adds time-based and priority queues on top of Dynomite. Dynomite is a distributed data layer that exposes Redis semantics and provides multi-datacenter replication. codeQ applies the same motivation to KVRocks and uses Go for the implementation. The service favors availability and throughput over strict global ordering.
+## What is codeq
+
+codeq is a task queue written in Go that runs as a single process and
+stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+from CockroachDB). The hot path is bidirectional gRPC streams from
+producers and workers; under the streams sits an intra-process shard
+table (up to N independent Pebble instances) and an in-memory lease
+table. On a 12-core Linux box the single binary sustains
+**83,420 tasks/s** for the full create → claim → complete cycle and
+**136,392 creates/s** for producer-only workloads.
+
+No Redis, no broker, no coordinator required in the default mode.
+Cluster (consistent-hash ring + gRPC routing) and a legacy Redis backend
+are opt-in for HA and multi-node deployments.
 
 ## Goals
 
-- Provide a stable API for enqueue, claim, and completion.
-- Persist state on disk via KVRocks.
-- Support delayed retries, priority, and retries.
-- Allow workers to pull by event type without a worker registry.
-- Provide optional push notifications without assigning work.
+- **Single binary.** Server, persistence, lease table, HTTP + gRPC API
+  all in one process. One disk directory. One systemd unit. No external
+  database required.
+- **80k+ tasks/s on one machine.** Full create → claim → complete cycle
+  measured by `internal/bench/profile_full_cycle_test.go` with 4 Pebble
+  shards, batched producer + worker streams.
+- **gRPC streaming as a first-class API.** Long-lived bidirectional
+  streams amortize auth and middleware; multiple requests can be in
+  flight before responses arrive.
+- **Multi-tenant by construction.** Every queue key is namespaced by
+  `tenantId` extracted from the JWT. Workers can only claim tasks from
+  their own tenant. No application code required to keep tenants
+  isolated.
+- **Cluster opt-in.** When one machine is no longer enough, run a
+  consistent-hash cluster (no consensus, no coordinator — static
+  membership + gRPC routing).
+- **Configurable durability.** `fsyncOnCommit` is a per-deployment knob.
+  Off by default for throughput; turn it on when your SLO demands it.
 
 ## Non-goals
 
-- Exactly-once processing.
-- Global FIFO across all commands.
-- Automatic worker discovery or scheduling.
+- **Kafka-scale event streaming.** codeq is a task queue, not a
+  partitioned log. If you want millions of messages/s with consumer
+  groups, use Kafka.
+- **Distributed consensus by default.** No Raft, no Paxos. Cluster mode
+  uses a static consistent-hash ring; node membership is configured at
+  startup, not gossiped.
+- **HA without explicit setup.** A single Pebble process loses
+  availability while it restarts. HA requires either the Redis backend
+  (legacy, multi-node) or running a cluster of Pebble nodes — each is a
+  trade-off the operator picks consciously.
+- **Exactly-once delivery.** Delivery is at-least-once. A worker that
+  crashes between completion and ACK will see the task re-delivered
+  after the lease expires.
+- **Global FIFO across all commands.** Ordering is per-(command,
+  tenant, priority) within a Pebble shard. Cross-shard ordering is not
+  defined.
+- **Worker discovery or scheduling.** codeq does not register workers
+  or assign work; workers pull when they are ready.
 
-## High-level data model
+## Data model summary
 
-- Task: unit of work, identified by UUID.
-- Message: queue element containing metadata used by the scheduler.
-- Result: completion record stored independently of the task body.
-- Command (event type): routing key for tasks.
-- Shard: not implemented; queues are single-shard in the current service.
+- **Task** — unit of work. Identified by UUID. Carries `command`
+  (routing key), `payload` (opaque JSON bytes), `priority` (0-9),
+  optional `webhook` URL, and lifecycle state.
+- **Result** — completion record. Stored separately from the task body
+  so completion can be GC'd on a different schedule than the task
+  metadata.
+- **Subscription** — webhook registration. A worker (or coordinator)
+  registers a callback URL for one or more event types; codeq pings it
+  when new work appears.
+
+Task lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> FAILED: SubmitResult(err)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DELAYED: Nack(backoff)
+  DELAYED --> PENDING: MoveDueDelayed
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  FAILED --> [*]
+  DLQ --> [*]
+```
+
+Full schema and state semantics in
+[02-domain-model.md](./02-domain-model.md).
+
+## Architecture summary
+
+```mermaid
+graph TB
+  subgraph Clients
+    SDK[Producer / Worker SDKs]
+    HTTPCLI[HTTP clients -- curl, browsers]
+  end
+  subgraph Server[codeq server]
+    API[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+    SCHED[Scheduler core]
+  end
+  subgraph Storage[Embedded persistence -- default]
+    P[Pebble shards 0..N-1]
+  end
+  subgraph OptIn[Opt-in modes]
+    CL[Cluster -- consistent-hash + gRPC routing]
+    REDIS[Redis backend -- legacy, HA]
+  end
+  SDK --> PGRPC
+  SDK --> WGRPC
+  HTTPCLI --> API
+  API --> SCHED
+  PGRPC --> SCHED
+  WGRPC --> SCHED
+  SCHED --> LEASE
+  SCHED --> P
+  Server -.-> CL
+  Server -.-> REDIS
+```
+
+Request flow at a glance:
+
+1. Producer or worker opens a gRPC stream (or sends an HTTP request).
+2. The middleware chain validates the JWT, extracts `tenantId`, and
+   applies rate limits.
+3. The scheduler routes the operation to its Pebble shard
+   (`hash(taskID) % numShards`) and updates the in-memory lease table.
+4. Pebble commits the batch; the group-commit coalescer (Phase 1.1)
+   merges concurrent writers into one fsync.
+5. On worker stream, ready tasks are pushed back through the same long-
+   lived connection — no per-claim handshake.
+
+Package-level breakdown in [03-architecture.md](./03-architecture.md).
+
+## When to use codeq
+
+- **Single-node task queue for a backend service.** You want claims,
+  leases, retries, DLQ, and results without standing up Redis or a
+  broker.
+- **Embedded sidecar in your own Go binary.** Import `pkg/app` and run
+  codeq in-process alongside your application.
+- **Multi-tenant SaaS background jobs.** Per-tenant queue isolation is
+  built in; you do not have to namespace keys yourself.
+- **High-throughput producers with small payloads.** The batched
+  producer stream sustains 100k+ creates/s on commodity hardware.
+- **Polyglot worker fleets.** Workers in Go, Java, Node, or Python can
+  all share the same queue via the official SDKs.
+- **Local development without external services.** `docker run codeq`
+  is enough; no Redis container, no compose dance.
+
+## When NOT to use codeq
+
+- **Kafka-scale event streaming.** Millions of events/s with consumer
+  groups, replay, and a retention window measured in days — use Kafka.
+- **Distributed transactions.** codeq has no two-phase commit and no
+  cross-shard transactions. If your business logic needs atomic updates
+  across multiple tasks, build it above codeq with an outbox pattern or
+  pick a workflow engine.
+- **HA without Redis or cluster mode.** A single Pebble process is
+  unavailable during restart. If your SLO does not tolerate a few
+  seconds of unavailability, you need the Redis backend (multi-node) or
+  a Pebble cluster.
+- **Workflow orchestration with branching, child tasks, timers, and
+  long-running state.** Use Temporal, Cadence, or Step Functions — they
+  are purpose-built for that. codeq is a queue.
+- **Exactly-once delivery semantics.** codeq is at-least-once. Idempotent
+  handlers are the operator's responsibility.
+
+## Performance baselines
+
+Measured on a 12-core Linux box, Go 1.25.0, loopback gRPC, Pebble with
+`fsyncOnCommit=false`, 20s measurement window after a 2s warm-up.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle, 4 shards, batched | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (32 goroutines, batch=16) |
+| Worker-only, batched stream | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep | 1 shard: 42k; 2: 65k; **4: 83k**; 6: 68k; 8: 67k | same as full cycle, `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on this hardware. Past that, the cost of more
+commit pipelines + compaction loops outweighs the parallelism win. See
+[30-performance-baselines.md](./30-performance-baselines.md) for raw
+output, allocator stats, and the per-release history.
+
+## Comparativos resumidos
+
+| Dimension | codeq | Asynq | BullMQ | Kafka |
+|---|---|---|---|---|
+| External dependency | **None** | Redis | Redis | ZooKeeper / KRaft |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k | ~5k | n/a (no task semantics) |
+| Language | Go server, multi-language SDKs | Go | Node | Polyglot |
+| Multi-tenant native | **Yes** | DIY | DIY | DIY |
+| HA model | Cluster or Redis (opt-in) | Redis | Redis | Replicated log |
+
+Full table with Sidekiq, Celery, and Temporal lives in
+[_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## What changed (Phases 1-8 summary)
+
+codeq has been through a sequence of refactors that shifted its
+positioning from "Redis-backed queue" to "embedded high-performance
+queue". The short version:
+
+| Phase | Theme | Effect |
+|---|---|---|
+| 0 | kvrocks-primary | First version: KVRocks (Redis protocol) as the only backend. ~1.5-2k tasks/s. |
+| 1 | Pebble embedded backend | Pebble added as a pluggable persistence provider. Single-binary deployment becomes possible. Single-shard throughput ~42k tasks/s. |
+| 1.1 | Pebble fast-paths + group-commit coalescer | `MoveDueDelayed` fast-path; concurrent writers coalesce into one fsync. |
+| 2 | Streaming groundwork | gRPC streaming surfaces designed. Auth amortized across stream lifetime. |
+| 5 | Cluster mode | Consistent-hash ring + gRPC routing between Pebble nodes. No consensus; static membership. |
+| 6 | Batched stream paths | Producer and worker streams gain batch APIs. `PHASE6_BATCH` / `PHASE6_PROD_BATCH` env knobs. |
+| 8 | Intra-process Pebble sharding | `numShards` opens N independent Pebble instances under one process. 4 shards → ~83k tasks/s on a 12-core box. **Mutually exclusive with cluster mode.** |
+
+PRs #527-#547 landed Phases 1.1, 6, and 8. The Redis backend remains
+supported for HA scenarios but is no longer the default.
+
+## See also
+
+- [_STYLE.md](./_STYLE.md) — documentation voice, numbers, diagrams.
+- [Architecture](./03-architecture.md) — package layout and request
+  flows.
+- [HTTP API](./04-http-api.md) — REST surface.
+- [Streaming API guide](./34-streaming-api-guide.md) — gRPC producer
+  and worker streams.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and per-release history.
+- [Performance tuning](./17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Cluster architecture](./05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Storage layout (Pebble)](./07b-storage-pebble.md) — keyspace and
+  sharding internals.
+- [Persistence plugin system](./27-persistence-plugin-system.md) —
+  choosing and configuring backends.

--- a/docs/35-producer-streaming-sdk.md
+++ b/docs/35-producer-streaming-sdk.md
@@ -1,0 +1,680 @@
+# Producer streaming SDK (Go)
+
+This document is the reference for `pkg/producerclient`, the Go SDK that
+talks the codeq producer streaming gRPC protocol. It covers the wire
+shape, the API surface, the concurrency model, batch mode, error
+handling, and a full working example.
+
+If you have not yet read the protocol-level overview, start with
+[gRPC streaming API guide](./34-streaming-api-guide.md). This doc dives
+into the Go client and the server fan-out that backs it.
+
+> codeq is an embedded high-performance task queue: a single Go binary,
+> Pebble for persistence, gRPC streaming for the wire — 83k tasks/s on
+> one machine with zero external dependencies. See
+> [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+
+## 1. What and why
+
+The producer streaming SDK exists for one reason: to remove the per-call
+HTTP middleware tax that dominated CPU on the create hot path once Phase
+2 had lifted the worker side. Every `POST /v1/codeq/tasks` request pays
+for Gin routing, auth middleware, tenant resolution, JSON binding, and
+response marshalling. None of that work is interesting on the second
+request from the same producer — only the create itself is.
+
+The streaming protocol amortises all of that to a single `Hello`
+handshake at connect time. After that, producers pipeline `CreateTask`
+events down a long-lived bidirectional gRPC stream and receive
+`CreateAck` events back, correlated by a producer-assigned `seq`.
+
+### Measured headroom
+
+| Path | Throughput | Harness |
+|---|---|---|
+| `POST /v1/codeq/tasks` (REST, 32 goroutines) | ~16,453 creates/s | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_RESTPath` |
+| `Session.Produce` (stream, 32 goroutines, single) | ~46,000 creates/s | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamPath` |
+| `Session.ProduceBatch` (stream, 32 × batch=16) | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+
+That is 8.29× over REST for the batched stream path on the reference
+box (12-core Linux, Go 1.25.0, loopback gRPC, Pebble persistence, no
+fsync, 6 s measurement window). The reference number for the
+[canonical performance baseline](./_STYLE.md#7-numbers-must-come-from-measurement)
+is `136,392 creates/s`.
+
+> **Performance**: the batched stream path is the only producer path
+> that hits six-figure creates/s on a single node. If you need that
+> throughput, you need `ProduceBatch`. `Produce` is for low-latency
+> single-task submission with the same wire format.
+
+The trade-off is honest:
+
+- The stream replaces a stateless HTTP request with a stateful gRPC
+  session. A dead stream takes every in-flight `Produce` with it; you
+  reconnect and retry at the application level.
+- Auth happens once at `Hello`. There is no per-call permission check —
+  the tenant resolved at handshake stays for the life of the stream.
+- The wire shape is protobuf, not JSON. Webhooks, idempotency keys, and
+  delays carry over verbatim from the REST body, but the encoding is
+  different.
+
+## 2. Architecture
+
+The SDK is one Go package on top of generated protobuf stubs. The
+server side lives in `internal/producer/`; the wire definition is at
+`internal/producer/proto/producerpb.proto`. The client itself is
+`pkg/producerclient/client.go`.
+
+```mermaid
+graph TB
+  subgraph Caller[Application goroutines]
+    G1[goroutine 1]
+    G2[goroutine 2]
+    G3[goroutine N]
+  end
+  subgraph SDK[pkg/producerclient]
+    SESS[Session]
+    SENDCH[(sendCh buffer 256)]
+    WRITE[writeLoop]
+    READ[readLoop]
+    PEND[pending sync.Map seq -> ackCh]
+  end
+  subgraph Wire[gRPC bidi stream]
+    STREAM[ProducerStream.Stream]
+  end
+  subgraph Server[internal/producer/server.go]
+    HELLO[handleHello + Validator]
+    HANDLE[handleCreate / handleCreateBatch]
+    SVC[services.SchedulerService]
+  end
+  subgraph Storage
+    PEB[Pebble shards]
+  end
+  G1 --> SESS
+  G2 --> SESS
+  G3 --> SESS
+  SESS --> SENDCH
+  SENDCH --> WRITE
+  WRITE --> STREAM
+  STREAM --> HELLO
+  STREAM --> HANDLE
+  HANDLE --> SVC
+  SVC --> PEB
+  HANDLE --> STREAM
+  STREAM --> READ
+  READ --> PEND
+  PEND --> SESS
+```
+
+Key invariants encoded in that diagram:
+
+- **One writer per stream.** Every `Send` on the gRPC stream goes
+  through `writeLoop`, a single goroutine reading from `sendCh`. This
+  is the Phase 6 / M1 finding — `sendMu` mutex contention across
+  pipelined `Produce` callers was the single largest source of delay in
+  the producer profile, so the client mirrors the server pattern.
+- **Async ack delivery.** `readLoop` consumes `ServerEvent` messages
+  off the wire and looks up the producer-assigned `seq` in the
+  `pending` map to wake the goroutine that called `Produce`.
+- **Per-seq channel of capacity 1.** Each `Produce` call allocates one
+  buffered ack channel and registers it in `pending`. The reader writes
+  exactly once and deletes the entry; the producer goroutine reads once
+  and returns.
+- **Server-side fan-out for singles, inline for batches.** The server
+  spawns one goroutine per `CreateTask` so a slow Pebble commit cannot
+  head-of-line the read loop. For `CreateTaskBatch` the server
+  processes the batch serially in one goroutine — the Phase 6 / F3
+  finding showed that spawning N goroutines per Recv contended with
+  the Pebble commit coalescer that already serialises commits.
+
+## 3. Hello handshake
+
+The first message on every stream must be `Hello`. The server
+validates the bearer token, resolves the tenant, and replies with
+`HelloAck`. Until that exchange completes, no `CreateTask` events are
+accepted.
+
+```mermaid
+sequenceDiagram
+  participant App as Application code
+  participant Sess as Session
+  participant Stream as gRPC stream
+  participant Srv as producer.Server
+  participant Val as auth.Validator
+  App->>Sess: Client.Connect(ctx)
+  Sess->>Stream: open bidi stream
+  Sess->>Stream: ProducerEvent{Hello{token}}
+  Stream->>Srv: stream.Recv()
+  Srv->>Val: Validate(token)
+  Val-->>Srv: claims (tenantId, subject)
+  Srv->>Stream: ServerEvent{HelloAck{tenantId, subject}}
+  Stream-->>Sess: ServerEvent{HelloAck}
+  Sess->>Sess: start readLoop goroutine
+  Sess-->>App: *Session ready
+```
+
+If the validator rejects the token, the server returns a gRPC
+`Unauthenticated` status and the stream closes immediately. The SDK
+surfaces that as the error returned from `Client.Connect`. If the first
+event the server receives is not `Hello`, it returns
+`FailedPrecondition` and likewise closes the stream.
+
+The resolved `tenantID` and `subject` are stamped on the session and
+are available as `Session.TenantID()` and `Session.Subject()`.
+Subsequent `CreateTask` events inherit them — there is no way for a
+client to override the tenant after the handshake.
+
+## 4. Pipelining and seq correlation
+
+The protocol is fully asynchronous. A producer may have N `CreateTask`
+events in flight before the first `CreateAck` arrives, and the acks
+may arrive out of order relative to the order the producer sent them
+in. The `seq` field on `CreateTask` is the correlation key: the server
+echoes it on the matching `CreateAck`, and the client uses it to wake
+the right caller.
+
+The `seq` is allocated by `Session.seq.Add(1)` (a `sync/atomic` uint64
+counter), so two concurrent `Produce` goroutines always see distinct
+strictly-monotonic values.
+
+```mermaid
+sequenceDiagram
+  participant G1 as goroutine A (Produce)
+  participant G2 as goroutine B (Produce)
+  participant G3 as goroutine C (Produce)
+  participant Sess as Session
+  participant Srv as producer.Server
+  G1->>Sess: Produce(req1)
+  Sess->>Srv: CreateTask{seq=1}
+  G2->>Sess: Produce(req2)
+  Sess->>Srv: CreateTask{seq=2}
+  G3->>Sess: Produce(req3)
+  Sess->>Srv: CreateTask{seq=3}
+  Note over Srv: fan-out: 3 goroutines, one per task
+  Srv-->>Sess: CreateAck{seq=2, taskId=t-002}
+  Sess-->>G2: return "t-002", nil
+  Srv-->>Sess: CreateAck{seq=1, taskId=t-001}
+  Sess-->>G1: return "t-001", nil
+  Srv-->>Sess: CreateAck{seq=3, taskId=t-003}
+  Sess-->>G3: return "t-003", nil
+```
+
+Two implications follow:
+
+1. **Ordering is not guaranteed.** Do not assume that ack order matches
+   send order. If your producer cares about ordering — say, for an
+   idempotency key collision check — wait for each ack before sending
+   the next, or use `ProduceBatch` (which acks in input order).
+2. **Send and receive are independent.** `writeLoop` is the only
+   goroutine that calls `stream.Send`. `readLoop` is the only goroutine
+   that calls `stream.Recv`. They do not synchronise with each other or
+   with caller goroutines except through `sendCh` and the `pending`
+   map.
+
+## 5. API reference
+
+All types live in `pkg/producerclient`.
+
+### Config
+
+```go
+type Config struct {
+    Addr        string             // gRPC dial target, e.g. "localhost:9092". Required.
+    Token       string             // Bearer token sent in Hello. Required.
+    DialOptions []grpc.DialOption  // Forwarded to grpc.NewClient. Defaults to insecure.
+    Logger      *slog.Logger       // Defaults to slog.Default().
+}
+```
+
+- `Addr`: the producer stream server address (set via
+  `producerStreamAddr` in `codeq.yml`, or the `ProducerStreamAddr`
+  field on `config.Config`). Required — `New` returns an error if
+  empty.
+- `Token`: bearer token validated by the configured `auth.Validator`.
+  Required.
+- `DialOptions`: if you need TLS, pass
+  `grpc.WithTransportCredentials(credentials.NewTLS(cfg))` here. If
+  you leave it nil, the client uses `insecure.NewCredentials()` — fine
+  for localhost, never for production over the public network.
+- `Logger`: receives Debug-level `hello ok` events and Warn-level
+  events for unknown acks or unhandled server messages. Defaults to
+  `slog.Default()`.
+
+### Client
+
+```go
+func New(cfg Config) (*Client, error)
+func (c *Client) Connect(ctx context.Context) (*Session, error)
+func (c *Client) Close() error
+```
+
+- `New` dials the gRPC target and returns a `Client`. It does not open
+  any stream yet — the dial is lazy under `grpc.NewClient`.
+- `Connect` opens a new bidirectional stream, completes the `Hello`
+  handshake, and starts the writer and reader goroutines. The returned
+  `Session` is bound to a derived context — when the caller's `ctx` is
+  cancelled, or `Session.Close` is called, the stream is torn down.
+  One `Client` can host many sequential `Session`s if you need to
+  rotate streams (for example, every 10 minutes to keep load balancers
+  happy).
+- `Close` releases the underlying `grpc.ClientConn`. Safe to call
+  multiple times. Sessions opened from this client become unusable
+  after `Close`.
+
+### CreateRequest
+
+```go
+type CreateRequest struct {
+    Command        string    // Task command, e.g. "GENERATE_MASTER". Required.
+    Payload        []byte    // Opaque JSON, stored as-is.
+    Priority       int       // Higher integer = earlier claim within the same shard.
+    Webhook        string    // Optional callback URL on completion.
+    MaxAttempts    int       // Overrides MaxAttemptsDefault from config when > 0.
+    IdempotencyKey string    // Server-side dedup over (tenant, key).
+    RunAt          time.Time // Absolute schedule. Zero means "now".
+    DelaySeconds   int       // Relative schedule. Must be >= 0. Mutually exclusive with RunAt.
+    TraceParent    string    // W3C trace context (optional).
+    TraceState     string    // W3C trace state (optional).
+}
+```
+
+Field semantics match `POST /v1/codeq/tasks` (see
+[HTTP API reference](./04-http-api.md)). `Command` is the only
+required field; the rest default to zero. The server defaults
+`Payload` to `null` if empty.
+
+### Session.Produce
+
+```go
+func (s *Session) Produce(ctx context.Context, req CreateRequest) (taskID string, err error)
+```
+
+Sends one `CreateTask` event and blocks until the matching
+`CreateAck` arrives, the caller's `ctx` fires, or the underlying
+stream dies.
+
+- On success, returns the server-assigned task id (the same string a
+  REST `POST /v1/codeq/tasks` would return in `202 Accepted`).
+- On `ctx` cancel, deletes the pending entry and returns `ctx.Err()`.
+  A late ack is harmless — `readLoop` logs `ack for unknown seq` at
+  Warn level and discards.
+- On stream death, every in-flight `Produce` returns a
+  `producerclient: stream closed: ...` error.
+- On server-side validation failure (empty command, negative
+  `DelaySeconds`, etc.) returns the error text the server put in
+  `CreateAck.error_message`.
+
+`Produce` is safe to call from many goroutines concurrently. The
+`seq` allocator is atomic and the `sendCh` writer serialises the
+actual `stream.Send` calls.
+
+### Session.ProduceBatch
+
+```go
+type BatchResult struct {
+    TaskID string
+    Err    error
+}
+
+func (s *Session) ProduceBatch(ctx context.Context, reqs []CreateRequest) ([]BatchResult, error)
+```
+
+Pipelines N `CreateTask` events into one `CreateTaskBatch` message and
+waits for the matching `CreateAckBatch`. Returns one `BatchResult` per
+input request, in input order, where `Err` is non-nil for rejected
+tasks and `TaskID` is set for accepted ones.
+
+- The outer error is non-nil only when the batch could not even be
+  sent (closed stream, dead writer) or when `ctx` fired before all
+  acks arrived. Individual task failures are reported per-slot in the
+  result.
+- On partial cancellation (`ctx.Done()` while N of M acks have
+  arrived) the function returns the first N filled `BatchResult`s and
+  `ctx.Err()` as the outer error. Pending entries for the remaining
+  seqs are dropped so late acks log a Warn and are discarded.
+
+`ProduceBatch` is the Phase 6 / Q3 batch entry point. Use it whenever
+the workload tolerates more than a few hundred microseconds of
+batching latency — see § 6.
+
+### Session metadata and lifecycle
+
+```go
+func (s *Session) TenantID() string
+func (s *Session) Subject() string
+func (s *Session) Close() error
+```
+
+- `TenantID` and `Subject` are the values the server resolved during
+  `Hello`. Useful for logging and for asserting that a multi-tenant
+  config actually routed your token to the right namespace.
+- `Close` drains the writer first (closing `sendCh` and waiting for
+  `writerDone`), then `CloseSend`s the stream, then cancels the
+  derived stream context so the reader exits. Safe to call multiple
+  times. Any pending `Produce` calls return `producerclient: stream
+  closed`.
+
+## 6. Batch mode (Phase 6 / Q3)
+
+Single `Produce` calls top out at roughly 46k creates/s for 32
+goroutines on the reference box. `ProduceBatch` with batch size 16
+hits 136k. The gap is real, and it has three sources.
+
+1. **Fewer stream Sends.** One `CreateTaskBatch` message replaces N
+   `CreateTask` messages. The writer goroutine pushes 1/N as many
+   protobuf-encoded frames through the gRPC framing layer, which
+   reduces both CPU and wakeup count on the writer side.
+2. **One server fan-out.** The server processes a batch serially in a
+   single goroutine (`handleCreateBatch` in `internal/producer/server.go`).
+   The Phase 6 / F3 profile showed that spawning one goroutine per
+   `CreateTask` accumulated in `runtime.newstack` — ~8 goroutine spawns
+   per Recv contending on the Pebble commit coalescer. The batch path
+   keeps one goroutine and one allocation per Recv.
+3. **One ack message back.** `CreateAckBatch` packs N acks into one
+   `ServerEvent`. Same compression of wire frames in the other
+   direction.
+
+The wire shape:
+
+```protobuf
+message CreateTaskBatch { repeated CreateTask tasks = 1; }
+message CreateAckBatch  { repeated CreateAck  acks  = 1; }
+```
+
+```mermaid
+sequenceDiagram
+  participant App as Application
+  participant Sess as Session
+  participant Srv as producer.Server
+  participant Peb as Pebble
+  App->>Sess: ProduceBatch([req1..req16])
+  Note over Sess: allocate 16 seqs, register pending entries
+  Sess->>Srv: CreateTaskBatch{tasks=[seq 1..16]}
+  Note over Srv: handleCreateBatch (single goroutine, serial loop)
+  Srv->>Peb: CreateTask seq=1
+  Peb-->>Srv: ok t-001
+  Srv->>Peb: CreateTask seq=2
+  Peb-->>Srv: ok t-002
+  Note over Srv: ... 14 more ...
+  Srv->>Peb: CreateTask seq=16
+  Peb-->>Srv: ok t-016
+  Srv-->>Sess: CreateAckBatch{acks=[16 acks, input order]}
+  Note over Sess: readLoop delivers each ack to its per-seq channel
+  Sess-->>App: []BatchResult (input order)
+```
+
+### When to batch
+
+- **Yes, batch**: bulk ingestion (CSV import, replay of a backlog,
+  fan-out from a single upstream event), workloads where the producer
+  is producer-only and can buffer briefly to amortise the wire cost.
+- **No, do not batch**: latency-critical paths where each task must
+  ack within sub-millisecond bounds, low-rate workloads where the
+  buffering delay exceeds the throughput benefit, or anywhere the
+  producer cannot tolerate one slow task in a batch slowing the
+  others. (The batch returns when all N have been processed.)
+
+### Latency vs throughput trade-off
+
+Single `Produce`: per-task latency is one round-trip plus one Pebble
+commit. Throughput is bounded by `sendCh` contention and per-task
+goroutine spawn cost.
+
+`ProduceBatch(N)`: per-task latency is one round-trip plus N serial
+Pebble commits *for that batch*. Throughput multiplies because the
+wire-side overhead is amortised across N tasks.
+
+A reasonable default is `N=16`. Larger batches push more amortisation
+but increase tail latency for the last task in the batch.
+
+## 7. Error handling
+
+The stream is the trust boundary. Three failure modes matter:
+
+### 7.1 Stream dead
+
+Network drop, server restart, or `Close` from either side. The reader
+goroutine receives an error on `stream.Recv` and:
+
+1. Sets `Session.readErr` so future `Produce` calls fail fast via
+   `peekReadErr`.
+2. Walks the `pending` map and delivers `deadStreamErr(err)` to every
+   waiting channel, so no goroutine blocks forever.
+3. Exits.
+
+Callers see a `producerclient: stream closed: <wrapped err>` error.
+The recovery pattern is to `Close` the session, open a new one via
+`Client.Connect`, and retry — same `Client`, same `grpc.ClientConn`,
+new stream.
+
+### 7.2 Server reject
+
+The server returns `CreateAck{ok: false, error_message: "..."}` for
+per-request validation failures. `Produce` returns
+`errors.New(error_message)`; `ProduceBatch` reports it in
+`BatchResult.Err`. These are not stream-fatal — the next `Produce`
+on the same session works fine.
+
+Examples surfaced through this path:
+
+- `command is required` — empty `Command`.
+- `delaySeconds must be >= 0` — negative `DelaySeconds`.
+- Anything `services.SchedulerService.CreateTask` returns (idempotency
+  conflict, tenant-mode violation, persistence error).
+
+### 7.3 Handshake failure
+
+`Client.Connect` returns an error if:
+
+- The bearer token is empty or invalid (`Unauthenticated`).
+- The server returns `ServerError` in place of `HelloAck`.
+- The stream fails to open (network, TLS handshake, server not
+  listening).
+
+There is no retry inside the SDK. Callers decide whether to back off
+and reconnect.
+
+### 7.4 Retry strategy
+
+Recommended pattern for production producers:
+
+```go
+for {
+    sess, err := cli.Connect(ctx)
+    if err != nil {
+        // backoff before retry — could be auth or transient network
+        time.Sleep(backoff.NextWith(err))
+        continue
+    }
+    runProducerLoop(ctx, sess) // returns when stream dies or ctx fires
+    _ = sess.Close()
+    if ctx.Err() != nil {
+        return
+    }
+}
+```
+
+The application owns the outer retry loop. The SDK keeps the inner
+loop simple — fail fast, fail visibly, do not paper over a dead
+stream.
+
+## 8. Concurrency model
+
+`Session` is designed for many goroutines calling `Produce`
+concurrently. The contract:
+
+| State | Owner | Synchronisation |
+|---|---|---|
+| `sendCh` | many producers write, `writeLoop` reads | buffered chan |
+| `seq` | every `Produce` increments | `atomic.Uint64` |
+| `pending` | producers register, `readLoop` deletes | `sync.Map` |
+| `sendErr` | `writeLoop` sets once, all readers observe | `atomic.Pointer[error]` |
+| `readErr` | `readLoop` sets, `peekReadErr` reads | `sync.Mutex` |
+| `closed` | `Close` flips | `atomic.Bool` + `closeMu` |
+
+The send path looks like this in
+[`pkg/producerclient/client.go`](../pkg/producerclient/client.go):
+
+```go
+func (s *Session) send(ev *producerpb.ProducerEvent) error {
+    if errPtr := s.sendErr.Load(); errPtr != nil {
+        return *errPtr
+    }
+    select {
+    case s.sendCh <- ev:
+        return nil
+    case <-s.streamCtx.Done():
+        return s.streamCtx.Err()
+    }
+}
+```
+
+There is no mutex on the producer-facing send path. The buffered
+channel absorbs short bursts, the writer goroutine drains it, and
+`atomic.Pointer[error]` is the bound between "stream is dead" and "we
+should stop trying". The Phase 6 / M1 profile is the reason this is
+shaped the way it is — the previous mutex-based send had measurable
+contention across pipelined callers.
+
+`Close` is the only operation that races with everything else, and it
+takes `closeMu` to serialise itself, then uses `closed.Swap(true)` so
+double-close is a no-op.
+
+## 9. Full working example
+
+End-to-end: dial, pipeline 1000 creates concurrently, handle per-task
+errors, then close cleanly.
+
+```go
+package main
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "log"
+    "log/slog"
+    "os"
+    "sync"
+    "time"
+
+    "github.com/osvaldoandrade/codeq/pkg/producerclient"
+)
+
+func main() {
+    cli, err := producerclient.New(producerclient.Config{
+        Addr:   "localhost:9092",
+        Token:  os.Getenv("CODEQ_PRODUCER_TOKEN"),
+        Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+    })
+    if err != nil {
+        log.Fatalf("producerclient.New: %v", err)
+    }
+    defer cli.Close()
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    sess, err := cli.Connect(ctx)
+    if err != nil {
+        log.Fatalf("Connect: %v", err)
+    }
+    defer sess.Close()
+    log.Printf("connected: tenant=%s subject=%s", sess.TenantID(), sess.Subject())
+
+    const total = 1000
+    const goroutines = 32
+
+    payload := []byte(`{"source":"example","kind":"smoke"}`)
+    work := make(chan int, total)
+    for i := 0; i < total; i++ {
+        work <- i
+    }
+    close(work)
+
+    var ok, fail int64
+    var wg sync.WaitGroup
+    for w := 0; w < goroutines; w++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            for i := range work {
+                _, err := sess.Produce(ctx, producerclient.CreateRequest{
+                    Command:        "GENERATE_MASTER",
+                    Payload:        payload,
+                    Priority:       5,
+                    MaxAttempts:    3,
+                    IdempotencyKey: fmt.Sprintf("example-%d", i),
+                })
+                switch {
+                case err == nil:
+                    atomicAdd(&ok)
+                case errors.Is(err, context.Canceled),
+                    errors.Is(err, context.DeadlineExceeded):
+                    return
+                default:
+                    log.Printf("Produce %d failed: %v", i, err)
+                    atomicAdd(&fail)
+                }
+            }
+        }()
+    }
+    wg.Wait()
+
+    log.Printf("done: ok=%d fail=%d", ok, fail)
+}
+```
+
+(`atomicAdd` is a stand-in for `sync/atomic.AddInt64` on a `*int64`;
+the real example would declare those as `atomic.Int64` for the same
+result without the helper.)
+
+For the batch variant, replace the inner `for i := range work` body
+with a buffered slice of `CreateRequest` of size 16 and call
+`sess.ProduceBatch(ctx, reqs)` per batch. Same error handling pattern;
+inspect `BatchResult.Err` per slot.
+
+## 10. Comparison: REST vs Stream vs StreamBatch
+
+| Dimension | `POST /v1/codeq/tasks` | `Session.Produce` | `Session.ProduceBatch` |
+|---|---|---|---|
+| Wire | HTTP/1.1 + JSON | gRPC bidi + protobuf | gRPC bidi + protobuf |
+| Auth | every request | once at Hello | once at Hello |
+| Throughput (32g, reference box) | ~16,453 creates/s | ~46,000 creates/s | **136,392 creates/s** |
+| Per-task latency floor | one HTTP RTT + 1 Pebble commit | one stream RTT + 1 Pebble commit | one stream RTT + N serial Pebble commits |
+| Back-pressure | TCP + `http.Server` limits | `sendCh` buffer (256) + stream flow control | `sendCh` buffer + stream flow control |
+| Failure unit | one request | one Produce call | one batch (atomic at wire level) |
+| Connection model | short-lived | long-lived, recoverable | long-lived, recoverable |
+| Idempotency key | yes (body field) | yes (`CreateRequest.IdempotencyKey`) | yes (per-request) |
+| Best for | one-off CLI tools, polyglot clients without an SDK | low-latency producer in Go | bulk ingestion, high-rate producers |
+| Reference harness | `TestProducerThroughput_RESTPath` | `TestProducerThroughput_StreamPath` | `TestProducerThroughput_StreamBatchPath` |
+
+The numbers come from
+`internal/bench/producer_stream_vs_rest_test.go` on the reference box
+(12-core Linux, Go 1.25.0, Pebble persistence, no fsync, 32 goroutines,
+6 s measurement window). See
+[Performance baselines](./30-performance-baselines.md) for raw output
+and historical numbers.
+
+## 11. Source map
+
+- `pkg/producerclient/client.go` — the SDK itself: `Config`, `Client`,
+  `Session`, `Produce`, `ProduceBatch`.
+- `internal/producer/server.go` — server-side stream handler, `Hello`
+  validation, fan-out, `handleCreateBatch`.
+- `internal/producer/proto/producerpb.proto` — wire definition for
+  `Hello`, `CreateTask`, `CreateTaskBatch`, `CreateAck`,
+  `CreateAckBatch`, `ServerError`, `ServerEvent`.
+- `internal/bench/producer_stream_vs_rest_test.go` — the harness
+  behind every throughput number in this doc.
+
+## See also
+
+- [gRPC streaming API guide](./34-streaming-api-guide.md) — protocol
+  overview and wire-level walkthrough.
+- [Worker streaming SDK](./36-worker-streaming-sdk.md) — the symmetric
+  consumer-side SDK for claiming and completing tasks.
+- [HTTP API reference](./04-http-api.md) — the REST path the streaming
+  SDK replaces on the hot path.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and historical numbers for every claim cited here.

--- a/docs/_STYLE.md
+++ b/docs/_STYLE.md
@@ -1,0 +1,291 @@
+# codeq documentation style guide
+
+This is the canonical style guide for codeq documentation. Every doc in
+`docs/` and the root `README.md` must follow it. Subsequent waves of doc
+revisions cite this file verbatim where relevant (especially the value
+proposition and comparativos). If you change the value proposition here,
+you must update the docs that quote it.
+
+## 1. Value proposition
+
+### One-line
+
+> codeq is an embedded high-performance task queue: a single Go binary,
+> Pebble for persistence, gRPC streaming for the wire — 83k tasks/s on
+> one machine with zero external dependencies.
+
+### One-paragraph
+
+> codeq is a task queue written in Go that runs as a single process and
+> stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+> from CockroachDB). The hot path is bidirectional gRPC streams from
+> producers and workers; under the streams sits an intra-process shard
+> table (up to N independent Pebble instances) and an in-memory lease
+> table. The result on a 12-core Linux box is 83,420 tasks/s for the
+> full create → claim → complete cycle, or 136,392 creates/s producer-
+> only. No Redis, no broker, no coordinator required in the default
+> mode. Cluster (consistent-hash + gRPC routing) and a legacy Redis
+> backend are opt-in for HA and multi-node deployments.
+
+### Comparativos (use verbatim or as a base)
+
+| Dimension | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | None (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper or KRaft cluster |
+| Throughput (single node, full cycle) | 83k tasks/s | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | 100k+ msgs/s, but no task semantics |
+| Language affinity | Go (HTTP + gRPC; SDKs for Java, Node, Python, Go) | Go | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant native | Yes (JWT tenantId namespacing built in) | No | No | No | No |
+| Learning curve | One binary, HTTP + curl in minutes | Moderate (Redis ops) | Moderate (Node + Redis) | High (broker + result backend) | High (broker, consumer groups, schema registry) |
+
+When citing this table in a doc, link back here:
+
+> See [_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## 2. Audience profile
+
+Primary reader: **backend engineer evaluating alternatives to Redis-backed
+task queues**. They are typically deciding between Asynq (Go + Redis),
+BullMQ (Node + Redis), Celery (Python + broker), Sidekiq (Ruby + Redis),
+Temporal (workflow engine), and Kafka (event log used as a queue).
+
+What they care about, ranked:
+
+1. **Throughput** — concrete numbers, harness names, and the box they
+   were measured on. No "blazing fast", no "10x". Cite the benchmark.
+2. **Operational cost** — how many processes, how many config knobs, how
+   long until they can `curl` a task.
+3. **Language affinity** — Go server, but with first-class SDKs for the
+   reader's stack.
+4. **Durability and at-least-once** — what survives a crash, and how
+   they prove it.
+5. **Multi-tenant** — whether they can run one queue server for many
+   customers without writing isolation themselves.
+6. **HA and scaling story** — single-node first, but with a credible
+   path to multi-node.
+
+Write for someone who already understands queues. Skip onboarding to
+basic concepts like "what is a task". Do define codeq-specific terms
+(shard, lease table, ring, scatter-gather) the first time they appear.
+
+## 3. Voice and tone
+
+### Numbers first, narrative second
+
+Bad:
+
+> codeq is blazing fast and can handle massive workloads.
+
+Good:
+
+> codeq sustains 83,420 tasks/s for a full create → claim → complete
+> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
+> batch=8, 128 worker slots, 20s measurement window
+> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
+
+Every throughput claim cites:
+
+- The exact test name in `internal/bench/`.
+- The env vars used to parameterize it.
+- The hardware class (cores, OS).
+- The measurement window.
+
+### Honest about limitations
+
+Always name the trade-offs. Examples to use as templates:
+
+- "HA is only available via the Redis backend or by running a cluster of
+  Pebble nodes. A single Pebble process loses availability while it
+  restarts; recovery is fast (in-memory lease table rebuilt from the
+  `KeyInprog` scan at Open) but not instantaneous."
+- "Cluster mode and intra-process sharding (`numShards > 1`) are
+  mutually exclusive — startup panics if both are enabled. Pick one:
+  multi-node across machines, or multi-shard inside one process."
+- "Delivery is at-least-once, not exactly-once. A worker that crashes
+  between completion and ACK will see its task re-delivered after the
+  lease expires."
+
+### No marketing fluff
+
+Banned words: blazing, massive, lightning, seamless, robust,
+cutting-edge, world-class, next-gen, revolutionary.
+
+Replace adjectives with measurements. If you cannot measure it, do not
+claim it.
+
+### Opinionated
+
+Tell the reader what to pick:
+
+- "For single-node deployments use Pebble with `numShards: 4`."
+- "Do not enable `fsyncOnCommit` unless you have measured the latency
+  impact in your workload — it costs ~20% throughput in our harness."
+- "Use Redis only if you need multi-node HA today and cannot deploy the
+  cluster mode."
+
+## 4. Markdown conventions
+
+- **Headings**: ATX style (`#`), single `#` per file (the title), then
+  `##` for top-level sections, `###` for subsections. Do not skip
+  levels.
+- **Code blocks**: always tag the language.
+  - `bash` for shell, `go` for Go, `yaml` for config, `json` for JSON,
+    `protobuf` for `.proto`, `mermaid` for diagrams.
+  - Untagged blocks are forbidden — they break syntax highlighting on
+    GitHub.
+- **Admonitions** (GitHub-flavored):
+
+  ```markdown
+  > **Note**: a normal aside.
+  > **Warning**: a footgun. Always for irreversible operations or
+  > silent data loss.
+  > **Performance**: a tuning hint with a number.
+  ```
+
+- **Tables**: pipe-aligned, header row separator `---`. Always have a
+  header row. Cells with multi-word values stay on one line.
+- **Inline code**: backticks for file paths, env vars, config keys,
+  function names, and protocol constants.
+- **Lists**: `-` for unordered, `1.` for ordered. Two spaces of
+  indentation for nested items.
+- **Links**: prefer descriptive text over "click here". Relative links
+  for in-repo references (see §6).
+
+## 5. Mermaid conventions
+
+All diagrams must render on the GitHub default theme in both light and
+dark mode. **Never set inline colors or styles** — let the renderer
+pick.
+
+### Flow diagrams
+
+Use `graph TB` for top-to-bottom layered architecture, `graph LR` for
+left-to-right pipelines. Always use `subgraph` to delimit logical
+layers.
+
+```mermaid
+graph TB
+  subgraph Producers
+    P1[Producer SDK]
+  end
+  subgraph Server[codeq server]
+    HTTP[HTTP API]
+    GRPC[gRPC stream]
+  end
+  subgraph Storage
+    PEB[Pebble shards]
+  end
+  P1 --> GRPC
+  GRPC --> PEB
+  HTTP --> PEB
+```
+
+Aim for 8 to 12 nodes max in a single diagram. If it grows past that,
+split it.
+
+### Sequence diagrams
+
+Use `sequenceDiagram` for flows over time. Participant names start
+capitalized.
+
+```mermaid
+sequenceDiagram
+  participant Producer
+  participant Server
+  participant Pebble
+  Producer->>Server: Produce(task)
+  Server->>Pebble: BatchCommit
+  Pebble-->>Server: ack
+  Server-->>Producer: TaskID
+```
+
+### State machines
+
+Use `stateDiagram-v2` for task lifecycle. Transition labels describe
+the **trigger action**, not the resulting state.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  DLQ --> [*]
+```
+
+### No inline colors
+
+Bad:
+
+```text
+style P1 fill:#f9f,stroke:#333
+```
+
+Good: nothing — let the theme decide.
+
+## 6. Cross-link policy
+
+Every doc ends with a `## See also` section enumerating related docs.
+Example:
+
+```markdown
+## See also
+
+- [Architecture](./03-architecture.md)
+- [Storage layout (Pebble)](./07b-storage-pebble.md)
+- [Performance tuning](./17-performance-tuning.md)
+```
+
+Path conventions:
+
+- **Inside `docs/`** (doc-to-doc): use relative paths starting with
+  `./`, e.g. `[Overview](./01-overview.md)`.
+- **From root `README.md`** (or other root-level files): use paths
+  rooted at `docs/`, e.g. `[Overview](docs/01-overview.md)`.
+- **To source files**: use repo-rooted paths, e.g.
+  `[application.go](../pkg/app/application.go)` from inside `docs/`, or
+  `pkg/app/application.go` from `README.md`.
+- **Anchors**: lowercase, hyphen-separated, match GitHub's slug
+  algorithm.
+
+When you cite the value prop, link to this file:
+
+```markdown
+See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+```
+
+## 7. Numbers must come from measurement
+
+Every throughput, latency, or memory claim in any doc must be traceable
+to a test in `internal/bench/`. The format is:
+
+> N tasks/s (`internal/bench/<file>.go::<TestName>`, env: `KEY=VAL`,
+> hardware: 12-core Linux).
+
+Catalog of canonical benchmarks (use these names, do not invent new
+ones):
+
+| Workload | Harness | Result on reference box |
+|---|---|---|
+| Full cycle, 4 shards, batched | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) | 83,420 tasks/s |
+| Producer-only, batched stream | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` | 136,392 creates/s |
+| Worker-only, batched stream | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) | 23,518 tasks/s |
+| Shard sweep | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=1,2,4,6,8`) | 42k / 65k / 83k / 68k / 67k |
+
+Reference box: 12-core Linux (kernel 5.15, WSL2-compatible), Go 1.25.0,
+local Pebble, loopback gRPC, no fsync.
+
+If you need a number that is not in this table, run the bench, add the
+row here, then cite it in your doc. Do not estimate.
+
+## See also
+
+- [README](../README.md) — applies this style guide at the entry point.
+- [Overview](./01-overview.md) — the canonical statement of what codeq
+  is.
+- [Architecture](./03-architecture.md) — package-level breakdown.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and historical numbers.


### PR DESCRIPTION
## Summary

- New `docs/35-producer-streaming-sdk.md` (~680 lines) — comprehensive reference for the Go producer streaming SDK in `pkg/producerclient`.
- Covers wire architecture, `Hello` handshake, async pipelining with `seq` correlation, full `Config` / `Client` / `Session.Produce` / `Session.ProduceBatch` API surface, Phase 6 / Q3 batch path, error / retry strategy, concurrency model (sendCh writer goroutine + `atomic.Pointer[error]`), a working 1000-task Go example, and a REST vs `Produce` vs `ProduceBatch` comparison table.
- Cites `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (136,392 creates/s, 8.29× over REST) per `_STYLE.md` rules. Links back to 34-streaming-api-guide, 36-worker-streaming-sdk, 04-http-api, 30-performance-baselines via `## See also`.
- Four Mermaid diagrams: `graph TB` architecture, three `sequenceDiagram` (Hello handshake, in-flight 3-way pipelining with out-of-order acks, batch pipeline with Pebble interactions). No inline colors, follows `_STYLE.md § 5`.

## Test plan

- [ ] CI / link checker on docs branch passes
- [ ] Mermaid diagrams render on GitHub preview in both light and dark themes
- [ ] Cross-links to `34-streaming-api-guide.md`, `04-http-api.md`, `30-performance-baselines.md`, `_STYLE.md` resolve
- [ ] Forward-link to `36-worker-streaming-sdk.md` (Wave 3 U9) is reserved — verify once that doc lands

Wave 3 U8 — branched off `docs/wave1-u1-foundation`.

Generated with Claude Code.