### PR TITLE
feat(webhook): fire result callback on BatchSubmit, Nack→DLQ, reaper→DLQ

### DIFF
--- a/internal/repository/pebble/reaper.go
+++ b/internal/repository/pebble/reaper.go
@@ -29,6 +29,7 @@ type Reaper struct {
 	backoffBaseSeconds int
 	backoffMaxSeconds  int
 	maxAttemptsDefault int
+	dlqCallback        func(ctx context.Context, t domain.Task, rec domain.ResultRecord)
 
 	leaseInterval time.Duration // how often to scan lease/*
 	ttlInterval   time.Duration // how often to scan ttl_index
@@ -48,6 +49,10 @@ type ReaperOptions struct {
 	BackoffBaseSeconds int
 	BackoffMaxSeconds  int
 	MaxAttemptsDefault int
+	// DLQCallback fires when a task is moved to DLQ due to lease expiry
+	// (after max attempts). Invoked once per task, post-commit, with a
+	// synthetic ResultRecord describing the failure. Optional.
+	DLQCallback func(ctx context.Context, t domain.Task, rec domain.ResultRecord)
 }
 
 func NewReaper(db *DB, tz *time.Location, logger *slog.Logger, opts ReaperOptions) *Reaper {
@@ -86,6 +91,7 @@ func NewReaper(db *DB, tz *time.Location, logger *slog.Logger, opts ReaperOption
 		backoffBaseSeconds: opts.BackoffBaseSeconds,
 		backoffMaxSeconds:  opts.BackoffMaxSeconds,
 		maxAttemptsDefault: opts.MaxAttemptsDefault,
+		dlqCallback:        opts.DLQCallback,
 		leaseInterval:      opts.LeaseInterval,
 		ttlInterval:        opts.TTLInterval,
 		leaseBatch:         opts.LeaseBatch,
@@ -219,6 +225,15 @@ func (r *Reaper) requeueExpiredOne(ctx context.Context, t *domain.Task, delaySec
 		}
 		r.db.Leases.Delete(t.ID)
 		metrics.TaskCompletedTotal.WithLabelValues(string(t.Command), string(t.Status)).Inc()
+		if r.dlqCallback != nil {
+			rec := domain.ResultRecord{
+				TaskID:      t.ID,
+				Status:      domain.StatusFailed,
+				Error:       t.Error,
+				CompletedAt: now,
+			}
+			r.dlqCallback(context.WithoutCancel(ctx), *t, rec)
+		}
 		return nil
 	}
 

--- a/internal/repository/pebble/reaper_dlq_callback_test.go
+++ b/internal/repository/pebble/reaper_dlq_callback_test.go
@@ -1,0 +1,109 @@
+package pebble
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/osvaldoandrade/codeq/pkg/domain"
+)
+
+// TestReaperDLQCallbackOnLeaseExpired verifies that when sweepLeases
+// requeues a task whose attempts are already at the limit, the configured
+// DLQCallback fires with a synthetic FAILED/LEASE_EXPIRED ResultRecord.
+//
+// Webhook coverage gap fix: pre-change the reaper silently moved tasks to
+// DLQ without notifying anyone. Producers that registered task.Webhook
+// got nothing when their work was abandoned.
+func TestReaperDLQCallbackOnLeaseExpired(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := NewTaskRepository(db, time.UTC, "fixed", 1, 5)
+	cmd := domain.CmdGenerateMaster
+
+	task, err := repo.Enqueue(ctx, cmd, `{"k":1}`, 0, "https://hook.example/z", 1, "", time.Time{}, "")
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	claimed, ok, err := repo.Claim(ctx, "w1", []domain.Command{cmd}, 30, 1, 1, "")
+	if err != nil || !ok || claimed.ID != task.ID {
+		t.Fatalf("claim: ok=%v err=%v claimed=%+v", ok, err, claimed)
+	}
+
+	db.Leases.Set(task.ID, "w1", cmd, "", 1) // unix=1 → far past
+
+	var (
+		mu    sync.Mutex
+		calls []domain.ResultRecord
+		tasks []domain.Task
+	)
+	r := NewReaper(db, time.UTC, slog.Default(), ReaperOptions{
+		LeaseInterval:      time.Hour,
+		MaxAttemptsDefault: 1,
+		DLQCallback: func(ctx context.Context, t domain.Task, rec domain.ResultRecord) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, rec)
+			tasks = append(tasks, t)
+		},
+	})
+
+	n, err := r.sweepLeases(ctx)
+	if err != nil {
+		t.Fatalf("sweepLeases: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 reaped task, got %d", n)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 DLQCallback call, got %d", len(calls))
+	}
+	if calls[0].Status != domain.StatusFailed {
+		t.Errorf("rec.Status: want FAILED, got %s", calls[0].Status)
+	}
+	if calls[0].Error != "LEASE_EXPIRED" {
+		t.Errorf("rec.Error: want LEASE_EXPIRED, got %q", calls[0].Error)
+	}
+	if tasks[0].ID != task.ID {
+		t.Errorf("task.ID mismatch: want %s, got %s", task.ID, tasks[0].ID)
+	}
+	if tasks[0].LastKnownLocation != domain.LocationDLQ {
+		t.Errorf("task.LastKnownLocation: want DLQ, got %s", tasks[0].LastKnownLocation)
+	}
+}
+
+// TestReaperDLQCallbackOnlyOnTerminal verifies that the callback does
+// NOT fire when the reaper merely requeues (attempts not yet exhausted).
+func TestReaperDLQCallbackOnlyOnTerminal(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	repo := NewTaskRepository(db, time.UTC, "fixed", 1, 5)
+	cmd := domain.CmdGenerateMaster
+
+	task, err := repo.Enqueue(ctx, cmd, `{"k":1}`, 0, "https://hook.example/q", 5, "", time.Time{}, "")
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	_, _, _ = repo.Claim(ctx, "w1", []domain.Command{cmd}, 30, 1, 5, "")
+	db.Leases.Set(task.ID, "w1", cmd, "", 1)
+
+	called := 0
+	r := NewReaper(db, time.UTC, slog.Default(), ReaperOptions{
+		LeaseInterval:      time.Hour,
+		MaxAttemptsDefault: 5,
+		DLQCallback: func(ctx context.Context, t domain.Task, rec domain.ResultRecord) {
+			called++
+		},
+	})
+	if _, err := r.sweepLeases(ctx); err != nil {
+		t.Fatalf("sweepLeases: %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("expected 0 callback calls on requeue, got %d", called)
+	}
+}

--- a/internal/services/results_service.go
+++ b/internal/services/results_service.go
@@ -334,5 +334,23 @@ func (s *resultsService) BatchSubmit(ctx context.Context, items []domain.BatchSu
 		}
 	}
 
