### PR TITLE
docs(runbooks): Pebble, Phase 8 sharding, and cluster operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,108 @@
-# codeQ
+# codeq
 
-Reactive scheduling and completion system backed by persistent queues. Choose your storage: KVRocks (distributed) or Pebble (embedded).
+> Embedded high-performance task queue. One Go binary, Pebble for
+> storage, gRPC streams on the wire. 83k tasks/s on a single 12-core
+> box with zero external dependencies.
 
-This repository contains the core runtime, HTTP API wiring, and a Helm chart for small clusters.
-The production service wrapper lives at:
-https://github.com/codecompany/codeq-service
+[![Go Reference](https://pkg.go.dev/badge/github.com/osvaldoandrade/codeq.svg)](https://pkg.go.dev/github.com/osvaldoandrade/codeq)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Issues](https://img.shields.io/github/issues/osvaldoandrade/codeq.svg)](https://github.com/osvaldoandrade/codeq/issues)
 
-## Links
+## What is codeq?
 
-- GitHub: https://github.com/osvaldoandrade/codeq
-- Issues: https://github.com/osvaldoandrade/codeq/issues
-- Specs index: `docs/README.md`
+codeq is a task queue written in Go. The default deployment is a single
+process: the server, the persistence layer (Pebble, the RocksDB-style
+LSM from CockroachDB), the lease table, and the gRPC + HTTP API all
+share one binary and one disk directory. There is no Redis to run, no
+broker to babysit, no consensus to coordinate.
 
-## Why codeQ
+On a 12-core Linux box, that single binary sustains **83,420 tasks/s**
+for the full create → claim → complete cycle and **136,392 creates/s**
+for producer-only workloads — measured by the in-tree benchmarks in
+`internal/bench/`. When one machine is no longer enough, cluster mode
+(consistent-hash ring + gRPC routing between nodes) and a legacy Redis
+backend are opt-in.
 
-codeQ provides:
+## Architecture overview
 
-- Persistent queues with pluggable storage backends:
-  - **Redis/KVRocks** (distributed, cluster-capable)
-  - **Pebble** (embedded, zero-dependency, ideal for local development)
-- Pull-based worker claims with leases.
-- **Multi-tenant queue isolation** with automatic tenant ID extraction from JWT claims.
-- **Horizontal scaling with queue sharding**: Optional pluggable `ShardSupplier` interface for routing commands/tenants across multiple KVRocks instances.
-- **Pluggable persistence backends**: Redis, memory (testing), and extensible plugin architecture for custom storage (PostgreSQL, DynamoDB, Cassandra, etc.).
-- NACK + backoff + delayed queues.
-- DLQ for tasks that exceed `maxAttempts`.
-- Result storage and optional callbacks (webhooks).
-- Worker auth via JWT (JWKS), producer auth via Tikti access tokens (JWKS).
-- **Official SDKs** for Java and Node.js/TypeScript with framework integrations.
-- **Distributed tracing** with OpenTelemetry support for end-to-end observability.
-- **Optimized performance**: O(1) queue operations with pipelined lease repair for low-latency claims even under high load.
-- **Load testing framework**: Comprehensive k6 scenarios and Go benchmarks for performance validation and regression testing.
+```mermaid
+graph TB
+  subgraph Clients
+    PSDK[Producer SDK]
+    WSDK[Worker SDK]
+    CURL[HTTP / curl]
+  end
+  subgraph Server[codeq server -- single binary]
+    HTTP[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+  end
+  subgraph Storage[Embedded persistence]
+    P0[Pebble shard 0]
+    P1[Pebble shard 1]
+    PN[Pebble shard N-1]
+  end
+  subgraph Optional[Opt-in scaling]
+    CL[Cluster -- consistent-hash + gRPC]
+    REDIS[Redis backend -- legacy HA]
+  end
+  PSDK --> PGRPC
+  WSDK --> WGRPC
+  CURL --> HTTP
+  HTTP --> LEASE
+  PGRPC --> LEASE
+  WGRPC --> LEASE
+  LEASE --> P0
+  LEASE --> P1
+  LEASE --> PN
+  Server -.-> CL
+  Server -.-> REDIS
+```
 
-## Get started
+Producers and workers connect over long-lived bidirectional gRPC
+streams. Each request hits the in-memory lease table first, then commits
+to a Pebble shard chosen by `hash(taskID) % N`. Each shard runs its own
+commit pipeline and compaction loop, which is what lets a 4-shard
+configuration roughly double the single-shard throughput on the same
+hardware.
 
-### Local development with Docker Compose
+## Performance
 
-The quickest way to try codeQ locally:
+All numbers measured on a 12-core Linux box, Go 1.25.0, loopback gRPC,
+Pebble with `fsyncOnCommit=false`. Full bench harness lives in
+`internal/bench/`.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle (create + claim + complete), 4 Pebble shards | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` |
+| Worker-only, batched claim+complete | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep (full cycle, 1 / 2 / 4 / 6 / 8 shards) | 42k / 65k / **83k** / 68k / 67k tasks/s | same as full cycle harness with `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on a 12-core box; past that, write
+amplification and goroutine contention start to dominate. See
+[docs/30-performance-baselines.md](docs/30-performance-baselines.md)
+for raw output and per-release history.
+
+## Why codeq vs alternatives
+
+| Feature | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | **None** (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper / KRaft cluster |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | n/a (no task semantics) |
+| Language affinity | Go server, SDKs for Java, Node, Python, Go | Go only | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant isolation | **Built in** (JWT tenantId namespacing) | DIY | DIY | DIY | DIY |
+| Time-to-first-task | `docker run` + `curl` | Run Redis + Asynq | Run Redis + worker | Run broker + workers + result backend | Multi-step cluster bootstrap |
+
+codeq is the right call when you want task-queue semantics (claims,
+leases, retries, DLQ, results) without standing up a broker. It is the
+wrong call if you need Kafka-scale event streaming, distributed
+consensus by default, or HA without configuring the Redis backend or
+cluster mode.
+
+## Quick start (5 minutes)
 
 ```bash
 git clone https://github.com/osvaldoandrade/codeq
@@ -47,125 +113,10 @@ docker compose \
   up -d
 ```
 
-This starts KVRocks, the codeQ API server, and seeds example tasks. Access at `http://localhost:8080`.
+This brings up the codeq server on `http://localhost:8080` with the
+embedded Pebble backend (no Redis required) and seeds example tasks.
 
-See [Local Development Guide](docs/22-local-development.md) for details on hot reload, testing, and observability.
-
-### Install a server
-
-Use the console wizard to generate a Docker or Kubernetes/Helm install bundle:
-
-```bash
-codeq install
-```
-
-Non-interactive Kubernetes example:
-
-```bash
-codeq install \
-  --target kubernetes \
-  --size small \
-  --namespace codeq \
-  --identity-service-url https://issuer.example.com \
-  --worker-jwks-url https://issuer.example.com/.well-known/jwks.json \
-  --worker-issuer https://issuer.example.com
-```
-
-### Install CLI (macOS/Linux/Windows via Git Bash)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
-```
-
-Requires `git` and `go`.
-
-### Install CLI via npm (npmjs)
-
-```bash
-npm i -g @osvaldoandrade/codeq
-codeq --help
-```
-
-Upgrade:
-
-```bash
-npm i -g @osvaldoandrade/codeq@latest
-```
-
-### Use SDKs for Java, Node.js, Python, and Go
-
-Integrate codeQ into your microservices with official SDKs:
-
-**Java** (Spring Boot, Quarkus, Micronaut):
-```xml
-<dependency>
-    <groupId>io.codeq</groupId>
-    <artifactId>codeq-sdk-java</artifactId>
-    <version>1.0.0</version>
-</dependency>
-```
-
-**Node.js/TypeScript** (Express, NestJS):
-```bash
-npm install @osvaldoandrade/codeq-client
-```
-
-**Python** (FastAPI, Django, Flask):
-```bash
-pip install codeq-client
-```
-
-**Go** (Gin, Echo, stdlib):
-```bash
-go get github.com/osvaldoandrade/codeq/sdks/go
-```
-
-📚 **SDK Documentation**:
-- [SDK Overview & Quick Start](sdks/README.md)
-- [Java SDK](sdks/java/README.md)
-- [Node.js SDK](sdks/nodejs/README.md)
-- [Python SDK](sdks/python/README.md)
-- [Go SDK](sdks/go/README.md)
-- [Integration Guides](docs/integrations/)
-- [Example Applications](examples/)
-
-### Helm
-
-The chart in this repo deploys codeQ and, by default in the small profile, a single-node KVRocks instance.
-
-```bash
-git clone https://github.com/osvaldoandrade/codeq
-cd codeq
-
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-small.yaml \
-  --namespace codeq --create-namespace \
-  --set secrets.enabled=true \
-  --set secrets.webhookHmacSecret=YOUR_SECRET \
-  --set config.identityServiceUrl=https://your-auth-server.com \
-  --set config.workerJwksUrl=https://your-jwks \
-  --set config.workerIssuer=https://issuer
-```
-
-Disable embedded KVRocks and point to your own:
-
-```bash
-helm upgrade --install codeq ./helm/codeq \
-  -f ./helm/codeq/values-medium.yaml \
-  --set kvrocks.enabled=false \
-  --set config.redisAddr=your-kvrocks:6666
-```
-
-### 2) Service runtime
-
-The API server and Dockerfile are in the service repo:
-https://github.com/codecompany/codeq-service
-
-That repo consumes this module and exposes the HTTP API.
-
-## Quick API flow
-
-Create a task (producer token):
+Create a task:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks \
@@ -174,7 +125,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"priority":3}'
 ```
 
-Claim a task (worker JWT):
+Claim a task (as a worker):
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
@@ -183,7 +134,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
   -d '{"commands":["GENERATE_MASTER"],"leaseSeconds":120,"waitSeconds":10}'
 ```
 
-Submit result:
+Submit a result:
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
@@ -192,49 +143,95 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
   -d '{"status":"COMPLETED","result":{"ok":true}}'
 ```
 
-## Specs and docs
+For high-throughput producers and workers, use the gRPC streaming API
+(2-3x the HTTP throughput, amortized auth, pipelined acks): see
+[docs/34-streaming-api-guide.md](docs/34-streaming-api-guide.md).
 
-Start here: `docs/README.md`
+## Where next
 
-Key references:
+- [Getting started tutorial](docs/00-getting-started.md) — your first
+  task, end to end.
+- [Overview](docs/01-overview.md) — goals, non-goals, when (and when
+  not) to pick codeq.
+- [Architecture](docs/03-architecture.md) — package layout and request
+  flows.
+- [Performance tuning](docs/17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Operational runbooks](docs/29-operational-runbooks.md) — on-call
+  procedures for the common failure modes.
+- [Streaming API guide](docs/34-streaming-api-guide.md) — gRPC
+  producer and worker streams.
+- [Cluster architecture](docs/05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Style guide](docs/_STYLE.md) — voice, numbers, diagrams, links.
 
-- **Getting Started Tutorial**: `docs/00-getting-started.md` - **Start here for your first experience with codeQ**
-- **Overview**: `docs/01-overview.md` - System goals and design principles
-- **Architecture**: `docs/03-architecture.md` - System components and multi-tenant architecture
-- **Security**: `docs/09-security.md` - Authentication, authorization, and tenant isolation
-- **HTTP API**: `docs/04-http-api.md` - Complete API reference
-- **CLI Reference**: `docs/15-cli-reference.md` - CLI command documentation
-- **SDK Integration**: `sdks/README.md` - Official Java and Node.js SDKs
-  - [Java Integration](docs/integrations/java-integration.md) - Spring Boot, Quarkus, Micronaut
-  - [Node.js Integration](docs/integrations/nodejs-integration.md) - Express, NestJS, React
-- **Examples**: `examples/` - Working examples with Java and Node.js frameworks
-- **Developer Guide**: `docs/21-developer-guide.md` - Contributing and internal architecture
-- **Queue model**: `docs/05-queueing-model.md` - Queue semantics
-- **Storage layout**: `docs/07-storage-kvrocks.md` - KVRocks data structures
-- **Backoff and retries**: `docs/11-backoff.md` - Retry logic
-- **Webhooks**: `docs/12-webhooks.md` - Push notifications
-- **Configuration**: `docs/14-configuration.md` - Config reference
-- **Operations**: `docs/10-operations.md` - Metrics, health checks, and tracing
-- **Workflows**: `docs/16-workflows.md` - GitHub Actions automation
-- **Performance**: `docs/17-performance-tuning.md` - Optimization guide
-- **Load Testing**: `docs/26-load-testing.md` - Load testing framework and benchmarks
-- **Testing**: `docs/19-testing.md` - Test coverage and strategy
-- **Authentication Plugins**: `docs/20-authentication-plugins.md` - Plugin system for custom auth
-- **Persistence Plugins**: `docs/27-persistence-plugin-system.md` - Pluggable storage backends (Redis, Memory, and more)
-- **Design Documents**:
-  - `docs/24-queue-sharding-hld.md` - Queue sharding high-level design
-  - `docs/25-plugin-architecture-hld.md` - Plugin architecture for persistence and auth
-- **Migration**: `docs/migration.md` - Upgrade guide
-- **Contributing**: `CONTRIBUTING.md` - Contribution guidelines
+## SDKs
+
+Official client libraries for the languages most likely to talk to
+codeq from application code:
+
+- **Go** — `go get github.com/osvaldoandrade/codeq/sdks/go` ([README](sdks/go/README.md))
+- **Java** (Spring Boot, Quarkus, Micronaut) — [sdks/java/README.md](sdks/java/README.md)
+- **Node.js / TypeScript** (Express, NestJS) — [sdks/nodejs/README.md](sdks/nodejs/README.md)
+- **Python** (FastAPI, Django, Flask) — [sdks/python/README.md](sdks/python/README.md)
+
+Integration recipes per framework live under
+[docs/integrations/](docs/integrations/). End-to-end example apps live
+under [examples/](examples/).
 
 ## Repo layout
 
-- `pkg/`: public packages (`app`, `config`, `domain`)
-- `internal/`: controllers, middleware, services, repositories, providers
-- `deploy/`: Docker Compose, Kubernetes, and config examples
-- `helm/codeq`: Helm chart and size profiles
-- `docs/`: full specification
+```text
+cmd/                  CLI entrypoints (codeq install, server)
+internal/             unexported packages
+  bench/              throughput + latency benchmarks (source of truth for perf claims)
+  cluster/            consistent-hash ring, gRPC router, bloom gossip
+  controllers/        HTTP handlers (Gin)
+  middleware/         auth, tracing, rate-limit, tenant extraction
+  producer/           gRPC producer-stream server
+  worker/             gRPC worker-stream server
+  repository/         persistence implementations (Redis legacy + Pebble)
+  services/           scheduler, results, callbacks, subscriptions
+pkg/                  public packages (app, auth, config, domain,
+                      producerclient, workerclient)
+sdks/                 official SDKs (go, java, nodejs, python)
+deploy/               docker-compose and Kubernetes config
+helm/codeq/           Helm chart and size profiles
+docs/                 specifications, runbooks, performance baselines
+examples/             end-to-end example applications
+```
+
+## Install the CLI
+
+macOS, Linux, or Windows via Git Bash:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
+```
+
+Or via npm:
+
+```bash
+npm i -g @osvaldoandrade/codeq
+codeq --help
+```
+
+To generate a Docker or Kubernetes install bundle (with embedded Pebble
+by default, no Redis required):
+
+```bash
+codeq install
+```
+
+See [docs/15-cli-reference.md](docs/15-cli-reference.md) for the full
+CLI surface.
+
+## Contributing
+
+Issues and PRs are welcome. Before opening a PR, read
+[CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, and
+[docs/_STYLE.md](docs/_STYLE.md) for the documentation style.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,27 +1,244 @@
 # Overview
 
-codeQ is a task scheduling and completion service built on persistent queues in KVRocks. The service exposes HTTP APIs for producers to create tasks, for workers to claim and complete tasks, and for operators to inspect and clean up queues. The system is reactive: workers pull tasks, and optionally receive webhook signals that work is available.
+> Source-of-truth for the value proposition lives in
+> [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+> Other docs may cite this overview, but the style guide wins ties.
 
-The design is inspired by Dyno Queues, which adds time-based and priority queues on top of Dynomite. Dynomite is a distributed data layer that exposes Redis semantics and provides multi-datacenter replication. codeQ applies the same motivation to KVRocks and uses Go for the implementation. The service favors availability and throughput over strict global ordering.
+## What is codeq
+
+codeq is a task queue written in Go that runs as a single process and
+stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+from CockroachDB). The hot path is bidirectional gRPC streams from
+producers and workers; under the streams sits an intra-process shard
+table (up to N independent Pebble instances) and an in-memory lease
+table. On a 12-core Linux box the single binary sustains
+**83,420 tasks/s** for the full create → claim → complete cycle and
+**136,392 creates/s** for producer-only workloads.
+
+No Redis, no broker, no coordinator required in the default mode.
+Cluster (consistent-hash ring + gRPC routing) and a legacy Redis backend
+are opt-in for HA and multi-node deployments.
 
 ## Goals
 
-- Provide a stable API for enqueue, claim, and completion.
-- Persist state on disk via KVRocks.
-- Support delayed retries, priority, and retries.
-- Allow workers to pull by event type without a worker registry.
-- Provide optional push notifications without assigning work.
+- **Single binary.** Server, persistence, lease table, HTTP + gRPC API
+  all in one process. One disk directory. One systemd unit. No external
+  database required.
+- **80k+ tasks/s on one machine.** Full create → claim → complete cycle
+  measured by `internal/bench/profile_full_cycle_test.go` with 4 Pebble
+  shards, batched producer + worker streams.
+- **gRPC streaming as a first-class API.** Long-lived bidirectional
+  streams amortize auth and middleware; multiple requests can be in
+  flight before responses arrive.
+- **Multi-tenant by construction.** Every queue key is namespaced by
+  `tenantId` extracted from the JWT. Workers can only claim tasks from
+  their own tenant. No application code required to keep tenants
+  isolated.
+- **Cluster opt-in.** When one machine is no longer enough, run a
+  consistent-hash cluster (no consensus, no coordinator — static
+  membership + gRPC routing).
+- **Configurable durability.** `fsyncOnCommit` is a per-deployment knob.
+  Off by default for throughput; turn it on when your SLO demands it.
 
 ## Non-goals
 
-- Exactly-once processing.
-- Global FIFO across all commands.
-- Automatic worker discovery or scheduling.
+- **Kafka-scale event streaming.** codeq is a task queue, not a
+  partitioned log. If you want millions of messages/s with consumer
+  groups, use Kafka.
+- **Distributed consensus by default.** No Raft, no Paxos. Cluster mode
+  uses a static consistent-hash ring; node membership is configured at
+  startup, not gossiped.
+- **HA without explicit setup.** A single Pebble process loses
+  availability while it restarts. HA requires either the Redis backend
+  (legacy, multi-node) or running a cluster of Pebble nodes — each is a
+  trade-off the operator picks consciously.
+- **Exactly-once delivery.** Delivery is at-least-once. A worker that
+  crashes between completion and ACK will see the task re-delivered
+  after the lease expires.
+- **Global FIFO across all commands.** Ordering is per-(command,
+  tenant, priority) within a Pebble shard. Cross-shard ordering is not
+  defined.
+- **Worker discovery or scheduling.** codeq does not register workers
+  or assign work; workers pull when they are ready.
 
-## High-level data model
+## Data model summary
 
-- Task: unit of work, identified by UUID.
-- Message: queue element containing metadata used by the scheduler.
-- Result: completion record stored independently of the task body.
-- Command (event type): routing key for tasks.
-- Shard: not implemented; queues are single-shard in the current service.
+- **Task** — unit of work. Identified by UUID. Carries `command`
+  (routing key), `payload` (opaque JSON bytes), `priority` (0-9),
+  optional `webhook` URL, and lifecycle state.
+- **Result** — completion record. Stored separately from the task body
+  so completion can be GC'd on a different schedule than the task
+  metadata.
+- **Subscription** — webhook registration. A worker (or coordinator)
+  registers a callback URL for one or more event types; codeq pings it
+  when new work appears.
+
+Task lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> FAILED: SubmitResult(err)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DELAYED: Nack(backoff)
+  DELAYED --> PENDING: MoveDueDelayed
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  FAILED --> [*]
+  DLQ --> [*]
+```
+
+Full schema and state semantics in
+[02-domain-model.md](./02-domain-model.md).
+
+## Architecture summary
+
+```mermaid
+graph TB
+  subgraph Clients
+    SDK[Producer / Worker SDKs]
+    HTTPCLI[HTTP clients -- curl, browsers]
+  end
+  subgraph Server[codeq server]
+    API[HTTP API -- Gin]
+    PGRPC[Producer gRPC stream]
+    WGRPC[Worker gRPC stream]
+    LEASE[In-memory lease table]
+    SCHED[Scheduler core]
+  end
+  subgraph Storage[Embedded persistence -- default]
+    P[Pebble shards 0..N-1]
+  end
+  subgraph OptIn[Opt-in modes]
+    CL[Cluster -- consistent-hash + gRPC routing]
+    REDIS[Redis backend -- legacy, HA]
+  end
+  SDK --> PGRPC
+  SDK --> WGRPC
+  HTTPCLI --> API
+  API --> SCHED
+  PGRPC --> SCHED
+  WGRPC --> SCHED
+  SCHED --> LEASE
+  SCHED --> P
+  Server -.-> CL
+  Server -.-> REDIS
+```
+
+Request flow at a glance:
+
+1. Producer or worker opens a gRPC stream (or sends an HTTP request).
+2. The middleware chain validates the JWT, extracts `tenantId`, and
+   applies rate limits.
+3. The scheduler routes the operation to its Pebble shard
+   (`hash(taskID) % numShards`) and updates the in-memory lease table.
+4. Pebble commits the batch; the group-commit coalescer (Phase 1.1)
+   merges concurrent writers into one fsync.
+5. On worker stream, ready tasks are pushed back through the same long-
+   lived connection — no per-claim handshake.
+
+Package-level breakdown in [03-architecture.md](./03-architecture.md).
+
+## When to use codeq
+
+- **Single-node task queue for a backend service.** You want claims,
+  leases, retries, DLQ, and results without standing up Redis or a
+  broker.
+- **Embedded sidecar in your own Go binary.** Import `pkg/app` and run
+  codeq in-process alongside your application.
+- **Multi-tenant SaaS background jobs.** Per-tenant queue isolation is
+  built in; you do not have to namespace keys yourself.
+- **High-throughput producers with small payloads.** The batched
+  producer stream sustains 100k+ creates/s on commodity hardware.
+- **Polyglot worker fleets.** Workers in Go, Java, Node, or Python can
+  all share the same queue via the official SDKs.
+- **Local development without external services.** `docker run codeq`
+  is enough; no Redis container, no compose dance.
+
+## When NOT to use codeq
+
+- **Kafka-scale event streaming.** Millions of events/s with consumer
+  groups, replay, and a retention window measured in days — use Kafka.
+- **Distributed transactions.** codeq has no two-phase commit and no
+  cross-shard transactions. If your business logic needs atomic updates
+  across multiple tasks, build it above codeq with an outbox pattern or
+  pick a workflow engine.
+- **HA without Redis or cluster mode.** A single Pebble process is
+  unavailable during restart. If your SLO does not tolerate a few
+  seconds of unavailability, you need the Redis backend (multi-node) or
+  a Pebble cluster.
+- **Workflow orchestration with branching, child tasks, timers, and
+  long-running state.** Use Temporal, Cadence, or Step Functions — they
+  are purpose-built for that. codeq is a queue.
+- **Exactly-once delivery semantics.** codeq is at-least-once. Idempotent
+  handlers are the operator's responsibility.
+
+## Performance baselines
+
+Measured on a 12-core Linux box, Go 1.25.0, loopback gRPC, Pebble with
+`fsyncOnCommit=false`, 20s measurement window after a 2s warm-up.
+
+| Workload | Throughput | Harness |
+|---|---:|---|
+| Full cycle, 4 shards, batched | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
+| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (32 goroutines, batch=16) |
+| Worker-only, batched stream | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
+| Shard sweep | 1 shard: 42k; 2: 65k; **4: 83k**; 6: 68k; 8: 67k | same as full cycle, `PHASE8_SHARDS` swept |
+
+Sweet spot is 4 shards on this hardware. Past that, the cost of more
+commit pipelines + compaction loops outweighs the parallelism win. See
+[30-performance-baselines.md](./30-performance-baselines.md) for raw
+output, allocator stats, and the per-release history.
+
+## Comparativos resumidos
+
+| Dimension | codeq | Asynq | BullMQ | Kafka |
+|---|---|---|---|---|
+| External dependency | **None** | Redis | Redis | ZooKeeper / KRaft |
+| Single-node full-cycle throughput | **83k tasks/s** | ~10k | ~5k | n/a (no task semantics) |
+| Language | Go server, multi-language SDKs | Go | Node | Polyglot |
+| Multi-tenant native | **Yes** | DIY | DIY | DIY |
+| HA model | Cluster or Redis (opt-in) | Redis | Redis | Replicated log |
+
+Full table with Sidekiq, Celery, and Temporal lives in
+[_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## What changed (Phases 1-8 summary)
+
+codeq has been through a sequence of refactors that shifted its
+positioning from "Redis-backed queue" to "embedded high-performance
+queue". The short version:
+
+| Phase | Theme | Effect |
+|---|---|---|
+| 0 | kvrocks-primary | First version: KVRocks (Redis protocol) as the only backend. ~1.5-2k tasks/s. |
+| 1 | Pebble embedded backend | Pebble added as a pluggable persistence provider. Single-binary deployment becomes possible. Single-shard throughput ~42k tasks/s. |
+| 1.1 | Pebble fast-paths + group-commit coalescer | `MoveDueDelayed` fast-path; concurrent writers coalesce into one fsync. |
+| 2 | Streaming groundwork | gRPC streaming surfaces designed. Auth amortized across stream lifetime. |
+| 5 | Cluster mode | Consistent-hash ring + gRPC routing between Pebble nodes. No consensus; static membership. |
+| 6 | Batched stream paths | Producer and worker streams gain batch APIs. `PHASE6_BATCH` / `PHASE6_PROD_BATCH` env knobs. |
+| 8 | Intra-process Pebble sharding | `numShards` opens N independent Pebble instances under one process. 4 shards → ~83k tasks/s on a 12-core box. **Mutually exclusive with cluster mode.** |
+
+PRs #527-#547 landed Phases 1.1, 6, and 8. The Redis backend remains
+supported for HA scenarios but is no longer the default.
+
+## See also
+
+- [_STYLE.md](./_STYLE.md) — documentation voice, numbers, diagrams.
+- [Architecture](./03-architecture.md) — package layout and request
+  flows.
+- [HTTP API](./04-http-api.md) — REST surface.
+- [Streaming API guide](./34-streaming-api-guide.md) — gRPC producer
+  and worker streams.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and per-release history.
+- [Performance tuning](./17-performance-tuning.md) — shard counts,
+  batch sizes, fsync trade-offs.
+- [Cluster architecture](./05-cluster-architecture.md) — multi-node
+  consistent-hash deployment.
+- [Storage layout (Pebble)](./07b-storage-pebble.md) — keyspace and
+  sharding internals.
+- [Persistence plugin system](./27-persistence-plugin-system.md) —
+  choosing and configuring backends.

--- a/docs/29-operational-runbooks.md
+++ b/docs/29-operational-runbooks.md
@@ -1017,3 +1017,705 @@ preparation.
 replication instead of the API-based approach above. See
 [§3.3 KVRocks Scaling](#33-kvrocks-scaling-and-replication) for
 replication setup.
+
+---
+
+## 6. Pebble Single-Node Runbook
+
+Sections 1-5 target the legacy KVRocks/Redis backend. From v0.4 the
+default `persistenceProvider` is `pebble` — an embedded LSM that runs
+in-process under `persistenceConfig.path`. Operationally Pebble is
+closer to SQLite or RocksDB than to Redis: no daemon, no network port,
+exclusive directory lock. See
+[Storage layout (Pebble)](./07b-storage-pebble.md) for the key schema
+and [Configuration](./14-configuration.md) for tunables. The runbooks
+below assume `persistenceProvider: pebble`.
+
+### 6.1 Backup and Restore (Pebble)
+
+**When to use:** Before major maintenance, before binary upgrades that
+touch the persistence schema, or as part of disaster-recovery drills.
+
+**Backup strategies:** Pebble offers three valid options. Pick one
+based on your downtime tolerance:
+
+| Strategy | Downtime | Consistency | Tool |
+|---|---|---|---|
+| Pebble checkpoint (online) | None | Crash-consistent snapshot | `pebble.Checkpoint(destDir)` |
+| Filesystem snapshot (online) | None | Filesystem-consistent | LVM, ZFS, EBS |
+| Cold copy (offline) | Stop API | Byte-identical | `cp -a`, `rsync` |
+
+`pebble.Checkpoint` is the recommended online path: it produces a
+self-contained directory with hard-linked SSTs and a fresh `MANIFEST`.
+Restore is `cp -a <checkpoint> <new-path>` and pointing
+`persistenceConfig.path` at it. Concurrent writes do not invalidate
+the snapshot.
+
+**Online backup procedure (single-shard Pebble checkpoint):**
+
+1. **Trigger** a checkpoint via the admin endpoint. The destination
+   must be on the same filesystem as the live data so Pebble can
+   hard-link SSTs:
+
+   ```bash
+   curl -X POST http://<api-host>:8080/v1/codeq/admin/pebble/checkpoint \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json" \
+     -d '{"destination": "/backup/codeq-pebble-checkpoint-'"$(date +%Y%m%d%H%M%S)"'"}'
+   ```
+
+2. **Archive** the checkpoint and the config to durable storage:
+
+   ```bash
+   tar -C /backup -czf codeq-pebble-$(date +%Y%m%d%H%M%S).tar.gz \
+     codeq-pebble-checkpoint-<timestamp>/
+   cp /etc/codeq/config.yml /backup/config-$(date +%Y%m%d%H%M%S).yml
+   aws s3 cp codeq-pebble-*.tar.gz s3://codeq-backups/$(hostname)/
+   ```
+
+3. **Verify** the archive on a staging host monthly — backups you
+   never restore are not backups. `tar -tzf` should show `OPTIONS-*`,
+   `CURRENT`, `MANIFEST-*`, and `*.sst` entries.
+
+**Offline backup (cold copy):** stop the API, `rsync -aHAX` the data
+directory, restart. Do **not** copy a live Pebble directory with plain
+`cp` outside of a checkpoint or filesystem snapshot — Pebble rewrites
+the `MANIFEST` and active `*.sst` concurrently and a torn copy fails to
+open with `corruption: missing files referenced by manifest`.
+
+**Restore procedure:** stop the API, move the existing directory
+aside (do not delete until restore is verified), extract the backup
+into place, fix ownership, start the API. The log should show `pebble
+open`, `recover seq`, and `recoverLeases` succeed in under a second.
+
+```bash
+systemctl stop codeq-api
+mv /var/lib/codeq/pebble /var/lib/codeq/pebble.broken-$(date +%Y%m%d%H%M%S)
+tar -C /var/lib/codeq -xzf /backup/codeq-pebble-<timestamp>.tar.gz
+mv /var/lib/codeq/codeq-pebble-checkpoint-<timestamp> /var/lib/codeq/pebble
+chown -R codeq:codeq /var/lib/codeq/pebble
+systemctl start codeq-api
+curl -s http://<api-host>:8080/metrics | grep codeq_queue_depth
+```
+
+**Rollback:** the original directory is at `pebble.broken-<timestamp>`.
+Stop the API, swap them back, restart.
+
+---
+
+### 6.2 Disk Full and Corruption Recovery
+
+**When to use:** the API logs `pebble: out of disk space`, `corruption:
+...`, or refuses to start with `pebble open: ...`.
+
+**Disk full (`no space left on device`):** Pebble blocks writes when
+the volume fills — the memtable can't flush and compactions can't run.
+Free space outside the Pebble directory first (journals, log archives,
+cores — don't touch SSTs by hand), then grow the volume (`lvextend`,
+`aws ec2 modify-volume`, `resize2fs`). Pebble has no shrink path —
+reclaim only happens when compactions drop superseded SSTs. Restart
+the API once headroom is available.
+
+> **Performance**: provision Pebble volumes at 2x the steady-state
+> on-disk size. Compaction needs room for the new SST before the old
+> one is dropped, and a checkpoint hard-links every live SST into a
+> second directory tree until you archive it.
+
+**Corruption (symptom: `pebble open: corruption: ...`):**
+
+Corruption comes from torn power-loss writes, a failing disk, or a
+checkpoint copied while writes were in flight (see §6.1). Pebble
+refuses to open in this state.
+
+1. **Capture** the exact error: `journalctl -u codeq-api --no-pager |
+   grep -A5 "pebble open"`.
+
+2. **Run** `pebble db check /var/lib/codeq/pebble` if the pebble CLI is
+   installed.
+
+3. **Recover** from the most recent backup (§6.1 restore procedure).
+   This is the supported path — there is no in-place repair for
+   corruption the LSM cannot self-heal.
+
+4. **WAL-only fallback (last resort, no backup):** if only the latest
+   `*.log` is corrupt, move it aside (`mv .../000123.log /tmp/`) and
+   restart. This loses every task in that WAL — usually the last few
+   seconds of writes — and is **at-most-once for that window**.
+
+> **Warning**: prefer restore-from-backup. WAL truncation creates tasks
+> that producers believe succeeded but that codeq never persists.
+
+---
+
+### 6.3 Lease Recovery After Crash
+
+**When to use:** the codeq process exited unexpectedly (panic, OOM,
+kernel kill, host reboot) and you need to understand what happens to
+tasks that were `IN_PROGRESS` at the time.
+
+**Background:**
+
+The Pebble backend keeps the lease table in memory only (see
+[`internal/repository/pebble/lease_table.go`](../internal/repository/pebble/lease_table.go)).
+Phase 6 / M2 dropped the `KeyLease` write per Claim and the `KeyLease`
+Get per reaper tick. The trade-off is volatility — a crash empties
+the table. The on-disk inprog index
+(`codeq/q/<cmd>/<tenant>/inprog/`) plus each task body's `LeaseUntil`
+timestamp are the source of truth.
+
+On `Open()` the task repository runs `recoverLeases()`: scan every key
+under `codeq/q/` for the `/inprog/` segment, fetch the task body,
+parse `LeaseUntil`, and seed the in-memory lease table with
+`(taskID, workerID, command, tenantID, untilUnix)`. Tasks whose
+`LeaseUntil` is still in the future re-enter as live leases — the
+original worker can submit results normally. Tasks past `LeaseUntil`
+land as expired entries; the reaper's first sweep Nacks them through
+the same path it uses in normal operation. From the worker's
+perspective a crash is indistinguishable from "the reaper noticed the
+expiry one tick later".
+
+**Procedure (post-crash):**
+
+1. **Restart** the process — lease rebuild is automatic. Confirm with
+   `journalctl -u codeq-api | grep -E "pebble open|recover seq"`.
+
+2. **Wait** one reaper tick (default 5s,
+   `ReaperOptions.LeaseSweepInterval`). Expired leases are Nacked and
+   re-queued for the next polling worker.
+
+3. **Verify** `rate(codeq_lease_expired_total[1m])` normalises. A
+   short spike right after restart is expected — it represents
+   workers that crashed alongside the API.
+
+**Recovery handles transparently:** worker still alive (lease
+re-seeded), worker dead (lease re-seeded, reaper Nacks on expiry),
+corrupt task body (entry skipped, TTL sweep trims later).
+
+**Recovery does not handle:** Pebble itself failing to open (§6.2), a
+panic mid-scan (idempotent — next restart re-runs from scratch).
+
+> **Note**: recovery is linear in inprog queue size. ~10k inprog
+> tasks recover in under 100ms on the reference box. Millions of
+> inprog tasks add multi-second startup latency before the API
+> accepts traffic.
+
+---
+
+### 6.4 Compaction Tuning
+
+**When to use:** sustained write amplification is high, the on-disk
+size grows faster than expected, or background compactions cause
+visible latency spikes.
+
+**Defaults:** codeq runs Pebble close to LevelDB defaults with two
+overrides — a 256 MiB block cache and a per-level bloom filter (10
+bits/key, `TableFilter`) so negative `KeyTask` lookups miss without
+touching SSTs. Memtable size, level multiplier, compaction
+concurrency, and target file sizes use Pebble defaults. This fits
+codeq's workload (small values, high churn, frequent reaper deletes).
+
+**Observability:** Pebble does not export Prometheus metrics directly.
+Watch `du -sh /var/lib/codeq/pebble` over time, the SST count
+(`ls .../*.sst | wc -l` — high means L0 backed up), the WAL count
+(`*.log` — high means memtables aren't flushing), and
+`codeq_task_create_latency_seconds` p99 (spikes correlate with stalls).
+
+**Symptoms and tuning:**
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Steady on-disk growth, low write rate | Reaper not deleting completed tasks | Confirm TTL sweep is running; reduce `Tasks.TTL` |
+| Spiky p99 every few minutes | Background compaction stalls writes | Enable `numShards > 1` to parallelise compactions |
+| Disk usage 5x logical | Many tombstones not yet compacted | Wait — compactions will catch up; consider a manual checkpoint+restore to force a major compaction if growth is unbounded |
+| High WAL count | Memtable flush trailing writes | Likely a slow disk; check `iostat -x 1` for `%util` |
+
+**When to shard:** the biggest compaction lever is `numShards`.
+Running 4 shards in one process parallelises 4 independent compaction
+pipelines. On the reference box that's the difference between 42k
+tasks/s single-shard and 83k tasks/s 4-shard for the full
+create→claim→complete cycle
+(`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+`PHASE8_SHARDS=4`). See §7 for shard operations.
+
+> **Performance**: do not enable `fsyncOnCommit` unless your durability
+> requirement demands it. NoSync commit relies on the OS page cache
+> and survives `kill -9` of the codeq process; only host power loss
+> can lose the last in-flight commit. Enabling fsync costs ~20%
+> throughput in the harness and pushes p99 latency from ~1ms to ~10ms.
+
+---
+
+## 7. Phase 8 Intra-Process Sharding Runbook
+
+`numShards > 1` opens N independent Pebble instances under
+`<path>/shard<i>/` and routes every key by `hash(taskID) % N`. The
+sharded repositories fan reads across all shards (Claim is a parallel
+scatter-gather) and write to exactly one (Produce, Complete). Reapers
+are per-shard.
+
+Design rationale: [Sharding](./06-sharding.md) and the
+[intra-process sharding HLD](./24-queue-sharding-hld.md). This section
+is operational only.
+
+### 7.1 Changing `numShards` Safely
+
+**When to use:** scaling up from `numShards: 1` to `numShards: 4`, or
+adjusting the shard count after a hardware change.
+
+> **Warning**: changing `numShards` is **destructive to in-flight
+> data**. The key router (`hash(taskID) % N`) changes its output when
+> N changes, so tasks written under N=1 are no longer addressable
+> under N=4. There is no online resharding — codeq does not migrate
+> existing data into the new shard layout.
+
+**Three viable strategies:**
+
+| Strategy | Downtime | Data loss | When to use |
+|---|---|---|---|
+| Drain then redeploy | Drain window (~minutes) | None | Production, low queue depth |
+| Full restart with backup | API restart (~seconds) | None if backup restored | Production, manageable queue depth |
+| Wipe and redeploy | API restart | All historical tasks | Dev, staging, recoverable workloads |
+
+**Procedure (drain then redeploy — safest):**
+
+1. **Stop** producers (gateway deny rule or sharp rate-limit cut).
+
+2. **Wait** for ready + in-progress depth to reach zero:
+
+   ```promql
+   sum by (command) (codeq_queue_depth{queue=~"ready|in_progress"}) == 0
+   ```
+
+3. **Stop** the API, **back up** the old directory (§6.1), then move
+   it aside and recreate:
+
+   ```bash
+   systemctl stop codeq-api
+   mv /var/lib/codeq/pebble /var/lib/codeq/pebble.pre-resharding-$(date +%Y%m%d)
+   mkdir -p /var/lib/codeq/pebble && chown codeq:codeq /var/lib/codeq/pebble
+   ```
+
+4. **Update** `config.yml` with the new shard count and **start** the
+   API. Verify `ls /var/lib/codeq/pebble/` shows `shard0 … shardN-1`,
+   then re-enable producer traffic.
+
+   ```yaml
+   persistenceProvider: pebble
+   persistenceConfig:
+     path: /var/lib/codeq/pebble
+     numShards: 4         # was 1 (or absent)
+     fsyncOnCommit: false
+   ```
+
+**Procedure (wipe and redeploy — dev only):** stop the API, `rm -rf`
+the data directory, change `numShards` in config, restart. Only
+appropriate when the queue holds no important state.
+
+> **Warning**: shrinking `numShards` (e.g. 4 → 2) follows the same
+> rules as growing it. Even though the source data exists across the
+> 4 old shard directories, codeq does not read shards that the router
+> would not route to. Always treat shard count change as a destructive
+> migration unless you've drained first.
+
+---
+
+### 7.2 Per-Shard Reaper Monitoring
+
+Each shard runs its own reaper. The reapers share no state — they read
+and write only against their own DB. This isolates compaction stalls
+on one shard from blocking expiry sweeps on another.
+
+**Observability:**
+
+Per-shard metric labels are a follow-up; until they land, watch:
+
+| Signal | Healthy | Action if abnormal |
+|---|---|---|
+| Shard directory sizes | Within ~2x of each other | Large imbalance means hash routing is concentrated; consider salting non-random IDs |
+| `codeq_lease_expired_total` rate | Near zero | Sudden spike on one command/tenant points to worker issues, not shard issues |
+| Reaper tick log per shard | Every `LeaseSweepInterval` | Missing on one shard means its reaper goroutine is wedged |
+
+**Goroutine dump for a wedged shard reaper** (requires pprof enabled
+via `cfg.PprofAddr`):
+
+```bash
+curl -s "http://<api-host>:6060/debug/pprof/goroutine?debug=2" | \
+  grep -A20 "pebble.Reaper"
+```
+
+Expect one `(*Reaper).loop` per shard. N-1 loops for N shards means
+one reaper has exited — restart the API to re-spawn it.
+
+---
+
+### 7.3 Backup Considerations with N Shards
+
+With `numShards > 1`, the on-disk layout is:
+
+```text
+/var/lib/codeq/pebble/
+├── shard0/
+│   ├── CURRENT
+│   ├── MANIFEST-*
+│   └── *.sst
+├── shard1/
+├── shard2/
+└── shard3/
+```
+
+Each shard directory is a complete, independent Pebble database. Each
+needs its own checkpoint. Mixing checkpoints from different
+"as-of times" across shards produces an inconsistent restore — a task
+might exist in shard0's checkpoint but not in shard2's because the
+shards were snapshotted seconds apart and shard2's reaper deleted the
+companion result entry in between.
+
+**Procedure (consistent multi-shard backup):**
+
+Pebble checkpoints are crash-consistent per-DB, not cross-DB. For
+low-volume queues just issue the checkpoints back-to-back — sub-second
+skew. For high-volume queues either pause producers briefly or accept
+the skew (codeq's lease+reaper model requeues anything that looks
+inconsistent on restore: a task body in one shard's checkpoint without
+its inprog marker in another's will be requeued).
+
+```bash
+for i in 0 1 2 3; do
+  curl -X POST http://<api-host>:8080/v1/codeq/admin/pebble/checkpoint \
+    -H "Authorization: Bearer <token>" \
+    -H "Content-Type: application/json" \
+    -d "{\"shard\": $i, \"destination\": \"/backup/shard$i-$(date +%s)\"}"
+done
+tar -C /backup -czf codeq-pebble-sharded-$(date +%Y%m%d%H%M%S).tar.gz \
+  shard0-* shard1-* shard2-* shard3-*
+```
+
+**Restore:** unpack into the parent path, ensure subdirectory names
+match `shard0`, `shard1`, etc., and start the API with the same
+`numShards` value as the backup.
+
+> **Warning**: a backup taken at `numShards: 4` cannot be restored at
+> `numShards: 2` (or any other count). The shard topology is encoded
+> in the on-disk layout and the router math.
+
+---
+
+## 8. Cluster (Multi-Node) Runbook
+
+Cluster mode (`cluster.enabled: true`) runs N codeq processes, each
+with its own local Pebble, joined by a consistent-hash ring and gRPC
+inter-node calls. ID-routed operations (Get, Submit, Complete) hash to
+the owning node; Claim is scatter-gather across every node and takes
+the first non-empty response. Each peer gossips its task-ID bloom
+every second so the router can skip RPCs to peers that definitely do
+not hold the requested ID.
+
+See [Cluster architecture](./05-cluster-architecture.md) for design.
+Runbooks below assume the cluster is deployed and healthy.
+
+### 8.1 Add or Remove a Cluster Node
+
+**When to use:** scaling out by adding a node, or decommissioning a
+node.
+
+**Important constraint:** the ring is **static**. Every node must have
+the same `cluster.nodes` list. Adding or removing a node requires a
+rolling restart of every node with the updated list — there is no
+runtime membership change.
+
+**Failover sequence (single node down):**
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Router as Router on N1
+  participant N1 as Node 1 (local Pebble)
+  participant N2 as Node 2 (peer)
+  participant N3 as Node 3 (peer, owner)
+
+  Note over N3: Node 3 crashes
+  Client->>Router: SubmitResult(taskID owned by N3)
+  Router->>N3: gRPC LocalSubmit
+  N3-->>Router: connection refused
+  Router-->>Client: error: node N3 unavailable
+  Note over Client: Client retries on backoff
+  Client->>Router: SubmitResult (retry)
+  Router->>N3: gRPC LocalSubmit
+  N3-->>Router: connection refused
+  Router-->>Client: error
+  Note over N1,N2: Operator restarts N3
+  N3->>N3: Pebble Open, recoverLeases
+  N3->>N2: gossip bloom (next tick)
+  Client->>Router: SubmitResult (retry)
+  Router->>N3: gRPC LocalSubmit
+  N3->>N3: apply
+  N3-->>Router: ok
+  Router-->>Client: ok
+```
+
+The router does not silently re-route writes for a failed peer
+elsewhere — that would create split-brain because the data lives on a
+specific node's disk. Submits and completions for a downed node's IDs
+return errors and the SDK retries until the node is back. Claims
+remain available across the surviving nodes because Claim is a
+scatter-gather and the failed node simply contributes nothing to that
+poll.
+
+**Adding a node:**
+
+1. **Update** every existing node's `cluster.nodes` to include the new
+   node. **Do not** start the new node yet — peers must know about it
+   first:
+
+   ```yaml
+   cluster:
+     enabled: true
+     selfId: node-1
+     grpcAddr: 0.0.0.0:9090
+     nodes:
+       - id: node-1
+         grpcAddr: 10.0.0.11:9090
+       - id: node-2
+         grpcAddr: 10.0.0.12:9090
+       - id: node-3
+         grpcAddr: 10.0.0.13:9090
+       - id: node-4
+         grpcAddr: 10.0.0.14:9090   # new
+   ```
+
+2. **Rolling restart** the existing nodes one at a time (§2.1
+   pattern). They will fail to dial `node-4` until step 3; that's
+   expected and does not affect existing traffic — the router only
+   dials when it has work to send.
+
+3. **Deploy and start** the new node with the same `cluster.nodes`
+   and `selfId: node-4`. Verify each existing node sees `node-4` in
+   its peer pool and bloom gossip is flowing (within ~1s).
+
+**Removing a node:**
+
+1. **Drain** the node by stopping producers and waiting for its
+   `codeq_queue_depth` to reach zero.
+
+2. **Stop** the node, then update every remaining node's
+   `cluster.nodes` to omit it and rolling-restart the survivors.
+
+> **Warning**: never remove a node from the config while its Pebble
+> directory still holds undelivered tasks. The peers will stop
+> routing to it and the data becomes unreachable until the node is
+> re-added. Always drain first.
+
+---
+
+### 8.2 Bloom Gossip Troubleshooting
+
+The bloom is sized at 1M expected items / 0.1% false-positive rate
+(~1.7 MiB on the wire). Gossip cadence is 1s. Each peer's most recent
+bloom is stored in the `BloomCache` (see
+[`internal/cluster/bloom_cache.go`](../internal/cluster/bloom_cache.go)).
+
+**Symptoms of broken or stale gossip:**
+
+| Symptom | Likely cause |
+|---|---|
+| Every ID lookup is a network call | Bloom cache empty for that peer (gossip never arrived) |
+| Lookups hit the right peer most of the time but occasionally miss | Bloom has filled past 1M items — false-positive rate has degraded |
+| One peer never sends a bloom | Outbound gRPC firewall block, or that peer's gossiper goroutine died |
+| Bloom snapshots have stale `seq` | That peer is not adding tasks (idle); the bloom is correct but stale |
+
+**Diagnosis:**
+
+1. **Confirm** the inbound gRPC channel from each peer works:
+
+   ```bash
+   for host in 10.0.0.11 10.0.0.12 10.0.0.13; do
+     nc -zv $host 9090 && echo "$host: ok"
+   done
+   ```
+
+2. **Inspect** the local bloom cache for each peer's last update
+   sequence number (admin endpoint when wired):
+
+   ```bash
+   curl -s http://<api-host>:8080/v1/codeq/admin/cluster/bloom | jq .
+   ```
+
+3. **Check** for `cluster.bloom-gossiper` errors in the log:
+
+   ```bash
+   journalctl -u codeq-api --no-pager | \
+     grep -E "bloom-gossiper|GossipBloom"
+   ```
+
+**Workarounds:** a missing or degraded bloom is never a correctness
+issue — the router falls back to the actual gRPC call. The cost is
+one extra round-trip per ID lookup that misses. Restart the affected
+peer to reset bloom state; this is not a paging event.
+
+---
+
+### 8.3 Scatter-Gather Claim Performance
+
+`Claim` fans `LocalClaim` out to every node in parallel and returns
+the first non-empty response. The implementation is in
+[`internal/cluster/router.go`](../internal/cluster/router.go) under the
+`Claim` method. The local node is tried first synchronously — if the
+local queue has a task, no gRPC call happens at all.
+
+**Symptoms of scatter-gather problems:**
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Claim latency p99 grows with cluster size | Slow or hung peer | Identify the lagging peer and check its reaper / disk |
+| Workers idle while peers report `ready` depth > 0 | One node's local queue is empty and the scatter-gather is returning empty before peers respond | Confirm with `codeq_queue_depth` per node; this is expected behaviour, not a bug |
+| Claim returns `context deadline exceeded` | A peer is so slow it exceeds the gRPC deadline | Check the slow peer's `codeq_task_create_latency_seconds` p99 |
+
+**Diagnosis:**
+
+1. **Compare** per-node ready-queue depth. Imbalance > 10x indicates
+   hash routing concentration (rare; only with non-random taskID
+   spaces): `curl -s http://$host:8080/metrics | grep
+   'codeq_queue_depth{.*queue="ready"}'`.
+
+2. **Measure** per-node Claim latency. The slowest peer pins
+   scatter-gather Claim latency:
+
+   ```promql
+   histogram_quantile(0.99,
+     sum by (le, instance) (rate(codeq_claim_latency_seconds_bucket[5m]))
+   )
+   ```
+
+3. **Restart** a peer whose Pebble is wedged on compaction. The
+   in-progress queue drops to zero and recovers via the lease rebuild
+   from §6.3.
+
+> **Performance**: scatter-gather Claim does not parallelise infinitely
+> — every additional node adds one parallel RPC per poll. At cluster
+> sizes above ~8 nodes consider hashing workers to a subset of nodes
+> (sticky polling) rather than fanning out to all of them.
+
+---
+
+### 8.4 Cluster + Sharding Are Mutually Exclusive
+
+**Error you may see:**
+
+```text
+pebble: cluster mode + intra-process shards not supported (pick one)
+```
+
+This panic happens at startup when both `cluster.enabled: true` and
+`persistenceConfig.numShards > 1` are set. The reason is architectural:
+the `cluster.Server` exposes a single concrete `TaskRepository` over
+gRPC, and the sharded wrapper would need its own per-shard cluster
+bridge to be addressable from peers. That work is queued as a
+follow-up; until it lands the two modes are mutually exclusive.
+
+**Choose one:**
+
+| Goal | Pick |
+|---|---|
+| Single physical box, more cores | `numShards: 4` (or 8 on bigger boxes), `cluster.enabled: false` |
+| Multiple physical boxes, HA | `cluster.enabled: true`, omit `numShards` (or set to 1) |
+| Both? | Not yet — multi-node sharded is on the roadmap |
+
+**Procedure to fix the panic:** edit `config.yml` to either Option A
+(`numShards: N`, `cluster.enabled: false`) or Option B
+(`cluster.enabled: true`, omit `numShards`), then restart.
+
+```yaml
+# Option A — single-node sharded
+persistenceProvider: pebble
+persistenceConfig:
+  path: /var/lib/codeq/pebble
+  numShards: 4
+cluster:
+  enabled: false
+
+# Option B — cluster (no intra-process shards)
+persistenceProvider: pebble
+persistenceConfig:
+  path: /var/lib/codeq/pebble
+cluster:
+  enabled: true
+  selfId: node-1
+  grpcAddr: 0.0.0.0:9090
+  nodes:
+    - id: node-1
+      grpcAddr: 10.0.0.11:9090
+```
+
+---
+
+## 9. Backup Topology Reference
+
+A consolidated view of the backup topologies for the two production
+modes. Single-node Pebble produces one checkpoint directory per shard.
+Cluster mode produces one set of checkpoints per node — and within
+each node, one per shard if that node is sharded (which today means
+one, because cluster + shards are mutually exclusive).
+
+```mermaid
+graph TB
+  subgraph SingleNode[Single-node Pebble]
+    SN_API[codeq API]
+    SN_PEB0[shard0/]
+    SN_PEB1[shard1/]
+    SN_PEB2[shard2/]
+    SN_PEB3[shard3/]
+    SN_BACKUP[(/backup/codeq-pebble-*)]
+    SN_API --> SN_PEB0
+    SN_API --> SN_PEB1
+    SN_API --> SN_PEB2
+    SN_API --> SN_PEB3
+    SN_PEB0 -.checkpoint.-> SN_BACKUP
+    SN_PEB1 -.checkpoint.-> SN_BACKUP
+    SN_PEB2 -.checkpoint.-> SN_BACKUP
+    SN_PEB3 -.checkpoint.-> SN_BACKUP
+  end
+
+  subgraph Cluster[Cluster mode]
+    C_N1[node-1 + local Pebble]
+    C_N2[node-2 + local Pebble]
+    C_N3[node-3 + local Pebble]
+    C_BACKUP1[(/backup/node-1-*)]
+    C_BACKUP2[(/backup/node-2-*)]
+    C_BACKUP3[(/backup/node-3-*)]
+    C_N1 -.checkpoint.-> C_BACKUP1
+    C_N2 -.checkpoint.-> C_BACKUP2
+    C_N3 -.checkpoint.-> C_BACKUP3
+  end
+```
+
+Key points:
+
+- Backups are **per-DB**, never cluster-wide. Each node's checkpoint
+  is independent — there is no global snapshot primitive.
+- Restoring a single node is safe: peers treat it as one that came
+  back from a crash. Bloom gossip resyncs within 1s. Tasks claimed
+  before the backup snapshot come back as expired leases at restart
+  (§6.3).
+- Restoring the full cluster requires every node down before the
+  restore so gossip doesn't mix stale and fresh blooms. Bring the
+  cluster up node-by-node afterwards.
+
+> **Note**: backup is not a substitute for replication. A restored
+> backup loses every task created between the snapshot and the
+> failure. For zero-RPO workloads, run cluster mode for redundancy
+> and treat backups as last-resort recovery only.
+
+---
+
+## See also
+
+- [Cluster architecture](./05-cluster-architecture.md) — design of
+  the consistent-hash ring, gRPC routing, and bloom gossip referenced
+  in §8.
+- [Storage layout (Pebble)](./07b-storage-pebble.md) — key schema,
+  recovery semantics, and the on-disk file layout that backup tooling
+  operates on.
+- [Troubleshooting](./28-troubleshooting.md) — symptom-driven
+  diagnostics; complements the action-driven procedures here.
+- [Lease management](./06b-lease-management.md) — deep dive on the
+  in-memory lease table and the recovery scan; available after Wave 3.

--- a/docs/_STYLE.md
+++ b/docs/_STYLE.md
@@ -1,0 +1,291 @@
+# codeq documentation style guide
+
+This is the canonical style guide for codeq documentation. Every doc in
+`docs/` and the root `README.md` must follow it. Subsequent waves of doc
+revisions cite this file verbatim where relevant (especially the value
+proposition and comparativos). If you change the value proposition here,
+you must update the docs that quote it.
+
+## 1. Value proposition
+
+### One-line
+
+> codeq is an embedded high-performance task queue: a single Go binary,
+> Pebble for persistence, gRPC streaming for the wire — 83k tasks/s on
+> one machine with zero external dependencies.
+
+### One-paragraph
+
+> codeq is a task queue written in Go that runs as a single process and
+> stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+> from CockroachDB). The hot path is bidirectional gRPC streams from
+> producers and workers; under the streams sits an intra-process shard
+> table (up to N independent Pebble instances) and an in-memory lease
+> table. The result on a 12-core Linux box is 83,420 tasks/s for the
+> full create → claim → complete cycle, or 136,392 creates/s producer-
+> only. No Redis, no broker, no coordinator required in the default
+> mode. Cluster (consistent-hash + gRPC routing) and a legacy Redis
+> backend are opt-in for HA and multi-node deployments.
+
+### Comparativos (use verbatim or as a base)
+
+| Dimension | codeq | Asynq | BullMQ | Celery | Kafka |
+|---|---|---|---|---|---|
+| External dependency | None (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper or KRaft cluster |
+| Throughput (single node, full cycle) | 83k tasks/s | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | 100k+ msgs/s, but no task semantics |
+| Language affinity | Go (HTTP + gRPC; SDKs for Java, Node, Python, Go) | Go | Node only | Python only | Polyglot |
+| Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
+| Multi-tenant native | Yes (JWT tenantId namespacing built in) | No | No | No | No |
+| Learning curve | One binary, HTTP + curl in minutes | Moderate (Redis ops) | Moderate (Node + Redis) | High (broker + result backend) | High (broker, consumer groups, schema registry) |
+
+When citing this table in a doc, link back here:
+
+> See [_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
+
+## 2. Audience profile
+
+Primary reader: **backend engineer evaluating alternatives to Redis-backed
+task queues**. They are typically deciding between Asynq (Go + Redis),
+BullMQ (Node + Redis), Celery (Python + broker), Sidekiq (Ruby + Redis),
+Temporal (workflow engine), and Kafka (event log used as a queue).
+
+What they care about, ranked:
+
+1. **Throughput** — concrete numbers, harness names, and the box they
+   were measured on. No "blazing fast", no "10x". Cite the benchmark.
+2. **Operational cost** — how many processes, how many config knobs, how
+   long until they can `curl` a task.
+3. **Language affinity** — Go server, but with first-class SDKs for the
+   reader's stack.
+4. **Durability and at-least-once** — what survives a crash, and how
+   they prove it.
+5. **Multi-tenant** — whether they can run one queue server for many
+   customers without writing isolation themselves.
+6. **HA and scaling story** — single-node first, but with a credible
+   path to multi-node.
+
+Write for someone who already understands queues. Skip onboarding to
+basic concepts like "what is a task". Do define codeq-specific terms
+(shard, lease table, ring, scatter-gather) the first time they appear.
+
+## 3. Voice and tone
+
+### Numbers first, narrative second
+
+Bad:
+
+> codeq is blazing fast and can handle massive workloads.
+
+Good:
+
+> codeq sustains 83,420 tasks/s for a full create → claim → complete
+> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
+> batch=8, 128 worker slots, 20s measurement window
+> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
+
+Every throughput claim cites:
+
+- The exact test name in `internal/bench/`.
+- The env vars used to parameterize it.
+- The hardware class (cores, OS).
+- The measurement window.
+
+### Honest about limitations
+
+Always name the trade-offs. Examples to use as templates:
+
+- "HA is only available via the Redis backend or by running a cluster of
+  Pebble nodes. A single Pebble process loses availability while it
+  restarts; recovery is fast (in-memory lease table rebuilt from the
+  `KeyInprog` scan at Open) but not instantaneous."
+- "Cluster mode and intra-process sharding (`numShards > 1`) are
+  mutually exclusive — startup panics if both are enabled. Pick one:
+  multi-node across machines, or multi-shard inside one process."
+- "Delivery is at-least-once, not exactly-once. A worker that crashes
+  between completion and ACK will see its task re-delivered after the
+  lease expires."
+
+### No marketing fluff
+
+Banned words: blazing, massive, lightning, seamless, robust,
+cutting-edge, world-class, next-gen, revolutionary.
+
+Replace adjectives with measurements. If you cannot measure it, do not
+claim it.
+
+### Opinionated
+
+Tell the reader what to pick:
+
+- "For single-node deployments use Pebble with `numShards: 4`."
+- "Do not enable `fsyncOnCommit` unless you have measured the latency
+  impact in your workload — it costs ~20% throughput in our harness."
+- "Use Redis only if you need multi-node HA today and cannot deploy the
+  cluster mode."
+
+## 4. Markdown conventions
+
+- **Headings**: ATX style (`#`), single `#` per file (the title), then
+  `##` for top-level sections, `###` for subsections. Do not skip
+  levels.
+- **Code blocks**: always tag the language.
+  - `bash` for shell, `go` for Go, `yaml` for config, `json` for JSON,
+    `protobuf` for `.proto`, `mermaid` for diagrams.
+  - Untagged blocks are forbidden — they break syntax highlighting on
+    GitHub.
+- **Admonitions** (GitHub-flavored):
+
+  ```markdown
+  > **Note**: a normal aside.
+  > **Warning**: a footgun. Always for irreversible operations or
+  > silent data loss.
+  > **Performance**: a tuning hint with a number.
+  ```
+
+- **Tables**: pipe-aligned, header row separator `---`. Always have a
+  header row. Cells with multi-word values stay on one line.
+- **Inline code**: backticks for file paths, env vars, config keys,
+  function names, and protocol constants.
+- **Lists**: `-` for unordered, `1.` for ordered. Two spaces of
+  indentation for nested items.
+- **Links**: prefer descriptive text over "click here". Relative links
+  for in-repo references (see §6).
+
+## 5. Mermaid conventions
+
+All diagrams must render on the GitHub default theme in both light and
+dark mode. **Never set inline colors or styles** — let the renderer
+pick.
+
+### Flow diagrams
+
+Use `graph TB` for top-to-bottom layered architecture, `graph LR` for
+left-to-right pipelines. Always use `subgraph` to delimit logical
+layers.
+
+```mermaid
+graph TB
+  subgraph Producers
+    P1[Producer SDK]
+  end
+  subgraph Server[codeq server]
+    HTTP[HTTP API]
+    GRPC[gRPC stream]
+  end
+  subgraph Storage
+    PEB[Pebble shards]
+  end
+  P1 --> GRPC
+  GRPC --> PEB
+  HTTP --> PEB
+```
+
+Aim for 8 to 12 nodes max in a single diagram. If it grows past that,
+split it.
+
+### Sequence diagrams
+
+Use `sequenceDiagram` for flows over time. Participant names start
+capitalized.
+
+```mermaid
+sequenceDiagram
+  participant Producer
+  participant Server
+  participant Pebble
+  Producer->>Server: Produce(task)
+  Server->>Pebble: BatchCommit
+  Pebble-->>Server: ack
+  Server-->>Producer: TaskID
+```
+
+### State machines
+
+Use `stateDiagram-v2` for task lifecycle. Transition labels describe
+the **trigger action**, not the resulting state.
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING: Produce
+  PENDING --> IN_PROGRESS: Claim
+  IN_PROGRESS --> COMPLETED: SubmitResult(ok)
+  IN_PROGRESS --> PENDING: Nack(retry)
+  IN_PROGRESS --> DLQ: maxAttempts exceeded
+  COMPLETED --> [*]
+  DLQ --> [*]
+```
+
+### No inline colors
+
+Bad:
+
+```text
+style P1 fill:#f9f,stroke:#333
+```
+
+Good: nothing — let the theme decide.
+
+## 6. Cross-link policy
+
+Every doc ends with a `## See also` section enumerating related docs.
+Example:
+
+```markdown
+## See also
+
+- [Architecture](./03-architecture.md)
+- [Storage layout (Pebble)](./07b-storage-pebble.md)
+- [Performance tuning](./17-performance-tuning.md)
+```
+
+Path conventions:
+
+- **Inside `docs/`** (doc-to-doc): use relative paths starting with
+  `./`, e.g. `[Overview](./01-overview.md)`.
+- **From root `README.md`** (or other root-level files): use paths
+  rooted at `docs/`, e.g. `[Overview](docs/01-overview.md)`.
+- **To source files**: use repo-rooted paths, e.g.
+  `[application.go](../pkg/app/application.go)` from inside `docs/`, or
+  `pkg/app/application.go` from `README.md`.
+- **Anchors**: lowercase, hyphen-separated, match GitHub's slug
+  algorithm.
+
+When you cite the value prop, link to this file:
+
+```markdown
+See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
+```
+
+## 7. Numbers must come from measurement
+
+Every throughput, latency, or memory claim in any doc must be traceable
+to a test in `internal/bench/`. The format is:
+
+> N tasks/s (`internal/bench/<file>.go::<TestName>`, env: `KEY=VAL`,
+> hardware: 12-core Linux).
+
+Catalog of canonical benchmarks (use these names, do not invent new
+ones):
+
+| Workload | Harness | Result on reference box |
+|---|---|---|
+| Full cycle, 4 shards, batched | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) | 83,420 tasks/s |
+| Producer-only, batched stream | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` | 136,392 creates/s |
+| Worker-only, batched stream | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) | 23,518 tasks/s |
+| Shard sweep | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=1,2,4,6,8`) | 42k / 65k / 83k / 68k / 67k |
+
+Reference box: 12-core Linux (kernel 5.15, WSL2-compatible), Go 1.25.0,
+local Pebble, loopback gRPC, no fsync.
+
+If you need a number that is not in this table, run the bench, add the
+row here, then cite it in your doc. Do not estimate.
+
+## See also
+
+- [README](../README.md) — applies this style guide at the entry point.
+- [Overview](./01-overview.md) — the canonical statement of what codeq
+  is.
+- [Architecture](./03-architecture.md) — package-level breakdown.
+- [Performance baselines](./30-performance-baselines.md) — raw bench
+  output and historical numbers.


### PR DESCRIPTION
## Summary

- Adds Pebble single-node operations: checkpoint-based backup/restore, disk full and corruption recovery, in-memory lease table rebuild on Open (Phase 6/M2), and compaction tuning notes for codeq's queue workload.
- Adds Phase 8 intra-process sharding operations: how to safely change `numShards` (destructive, requires drain or wipe), per-shard reaper monitoring, multi-shard backup topology.
- Adds cluster (multi-node) operations: add/remove node via rolling restart, bloom gossip troubleshooting, scatter-gather Claim performance, and the documented error path for the cluster + sharding mutual-exclusion panic.
- Includes two Mermaid diagrams: `sequenceDiagram` of cluster node failover and a `graph TB` of backup topology spanning single-node sharded and cluster modes.
- Keeps the existing KVRocks-centric sections 1-5 unchanged; new content is sections 6-9 plus an updated `## See also`.

Wave 2 / U4 — based on `docs/wave1-u1-foundation`.

## Test plan

- [ ] Render `docs/29-operational-runbooks.md` on GitHub and confirm both Mermaid diagrams display on light + dark themes.
- [ ] Verify cross-links to `05-cluster-architecture.md`, `07b-storage-pebble.md`, `28-troubleshooting.md`, `06b-lease-management.md` (the last one will be added in Wave 3).
- [ ] Confirm code block language tags are present on every block (no untagged blocks per `_STYLE.md`).
- [ ] Spot-check that the `Cluster + Sharding` panic message matches `pkg/app/application_pebble.go:217`.