### PR TITLE
feat(api): long-poll GET /tasks/:id/result?waitSeconds=N

### DIFF
--- a/docs/04-http-api.md
+++ b/docs/04-http-api.md
@@ -434,15 +434,38 @@ Auth: producer token or worker token.
 
 ## Get result
 
-`GET /v1/codeq/tasks/:id/result`
+`GET /v1/codeq/tasks/:id/result[?waitSeconds=N]`
 
 Auth: producer token or worker token.
+
+Query params:
+
+- `waitSeconds` (int, optional, default `0`, max `60`): enables
+  long-poll. The server holds the request open until either the result
+  is available or the deadline elapses. `0` (or omitted) returns
+  immediately with whatever state is on disk.
 
 Response `200`:
 
 ```json
 {"task": {"id": "..."}, "result": {"taskId": "..."}}
 ```
+
+Response `404`:
+
+- `{"error":"task not found"}` — task ID does not exist. Long-poll
+  short-circuits in this case; no waiting.
+- `{"error":"result not found"}` — task exists but no result yet (still
+  pending, in-progress, or timed out before completion). With
+  `waitSeconds > 0` this response is only returned when the deadline
+  elapses without the result landing.
+
+Notes:
+
+- The implementation polls the store every 100 ms while waiting;
+  Pebble's in-process `Get` keeps the overhead negligible.
+- Client cancellation (`ctx.Done()`) aborts the wait immediately.
+- `waitSeconds` larger than 60 is silently capped to 60.
 
 ## Register webhook notifier (push)
 

--- a/internal/controllers/get_result_controller.go
+++ b/internal/controllers/get_result_controller.go
@@ -2,10 +2,23 @@ package controllers
 
 import (
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/osvaldoandrade/codeq/internal/services"
 
 	"github.com/gin-gonic/gin"
+)
+
+const (
+	// maxLongPollSeconds caps `?waitSeconds=` to keep connection budgets
+	// predictable. Producers that want to wait longer should retry.
+	maxLongPollSeconds = 60
+	// longPollInterval is how often the controller re-checks the result
+	// while waiting. Pebble's `Get` is a memtable/L0 lookup so 100 ms is
+	// effectively free; tighter intervals add CPU without changing
+	// perceived latency.
+	longPollInterval = 100 * time.Millisecond
 )
 
 type getResultController struct{ svc services.ResultsService }
@@ -14,12 +27,63 @@ func NewGetResultController(s services.ResultsService) *getResultController {
 	return &getResultController{svc: s}
 }
 
+// Handle returns the stored result for a task. With `?waitSeconds=N`
+// the request is held open until either the result becomes available
+// or the deadline elapses (long-poll). Without the query param the
+// behavior is the original fire-and-return.
 func (h *getResultController) Handle(c *gin.Context) {
 	id := c.Param("id")
-	res, task, err := h.svc.Get(c.Request.Context(), id)
-	if err != nil {
+	wait := parseWaitSeconds(c.Query("waitSeconds"))
+
+	if rec, task, err := h.svc.Get(c.Request.Context(), id); err == nil {
+		c.JSON(http.StatusOK, gin.H{"task": task, "result": rec})
+		return
+	} else if wait == 0 || err.Error() == "task not found" {
+		// No long-poll requested, or the task itself doesn't exist —
+		// no amount of waiting will make a result appear.
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"task": task, "result": res})
+
+	deadline := time.NewTimer(time.Duration(wait) * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(longPollInterval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			// Client gave up; nothing left to send.
+			return
+		case <-deadline.C:
+			rec, task, err := h.svc.Get(c.Request.Context(), id)
+			if err != nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"task": task, "result": rec})
+			return
+		case <-tick.C:
+			rec, task, err := h.svc.Get(c.Request.Context(), id)
+			if err != nil {
+				continue
+			}
+			c.JSON(http.StatusOK, gin.H{"task": task, "result": rec})
+			return
+		}
+	}
+}
+
+func parseWaitSeconds(raw string) int {
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	if n > maxLongPollSeconds {
+		return maxLongPollSeconds
+	}
+	return n
 }