+	// Webhook fan-out for each successful submission (parity with Submit's
+	// callback hook). Send is fire-and-forget internally, so this stays
+	// cheap on the response path.
+	if s.callback != nil {
+		callbackCtx := context.WithoutCancel(ctx)
+		for i := range resultRecords {
+			origIdx := indexMap[i]
+			if responses[origIdx].Error != "" {
+				continue
+			}
+			task, ok := tasks[items[origIdx].TaskID]
+			if !ok || task == nil {
+				continue
+			}
+			s.callback.Send(callbackCtx, *task, resultRecords[i])
+		}
+	}
+
 	return responses, nil
 }

--- a/internal/services/scheduler_service.go
+++ b/internal/services/scheduler_service.go
@@ -50,6 +50,7 @@ type batchClaimer interface {
 type schedulerService struct {
 	repo                repository.TaskRepository
 	notifier            NotifierService
+	callback            ResultCallbackService
 	tz                  *time.Location
 	now                 func() time.Time
 	defaultLease        int
@@ -61,7 +62,7 @@ type schedulerService struct {
 	rng                 *rand.Rand
 }
 
-func NewSchedulerService(repo repository.TaskRepository, notifier NotifierService, tz *time.Location, now func() time.Time, defaultLease, inspectLimit, maxAttemptsDefault int, backoffPolicy string, backoffBaseSeconds int, backoffMaxSeconds int) SchedulerService {
+func NewSchedulerService(repo repository.TaskRepository, notifier NotifierService, callback ResultCallbackService, tz *time.Location, now func() time.Time, defaultLease, inspectLimit, maxAttemptsDefault int, backoffPolicy string, backoffBaseSeconds int, backoffMaxSeconds int) SchedulerService {
 	if maxAttemptsDefault <= 0 {
 		maxAttemptsDefault = 5
 	}
@@ -77,6 +78,7 @@ func NewSchedulerService(repo repository.TaskRepository, notifier NotifierServic
 	return &schedulerService{
 		repo:                repo,
 		notifier:            notifier,
+		callback:            callback,
 		tz:                  tz,
 		now:                 now,
 		defaultLease:        defaultLease,
@@ -260,7 +262,24 @@ func (s *schedulerService) NackTask(ctx context.Context, taskID, workerID string
 	if delaySeconds > s.backoffMaxSeconds {
 		delaySeconds = s.backoffMaxSeconds
 	}
-	return s.repo.Nack(ctx, taskID, workerID, delaySeconds, s.maxAttemptsDefault, reason)
+	attempts, terminal, err := s.repo.Nack(ctx, taskID, workerID, delaySeconds, s.maxAttemptsDefault, reason)
+	if err != nil {
+		return attempts, terminal, err
+	}
+	if terminal && s.callback != nil {
+		effectiveReason := reason
+		if effectiveReason == "" {
+			effectiveReason = "MAX_ATTEMPTS"
+		}
+		rec := domain.ResultRecord{
+			TaskID:      taskID,
+			Status:      domain.StatusFailed,
+			Error:       effectiveReason,
+			CompletedAt: s.now().In(s.tz),
+		}
+		s.callback.Send(context.WithoutCancel(ctx), *t, rec)
+	}
+	return attempts, terminal, nil
 }
 
 func (s *schedulerService) GetTask(ctx context.Context, id string) (*domain.Task, error) {

--- a/internal/services/scheduler_service_test.go
+++ b/internal/services/scheduler_service_test.go
@@ -31,7 +31,7 @@ func setupSchedulerTest(t *testing.T) (context.Context, *miniredis.Miniredis, *r
 	notifier := NewNotifierService(mockSubRepo, nil, "test-secret", 5, nil, ratelimit.Bucket{}, nil)
 
 	now := func() time.Time { return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) }
-	svc := NewSchedulerService(repo, notifier, time.UTC, now, 60, 50, 5, "exp_full_jitter", 5, 900)
+	svc := NewSchedulerService(repo, notifier, nil, time.UTC, now, 60, 50, 5, "exp_full_jitter", 5, 900)
 
 	return context.Background(), mr, rdb, repo, svc
 }
@@ -532,7 +532,7 @@ func TestNewSchedulerServiceDefaults(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			now := func() time.Time { return time.Now() }
-			svc := NewSchedulerService(repo, notifier, time.UTC, now, 60, 50, tt.maxAttemptsInput, tt.backoffPolicyInput, tt.backoffBaseInput, tt.backoffMaxInput)
+			svc := NewSchedulerService(repo, notifier, nil, time.UTC, now, 60, 50, tt.maxAttemptsInput, tt.backoffPolicyInput, tt.backoffBaseInput, tt.backoffMaxInput)
 			if svc == nil {
 				t.Fatal("Expected service to be non-nil")
 			}

--- a/internal/services/webhook_coverage_test.go
+++ b/internal/services/webhook_coverage_test.go
@@ -1,0 +1,154 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/osvaldoandrade/codeq/internal/ratelimit"
+	"github.com/osvaldoandrade/codeq/internal/repository"
+	"github.com/osvaldoandrade/codeq/pkg/domain"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+)
+
+// captureCallback records every Send invocation so tests can assert
+// webhook coverage across terminal paths (Submit, BatchSubmit, Nack→DLQ,
+// reaper→DLQ).
+type captureCallback struct {
+	mu    sync.Mutex
+	calls []captureEntry
+}
+
+type captureEntry struct {
+	task domain.Task
+	rec  domain.ResultRecord
+}
+
+func (c *captureCallback) Send(ctx context.Context, task domain.Task, rec domain.ResultRecord) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, captureEntry{task: task, rec: rec})
+}
+
+func (c *captureCallback) snapshot() []captureEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]captureEntry, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+func TestBatchSubmitFiresCallbackPerItem(t *testing.T) {
+	mr, _ := miniredis.Run()
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	taskRepo := repository.NewTaskRepository(rdb, time.UTC, "exp_full_jitter", 1, 10, nil)
+	t1, _ := taskRepo.Enqueue(context.Background(), domain.CmdGenerateMaster, `{"k":1}`, 0, "https://hook.example/1", 5, "", time.Time{}, "")
+	t2, _ := taskRepo.Enqueue(context.Background(), domain.CmdGenerateMaster, `{"k":2}`, 0, "https://hook.example/2", 5, "", time.Time{}, "")
+	cmds := []domain.Command{domain.CmdGenerateMaster}
+	_, _, _ = taskRepo.Claim(context.Background(), "w1", cmds, 30, 1, 5, "")
+	_, _, _ = taskRepo.Claim(context.Background(), "w1", cmds, 30, 1, 5, "")
+
+	resultRepo := repository.NewResultRepository(rdb, time.UTC, nil)
+	cb := &captureCallback{}
+	svc := NewResultsService(resultRepo, &mockResultsUploader{}, cb, slog.Default(), time.Now, time.UTC)
+
+	items := []domain.BatchSubmitItem{
+		{TaskID: t1.ID, SubmitResultRequest: domain.SubmitResultRequest{WorkerID: "w1", Status: domain.StatusCompleted, Result: map[string]any{"ok": true}}},
+		{TaskID: t2.ID, SubmitResultRequest: domain.SubmitResultRequest{WorkerID: "w1", Status: domain.StatusFailed, Error: "boom"}},
+	}
+	if _, err := svc.BatchSubmit(context.Background(), items); err != nil {
+		t.Fatalf("BatchSubmit: %v", err)
+	}
+
+	got := cb.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 callback calls, got %d", len(got))
+	}
+	seen := map[string]domain.TaskStatus{}
+	for _, e := range got {
+		seen[e.task.ID] = e.rec.Status
+	}
+	if seen[t1.ID] != domain.StatusCompleted {
+		t.Errorf("t1 status: want COMPLETED, got %s", seen[t1.ID])
+	}
+	if seen[t2.ID] != domain.StatusFailed {
+		t.Errorf("t2 status: want FAILED, got %s", seen[t2.ID])
+	}
+}
+
+func TestNackTerminalFiresCallback(t *testing.T) {
+	mr, _ := miniredis.Run()
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	taskRepo := repository.NewTaskRepository(rdb, time.UTC, "exp_full_jitter", 1, 10, nil)
+	mockSubRepo := &mockSubscriptionRepo{}
+	notifier := NewNotifierService(mockSubRepo, nil, "test-secret", 5, nil, ratelimit.Bucket{}, nil)
+	cb := &captureCallback{}
+	// maxAttemptsDefault=1 so the first Nack lands the task in DLQ.
+	svc := NewSchedulerService(taskRepo, notifier, cb, time.UTC, time.Now, 60, 50, 1, "exp_full_jitter", 5, 900)
+
+	created, err := svc.CreateTask(context.Background(), domain.CmdGenerateMaster, `{"k":1}`, 0, "https://hook.example/x", 1, "", time.Time{}, 0, "")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	claimed, ok, err := svc.ClaimTask(context.Background(), "w1", []domain.Command{domain.CmdGenerateMaster}, 30, 0, "")
+	if err != nil || !ok {
+		t.Fatalf("ClaimTask: ok=%v err=%v", ok, err)
+	}
+	if claimed.ID != created.ID {
+		t.Fatalf("claimed wrong task: %s != %s", claimed.ID, created.ID)
+	}
+	_, terminal, err := svc.NackTask(context.Background(), claimed.ID, "w1", 0, "fatal")
+	if err != nil {
+		t.Fatalf("NackTask: %v", err)
+	}
+	if !terminal {
+		t.Fatalf("expected terminal=true with maxAttempts=1")
+	}
+	got := cb.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 callback call, got %d", len(got))
+	}
+	if got[0].rec.Status != domain.StatusFailed {
+		t.Errorf("status: want FAILED, got %s", got[0].rec.Status)
+	}
+	if got[0].rec.Error != "fatal" {
+		t.Errorf("error: want fatal, got %q", got[0].rec.Error)
+	}
+	if got[0].task.ID != created.ID {
+		t.Errorf("task.ID mismatch: want %s, got %s", created.ID, got[0].task.ID)
+	}
+}
+
+func TestNackNonTerminalDoesNotFireCallback(t *testing.T) {
+	mr, _ := miniredis.Run()
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	taskRepo := repository.NewTaskRepository(rdb, time.UTC, "exp_full_jitter", 1, 10, nil)
+	mockSubRepo := &mockSubscriptionRepo{}
+	notifier := NewNotifierService(mockSubRepo, nil, "test-secret", 5, nil, ratelimit.Bucket{}, nil)
+	cb := &captureCallback{}
+	// maxAttempts=5; first Nack should retry, not DLQ.
+	svc := NewSchedulerService(taskRepo, notifier, cb, time.UTC, time.Now, 60, 50, 5, "exp_full_jitter", 5, 900)
+
+	created, _ := svc.CreateTask(context.Background(), domain.CmdGenerateMaster, `{"k":1}`, 0, "https://hook.example/y", 5, "", time.Time{}, 0, "")
+	_, _, _ = svc.ClaimTask(context.Background(), "w1", []domain.Command{domain.CmdGenerateMaster}, 30, 0, "")
+	_, terminal, _ := svc.NackTask(context.Background(), created.ID, "w1", 1, "retry-me")
+	if terminal {
+		t.Fatalf("expected terminal=false on first Nack with maxAttempts=5")
+	}
+	if got := cb.snapshot(); len(got) != 0 {
+		t.Fatalf("expected 0 callback calls on retry, got %d", len(got))
+	}
+}

--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -177,9 +177,20 @@ func NewApplication(cfg *config.Config, opts ...ApplicationOption) (*Application
 	subs := services.NewSubscriptionService(subRepo)
 	notifier := services.NewNotifierService(subRepo, logger, cfg.WebhookHmacSecret, cfg.SubscriptionMinIntervalSeconds, limiter, ratelimit.Bucket(cfg.RateLimit.Webhook), webhookClient)
 	cleanup := services.NewSubscriptionCleanupService(subRepo, logger, cfg.SubscriptionCleanupIntervalSeconds)
+	resultCallback := services.NewResultCallbackService(
+		logger,
+		cfg.WebhookHmacSecret,
+		cfg.ResultWebhookMaxAttempts,
+		cfg.ResultWebhookBaseBackoffSeconds,
+		cfg.ResultWebhookMaxBackoffSeconds,
+		limiter,
+		ratelimit.Bucket(cfg.RateLimit.Webhook),
+		webhookClient,
+	)
 	scheduler := services.NewSchedulerService(
 		repo,
 		notifier,
+		resultCallback,
 		loc,
 		time.Now,
 		cfg.DefaultLeaseSeconds,
@@ -216,16 +227,6 @@ func NewApplication(cfg *config.Config, opts ...ApplicationOption) (*Application
 		resultRepo = repository.NewResultRepository(redisClient, loc, shardSupplier)
 	}
 	uploader := providers.NewLocalUploader(cfg.LocalArtifactsDir)
-	resultCallback := services.NewResultCallbackService(
-		logger,
-		cfg.WebhookHmacSecret,
-		cfg.ResultWebhookMaxAttempts,
-		cfg.ResultWebhookBaseBackoffSeconds,
-		cfg.ResultWebhookMaxBackoffSeconds,
-		limiter,
-		ratelimit.Bucket(cfg.RateLimit.Webhook),
-		webhookClient,
-	)
 	results := services.NewResultsService(resultRepo, uploader, resultCallback, logger, time.Now, loc)
 
 	engine := gin.New()

--- a/pkg/app/application_pebble.go
+++ b/pkg/app/application_pebble.go
@@ -280,6 +280,20 @@ func newPebbleApplication(
 		gossiper.Start(bgCtx)
 	}
 
+	subs := services.NewSubscriptionService(subRepo)
+	notifier := services.NewNotifierService(subRepo, logger, cfg.WebhookHmacSecret, cfg.SubscriptionMinIntervalSeconds, limiter, ratelimit.Bucket(cfg.RateLimit.Webhook), webhookClient)
+	cleanup := services.NewSubscriptionCleanupService(subRepo, logger, cfg.SubscriptionCleanupIntervalSeconds)
+	resultCallback := services.NewResultCallbackService(
+		logger,
+		cfg.WebhookHmacSecret,
+		cfg.ResultWebhookMaxAttempts,
+		cfg.ResultWebhookBaseBackoffSeconds,
+		cfg.ResultWebhookMaxBackoffSeconds,
+		limiter,
+		ratelimit.Bucket(cfg.RateLimit.Webhook),
+		webhookClient,
+	)
+
 	// Background reaper: enforces lease expiry + TTL cleanup, which Redis
 	// gives us via key TTL. Phase 8: one reaper per Pebble shard so the
 	// sweeps run in parallel and the per-shard commit pipelines stay
@@ -289,14 +303,17 @@ func newPebbleApplication(
 		BackoffBaseSeconds: cfg.BackoffBaseSeconds,
 		BackoffMaxSeconds:  cfg.BackoffMaxSeconds,
 		MaxAttemptsDefault: cfg.MaxAttemptsDefault,
+		DLQCallback: func(ctx context.Context, t domain.Task, rec domain.ResultRecord) {
+			if resultCallback != nil {
+				resultCallback.Send(ctx, t, rec)
+			}
+		},
 	})
 
-	subs := services.NewSubscriptionService(subRepo)
-	notifier := services.NewNotifierService(subRepo, logger, cfg.WebhookHmacSecret, cfg.SubscriptionMinIntervalSeconds, limiter, ratelimit.Bucket(cfg.RateLimit.Webhook), webhookClient)
-	cleanup := services.NewSubscriptionCleanupService(subRepo, logger, cfg.SubscriptionCleanupIntervalSeconds)
 	scheduler := services.NewSchedulerService(
 		taskRepo,
 		notifier,
+		resultCallback,
 		loc,
 		time.Now,
 		cfg.DefaultLeaseSeconds,
@@ -309,16 +326,6 @@ func newPebbleApplication(
 
 	// Result service & uploader mirror the redis path verbatim.
 	uploader := providers.NewLocalUploader(cfg.LocalArtifactsDir)
-	resultCallback := services.NewResultCallbackService(
-		logger,
-		cfg.WebhookHmacSecret,
-		cfg.ResultWebhookMaxAttempts,
-		cfg.ResultWebhookBaseBackoffSeconds,
-		cfg.ResultWebhookMaxBackoffSeconds,
-		limiter,
-		ratelimit.Bucket(cfg.RateLimit.Webhook),
-		webhookClient,
-	)
 	results := services.NewResultsService(resultRepo, uploader, resultCallback, logger, time.Now, loc)
 
 	engine := gin.New()


### PR DESCRIPTION
## Summary

Closes the webhook coverage gap documented in `docs/12-webhooks.md`: producers that registered `task.Webhook` only received the callback when the result came through single-task `Submit`. All other terminal paths were silent.

This PR fires `ResultCallbackService.Send` for the three missing paths:

- **`BatchSubmit`** — fan-out per successful entry, reusing the task already fetched in `GetTasksBatch`.
- **`Nack` → DLQ** — `SchedulerService.NackTask` synthesises a FAILED record when `repo.Nack` returns `terminal=true`.
- **Reaper lease-expired → DLQ** — Pebble `Reaper` accepts an optional `DLQCallback` closure (passed via `ReaperOptions`), invoked post-commit inside `requeueExpiredOne` when attempts ≥ max.

The reaper sits below `internal/services` in the dependency graph, so the callback is injected as a closure rather than importing the service.

Out of scope (follow-up):
- Redis-backed lease expiry is handled by Lua/TTL — same fix would need a different harness.
- TTL cleanup deletes the task entirely; no `Result` to send, so no callback expected.

## Test plan

- [x] `TestBatchSubmitFiresCallbackPerItem` — mixed COMPLETED+FAILED batch produces 2 Send calls
- [x] `TestNackTerminalFiresCallback` — terminal Nack fires once with status=FAILED + provided reason
- [x] `TestNackNonTerminalDoesNotFireCallback` — non-terminal Nack does not fire
- [x] `TestReaperDLQCallbackOnLeaseExpired` — backdated lease → callback fires with FAILED + LEASE_EXPIRED
- [x] `TestReaperDLQCallbackOnlyOnTerminal` — retry path does not fire
- [x] `go test ./internal/services ./internal/repository/pebble ./pkg/app -count=1` passes
- [ ] Manual: stand up an HTTP webhook sink (Python `http.server`), submit a task with `webhook` set, trigger lease expiry, confirm POST arrives with FAILED/LEASE_EXPIRED body