--- a/pkg/app/long_poll_e2e_test.go
+++ b/pkg/app/long_poll_e2e_test.go
@@ -1,0 +1,188 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/static"
+	"github.com/osvaldoandrade/codeq/pkg/config"
+)
+
+// TestLongPollGetResult_E2E exercises the `?waitSeconds=N` long-poll
+// added to `GET /v1/codeq/tasks/:id/result`. Three cases:
+//   - waiter receives the result mid-flight, before the deadline
+//   - waiter times out cleanly with a 404 when the result never lands
+//   - missing task returns 404 immediately even with waitSeconds set
+func TestLongPollGetResult_E2E(t *testing.T) {
+	server := startLongPollServer(t)
+
+	t.Run("waiter receives result mid-flight", func(t *testing.T) {
+		id := createTaskNoHook(t, server.URL)
+		claimTaskByID(t, server.URL, id)
+
+		// Submit the result 300 ms after starting the long-poll.
+		go func() {
+			time.Sleep(300 * time.Millisecond)
+			submitBody := `{"status":"COMPLETED","result":{"ok":true}}`
+			req, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/codeq/tasks/"+id+"/result", strings.NewReader(submitBody))
+			req.Header.Set("Authorization", "Bearer dev-token")
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("background submit: %v", err)
+				return
+			}
+			resp.Body.Close()
+		}()
+
+		start := time.Now()
+		req, _ := http.NewRequest(http.MethodGet, server.URL+"/v1/codeq/tasks/"+id+"/result?waitSeconds=5", nil)
+		req.Header.Set("Authorization", "Bearer dev-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("long-poll GET: %v", err)
+		}
+		defer resp.Body.Close()
+		elapsed := time.Since(start)
+
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("long-poll: expected 200, got %d body=%s", resp.StatusCode, string(b))
+		}
+		if elapsed < 200*time.Millisecond || elapsed > 2*time.Second {
+			t.Errorf("long-poll elapsed=%v, want ~300ms-1s (submit fires at 300ms, poll interval 100ms)", elapsed)
+		}
+
+		var out map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		rec, _ := out["result"].(map[string]any)
+		if rec == nil || rec["status"] != "COMPLETED" {
+			t.Errorf("unexpected result payload: %+v", out)
+		}
+	})
+
+	t.Run("waiter times out when result never arrives", func(t *testing.T) {
+		id := createTaskNoHook(t, server.URL)
+		claimTaskByID(t, server.URL, id) // task is IN_PROGRESS, no result.
+
+		start := time.Now()
+		req, _ := http.NewRequest(http.MethodGet, server.URL+"/v1/codeq/tasks/"+id+"/result?waitSeconds=1", nil)
+		req.Header.Set("Authorization", "Bearer dev-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("long-poll GET: %v", err)
+		}
+		defer resp.Body.Close()
+		elapsed := time.Since(start)
+
+		if resp.StatusCode != http.StatusNotFound {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 404 on timeout, got %d body=%s", resp.StatusCode, string(b))
+		}
+		if elapsed < 900*time.Millisecond || elapsed > 1500*time.Millisecond {
+			t.Errorf("timeout elapsed=%v, want ~1s", elapsed)
+		}
+	})
+
+	t.Run("missing task short-circuits long-poll", func(t *testing.T) {
+		start := time.Now()
+		req, _ := http.NewRequest(http.MethodGet, server.URL+"/v1/codeq/tasks/does-not-exist/result?waitSeconds=10", nil)
+		req.Header.Set("Authorization", "Bearer dev-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("long-poll GET: %v", err)
+		}
+		defer resp.Body.Close()
+		elapsed := time.Since(start)
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", resp.StatusCode)
+		}
+		if elapsed > 500*time.Millisecond {
+			t.Errorf("missing-task call took %v — should short-circuit, not wait 10s", elapsed)
+		}
+	})
+}
+
+func startLongPollServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	dir := t.TempDir()
+	pcfg, _ := json.Marshal(map[string]any{"path": dir})
+
+	cfg := &config.Config{
+		Port:                               0,
+		Timezone:                           "UTC",
+		LogLevel:                           "error",
+		LogFormat:                          "json",
+		Env:                                "dev",
+		DefaultLeaseSeconds:                60,
+		RequeueInspectLimit:                50,
+		LocalArtifactsDir:                  t.TempDir(),
+		MaxAttemptsDefault:                 5,
+		BackoffPolicy:                      "fixed",
+		BackoffBaseSeconds:                 1,
+		BackoffMaxSeconds:                  3,
+		WebhookHmacSecret:                  "secret",
+		WorkerAudience:                     "codeq-worker",
+		SubscriptionMinIntervalSeconds:     5,
+		SubscriptionCleanupIntervalSeconds: 60,
+		ResultWebhookMaxAttempts:           1,
+		ResultWebhookBaseBackoffSeconds:    1,
+		ResultWebhookMaxBackoffSeconds:     2,
+		ProducerAuthProvider:               "static",
+		ProducerAuthConfig:                 json.RawMessage(`{"token":"dev-token","subject":"producer-dev","email":"dev@codeq.local","raw":{"role":"ADMIN","tenantId":"dev-tenant"}}`),
+		WorkerAuthProvider:                 "static",
+		WorkerAuthConfig:                   json.RawMessage(`{"token":"dev-token","subject":"worker-dev","scopes":["codeq:claim","codeq:heartbeat","codeq:abandon","codeq:nack","codeq:result","codeq:subscribe"],"eventTypes":["*"],"raw":{"tenantId":"dev-tenant"}}`),
+		PersistenceProvider:                "pebble",
+		PersistenceConfig:                  pcfg,
+		RedisAddr:                          "127.0.0.1:0",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	app, err := NewApplication(cfg)
+	if err != nil {
+		t.Fatalf("NewApplication: %v", err)
+	}
+	t.Cleanup(func() {
+		if app.TracingShutdown != nil {
+			_ = app.TracingShutdown(context.Background())
+		}
+	})
+	SetupMappings(app)
+	srv := httptest.NewServer(app.Engine)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func createTaskNoHook(t *testing.T, base string) string {
+	t.Helper()
+	body := `{"command":"GENERATE_MASTER","payload":{"k":"v"},"priority":5}`
+	req, _ := http.NewRequest(http.MethodPost, base+"/v1/codeq/tasks", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dev-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("create task: expected 202, got %d", resp.StatusCode)
+	}
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	id, _ := out["id"].(string)
+	if id == "" {
+		t.Fatalf("create task: no id in response: %+v", out)
+	}
+	return id
+}


### PR DESCRIPTION
## Summary

Adds long-poll semantics to the result-fetch endpoint. Producers that want push-style notification without setting up a webhook can now hold the GET request open until the result is ready.

\`\`\`
GET /v1/codeq/tasks/<id>/result?waitSeconds=10
\`\`\`

- \`waitSeconds=0\` (or omitted): unchanged — returns whatever is on disk.
- \`waitSeconds>0\`: holds the request open up to N seconds (capped at 60).
- \`task not found\` short-circuits regardless of \`waitSeconds\`.
- Client cancellation aborts the wait immediately.

Implementation is poll-based — 100 ms ticker over the existing \`ResultsService.Get\`. With Pebble in-process, the per-tick cost is a memtable/L0 lookup; a notification-based upgrade can land later if connection counts climb.

## Test plan

- [x] \`TestLongPollGetResult_E2E\` covers the three branches (mid-flight result, timeout, missing task)
- [x] \`go build ./...\` clean
- [x] Existing \`pkg/app\` tests still pass

## Docs

- \`docs/04-http-api.md\` updated with the new query param + status semantics