### PR TITLE
feat(raft): M2 — multi-shard raft topology

### DIFF
--- a/internal/repository/pebble/sharded_task_repository.go
+++ b/internal/repository/pebble/sharded_task_repository.go
@@ -2,6 +2,7 @@ package pebble
 
 import (
 	"context"
+	"errors"
 	"hash/fnv"
 	"sync/atomic"
 	"time"
@@ -11,6 +12,15 @@ import (
 	"github.com/osvaldoandrade/codeq/internal/repository"
 	"github.com/osvaldoandrade/codeq/pkg/domain"
 )
+
+// isNotLeader checks whether err is the local pebble.ErrNotLeader
+// sentinel. In raft mode, a shard's local writes return this when the
+// current node isn't the leader for that shard's raft group; the
+// fan-out methods below treat it as "skip this shard, try the next"
+// rather than a fatal error.
+func isNotLeader(err error) bool {
+	return errors.Is(err, ErrNotLeader)
+}
 
 // ShardedTaskRepository owns N TaskRepository instances (one per Pebble
 // shard) and routes every task-keyed operation by hash(task_id) % N.
@@ -93,6 +103,12 @@ func (s *ShardedTaskRepository) Claim(ctx context.Context, workerID string, comm
 		idx := (start + i) % n
 		t, ok, err := s.shards[idx].Claim(ctx, workerID, commands, leaseSeconds, inspectLimit, maxAttemptsDefault, tenantID)
 		if err != nil {
+			if isNotLeader(err) {
+				// In raft mode this shard is read-only on this node;
+				// try the next one. The wrapper's job is to find
+				// claimable work across whichever shards we lead.
+				continue
+			}
 			return nil, false, err
 		}
 		if ok && t != nil {
@@ -117,6 +133,9 @@ func (s *ShardedTaskRepository) ClaimMany(ctx context.Context, workerID string, 
 		remain := max - len(out)
 		got, err := s.shards[idx].ClaimMany(ctx, workerID, commands, leaseSeconds, remain, inspectLimit, maxAttemptsDefault, tenantID)
 		if err != nil {
+			if isNotLeader(err) {
+				continue
+			}
 			return out, err
 		}
 		out = append(out, got...)
@@ -141,6 +160,9 @@ func (s *ShardedTaskRepository) MoveDueDelayed(ctx context.Context, cmd domain.C
 	for _, sh := range s.shards {
 		n, err := sh.MoveDueDelayed(ctx, cmd, limit)
 		if err != nil {
+			if isNotLeader(err) {
+				continue
+			}
 			return total, err
 		}
 		total += n
@@ -204,6 +226,9 @@ func (s *ShardedTaskRepository) CleanupExpired(ctx context.Context, limit int, b
 	for _, sh := range s.shards {
 		n, err := sh.CleanupExpired(ctx, per, before)
 		if err != nil {
+			if isNotLeader(err) {
+				continue
+			}
 			return total, err
 		}
 		total += n

--- a/pkg/app/application_pebble.go
+++ b/pkg/app/application_pebble.go
@@ -181,41 +181,77 @@ func newPebbleApplication(
 	// next tick against a closed DB and panics.
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 
-	// Raft replication (M1). When cfg.Raft.Enabled, wire a raft node
-	// per Pebble shard and attach as a Replicator so every Set/Delete/
-	// CommitBatch on that shard flows through raft.Apply. Validation
-	// guarantees raft is mutually exclusive with cluster + sharding, so
-	// in raft mode len(dbs) == 1.
-	var raftNodes []*raftpkg.DB
+	// Raft replication (M1 single-shard + M2 multi-shard). When
+	// cfg.Raft.Enabled, wire one raft group per Pebble shard. Each
+	// group has its own LogStore/StableStore/SnapshotStore over the
+	// shard's Pebble (different prefixes), its own listening socket
+	// (BindAddr+shardIdx), and its own FSM. Cross-shard writes already
+	// fan out via ShardedTaskRepository — the per-shard raft groups
+	// keep each fan-out arm independently replicated.
+	//
+	// raftNodes[i] is the raft group for dbs[i]. They share the same
+	// lifecycle as the shard's Pebble (raft.Close must run BEFORE
+	// pebble.Close — see TracingShutdown and cleanupStartupFailure).
+	raftNodes := make([]*raftpkg.DB, len(dbs))
 	if cfg.Raft.Enabled {
-		raftCfg := raftpkg.Config{
-			Path:          pc.Path,
-			SelfID:        cfg.Raft.SelfID,
-			BindAddr:      cfg.Raft.BindAddr,
-			Bootstrap:     cfg.Raft.Bootstrap,
-			PeerAddrs:     cfg.Raft.Peers,
-			HeartbeatMS:   cfg.Raft.HeartbeatMS,
-			ElectionMS:    cfg.Raft.ElectionMS,
-			LeaderLeaseMS: cfg.Raft.LeaderLeaseMS,
-			CommitMS:      cfg.Raft.CommitMS,
-		}
-		if cfg.Raft.ApplyTimeoutSeconds > 0 {
-			raftCfg.ApplyTimeout = time.Duration(cfg.Raft.ApplyTimeoutSeconds) * time.Second
-		}
-		rdb, err := raftpkg.OpenWithPebble(bgCtx, raftCfg, db.Raw())
-		if err != nil {
-			bgCancel()
-			for _, d := range dbs {
-				_ = d.Close()
+		for i, shardDB := range dbs {
+			shardBind, err := bindAddrForShard(cfg.Raft.BindAddr, i)
+			if err != nil {
+				bgCancel()
+				for _, d := range dbs {
+					_ = d.Close()
+				}
+				return nil, fmt.Errorf("raft bind addr shard %d: %w", i, err)
 			}
-			return nil, fmt.Errorf("raft open: %w", err)
+			shardPeers, err := peersForShard(cfg.Raft.Peers, i)
+			if err != nil {
+				bgCancel()
+				for _, d := range dbs {
+					_ = d.Close()
+				}
+				return nil, fmt.Errorf("raft peers shard %d: %w", i, err)
+			}
+			shardPath := pc.Path
+			if numShards > 1 {
+				shardPath = fmt.Sprintf("%s/shard%d", pc.Path, i)
+			}
+			raftCfg := raftpkg.Config{
+				Path:          shardPath,
+				SelfID:        cfg.Raft.SelfID,
+				BindAddr:      shardBind,
+				Bootstrap:     cfg.Raft.Bootstrap,
+				PeerAddrs:     shardPeers,
+				HeartbeatMS:   cfg.Raft.HeartbeatMS,
+				ElectionMS:    cfg.Raft.ElectionMS,
+				LeaderLeaseMS: cfg.Raft.LeaderLeaseMS,
+				CommitMS:      cfg.Raft.CommitMS,
+			}
+			if cfg.Raft.ApplyTimeoutSeconds > 0 {
+				raftCfg.ApplyTimeout = time.Duration(cfg.Raft.ApplyTimeoutSeconds) * time.Second
+			}
+			rdb, err := raftpkg.OpenWithPebble(bgCtx, raftCfg, shardDB.Raw())
+			if err != nil {
+				bgCancel()
+				// Close any raft nodes already opened (lifecycle:
+				// raft.Close before pebble.Close).
+				for _, r := range raftNodes[:i] {
+					if r != nil {
+						_ = r.Close()
+					}
+				}
+				for _, d := range dbs {
+					_ = d.Close()
+				}
+				return nil, fmt.Errorf("raft open shard %d: %w", i, err)
+			}
+			shardDB.AttachReplicator(rdb)
+			raftNodes[i] = rdb
 		}
-		db.AttachReplicator(rdb)
-		raftNodes = append(raftNodes, rdb)
 		logger.Info("raft replication enabled",
 			"selfID", cfg.Raft.SelfID,
-			"bindAddr", cfg.Raft.BindAddr,
-			"peers", len(cfg.Raft.Peers))
+			"baseBindAddr", cfg.Raft.BindAddr,
+			"peers", len(cfg.Raft.Peers),
+			"shards", len(dbs))
 	}
 
 	taskShards := make([]*pebblerepo.TaskRepository, len(dbs))
@@ -348,13 +384,18 @@ func newPebbleApplication(
 			}
 		},
 	}
-	if len(raftNodes) > 0 {
-		// Per-shard LeaderGate would matter for M2 multi-raft. M1 has
-		// one shard ⇒ one raft node, so a single IsLeader() suffices.
-		raftRef := raftNodes[0]
-		reaperOpts.LeaderGate = raftRef.IsLeader
+	// Each shard's reaper checks its own raft group's leadership. M1's
+	// single-shard path still works (raftNodes[0].IsLeader). M2's
+	// multi-shard path uses the per-shard raft instance so a node that
+	// leads shard 0 but follows shard 1 only sweeps shard 0.
+	for i, shardDB := range dbs {
+		opts := reaperOpts // value copy keeps DLQCallback shared
+		if cfg.Raft.Enabled && raftNodes[i] != nil {
+			ref := raftNodes[i]
+			opts.LeaderGate = ref.IsLeader
+		}
+		pebblerepo.NewReaper(shardDB, loc, logger, opts).Start(bgCtx)
 	}
-	pebblerepo.StartReapersForShards(bgCtx, dbs, loc, logger, reaperOpts)
 
 	scheduler := services.NewSchedulerService(
 		taskRepo,

--- a/pkg/app/raft_addr.go
+++ b/pkg/app/raft_addr.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// bindAddrForShard derives a per-shard listen address from a base
+// "host:port" by adding shardIdx to the port. Multi-raft (M2) opens
+// one raft group per Pebble shard; each group needs its own listening
+// socket. Convention: base BindAddr is for shard 0, +1 for shard 1, …
+//
+// Port 0 (ephemeral) is only valid for shardIdx==0 — without a known
+// base port we can't predict the offsets, which breaks the peer
+// configuration of the other shards. Tests that need ephemeral ports
+// pre-grab N free ports and pass them explicitly via Raft.Peers.
+func bindAddrForShard(baseAddr string, shardIdx int) (string, error) {
+	if baseAddr == "" {
+		return "", fmt.Errorf("bindAddrForShard: empty base address")
+	}
+	host, portStr, err := net.SplitHostPort(baseAddr)
+	if err != nil {
+		return "", fmt.Errorf("bindAddrForShard: %w", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", fmt.Errorf("bindAddrForShard: invalid port %q: %w", portStr, err)
+	}
+	if port == 0 {
+		if shardIdx > 0 {
+			return "", fmt.Errorf("bindAddrForShard: port 0 only supported with shardIdx=0 (got %d)", shardIdx)
+		}
+		return baseAddr, nil
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port+shardIdx)), nil
+}
+
+// peersForShard derives the per-shard peer map by applying
+// bindAddrForShard to every peer's base address. Returns a fresh map.
+func peersForShard(basePeers map[string]string, shardIdx int) (map[string]string, error) {
+	if len(basePeers) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(basePeers))
+	for id, addr := range basePeers {
+		shardAddr, err := bindAddrForShard(addr, shardIdx)
+		if err != nil {
+			return nil, fmt.Errorf("peersForShard: peer %s: %w", id, err)
+		}
+		out[id] = shardAddr
+	}
+	return out, nil
+}

--- a/pkg/app/raft_addr_test.go
+++ b/pkg/app/raft_addr_test.go
@@ -1,0 +1,73 @@
+package app
+
+import "testing"
+
+func TestBindAddrForShard(t *testing.T) {
+	cases := []struct {
+		name    string
+		base    string
+		shard   int
+		want    string
+		wantErr bool
+	}{
+		{"shard0", "127.0.0.1:7000", 0, "127.0.0.1:7000", false},
+		{"shard3", "127.0.0.1:7000", 3, "127.0.0.1:7003", false},
+		{"ipv6", "[::1]:7000", 2, "[::1]:7002", false},
+		{"hostname", "localhost:9000", 1, "localhost:9001", false},
+		{"port0_shard0_ok", "127.0.0.1:0", 0, "127.0.0.1:0", false},
+		{"port0_shardN_err", "127.0.0.1:0", 1, "", true},
+		{"empty", "", 0, "", true},
+		{"no_port", "127.0.0.1", 1, "", true},
+		{"bad_port", "127.0.0.1:abc", 1, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := bindAddrForShard(tc.base, tc.shard)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected err: %v", err)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPeersForShard(t *testing.T) {
+	base := map[string]string{
+		"node-1": "127.0.0.1:7000",
+		"node-2": "127.0.0.1:7100",
+		"node-3": "127.0.0.1:7200",
+	}
+	got, err := peersForShard(base, 2)
+	if err != nil {
+		t.Fatalf("peersForShard: %v", err)
+	}
+	want := map[string]string{
+		"node-1": "127.0.0.1:7002",
+		"node-2": "127.0.0.1:7102",
+		"node-3": "127.0.0.1:7202",
+	}
+	for id, addr := range want {
+		if got[id] != addr {
+			t.Errorf("peer %s: got %q, want %q", id, got[id], addr)
+		}
+	}
+}
+
+func TestPeersForShard_EmptyReturnsNil(t *testing.T) {
+	got, err := peersForShard(nil, 0)
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("want nil, got %v", got)
+	}
+}

--- a/pkg/app/raft_multishard_1node_test.go
+++ b/pkg/app/raft_multishard_1node_test.go
@@ -1,0 +1,282 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/static"
+	"github.com/osvaldoandrade/codeq/pkg/config"
+)
+
+// TestRaft_MultiShard_1Node boots one codeq with numShards=4 +
+// raft.enabled=true. Each shard bootstraps its own 1-voter raft group
+// on BindAddr+shardIdx. Tasks distribute across shards via ShardedTask-
+// Repository's fnv64a routing; each shard's writes replicate through
+// its own raft group.
+//
+// This is the M2.T4 smoke: verify the multi-shard raft topology comes
+// up cleanly and the standard create → claim → submit cycle works.
+func TestRaft_MultiShard_1Node(t *testing.T) {
+	numShards := 4
+	basePort := pickContiguousFreePorts(t, numShards)
+	pebbleDir := t.TempDir() + "/pebble"
+	pcfg, _ := json.Marshal(map[string]any{
+		"path":      pebbleDir,
+		"numShards": numShards,
+	})
+
+	cfg := &config.Config{
+		Port:                               0,
+		Timezone:                           "UTC",
+		LogLevel:                           "error",
+		LogFormat:                          "json",
+		Env:                                "dev",
+		DefaultLeaseSeconds:                60,
+		RequeueInspectLimit:                50,
+		LocalArtifactsDir:                  t.TempDir(),
+		MaxAttemptsDefault:                 5,
+		BackoffPolicy:                      "fixed",
+		BackoffBaseSeconds:                 1,
+		BackoffMaxSeconds:                  3,
+		WebhookHmacSecret:                  "secret",
+		WorkerAudience:                     "codeq-worker",
+		SubscriptionMinIntervalSeconds:     5,
+		SubscriptionCleanupIntervalSeconds: 60,
+		ResultWebhookMaxAttempts:           3,
+		ResultWebhookBaseBackoffSeconds:    1,
+		ResultWebhookMaxBackoffSeconds:     2,
+		ProducerAuthProvider:               "static",
+		ProducerAuthConfig:                 json.RawMessage(`{"token":"dev-token","subject":"producer-dev","email":"dev@codeq.local","raw":{"role":"ADMIN","tenantId":"dev-tenant"}}`),
+		WorkerAuthProvider:                 "static",
+		WorkerAuthConfig:                   json.RawMessage(`{"token":"dev-token","subject":"worker-dev","scopes":["codeq:claim","codeq:heartbeat","codeq:abandon","codeq:nack","codeq:result","codeq:subscribe"],"eventTypes":["*"],"raw":{"tenantId":"dev-tenant"}}`),
+		PersistenceProvider:                "pebble",
+		PersistenceConfig:                  pcfg,
+		RedisAddr:                          "127.0.0.1:0",
+		Raft: config.RaftConfig{
+			Enabled:             true,
+			SelfID:              "node-1",
+			BindAddr:            fmt.Sprintf("127.0.0.1:%d", basePort),
+			Bootstrap:           true,
+			HeartbeatMS:         50,
+			ElectionMS:          50,
+			LeaderLeaseMS:       50,
+			CommitMS:            10,
+			ApplyTimeoutSeconds: 3,
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	app, err := NewApplication(cfg)
+	if err != nil {
+		t.Fatalf("NewApplication: %v", err)
+	}
+	defer func() {
+		if app.TracingShutdown != nil {
+			_ = app.TracingShutdown(context.Background())
+		}
+	}()
+	SetupMappings(app)
+
+	srv := httptest.NewServer(app.Engine)
+	defer srv.Close()
+
+	// Wait for all shards to elect (single-voter, sub-100ms each).
+	if !waitWritesAccepted(t, srv, 3*time.Second) {
+		t.Fatal("never reached a state where writes succeed across all 4 shards")
+	}
+
+	// Submit 40 tasks. With fnv64a routing on uuid task IDs, the
+	// distribution should be roughly even across 4 shards. Retry on
+	// transient "not leader" — shards elect independently within a few
+	// election timeouts, so the first writes may land on a still-
+	// settling shard until every group has a leader. This matches the
+	// expected client behavior.
+	ids := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		body := fmt.Sprintf(`{"command":"GENERATE_MASTER","payload":{"i":%d},"priority":5}`, i)
+		id, err := createTaskWithRetry(t, srv.URL, body, 3*time.Second)
+		if err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+
+	// Each task readable via GET — confirms the local read path works
+	// after multi-shard raft writes.
+	for _, id := range ids {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/codeq/tasks/"+id, nil)
+		req.Header.Set("Authorization", "Bearer dev-token")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", id, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s status %d", id, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+
+	// Claim everything (round-robin across shards inside ShardedTask-
+	// Repository) and submit results. Each cycle exercises that
+	// shard's raft pipeline.
+	for range ids {
+		claimReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/codeq/tasks/claim",
+			strings.NewReader(`{"commands":["GENERATE_MASTER"],"leaseSeconds":60,"waitSeconds":0}`))
+		claimReq.Header.Set("Authorization", "Bearer dev-token")
+		claimReq.Header.Set("Content-Type", "application/json")
+		claimResp, err := http.DefaultClient.Do(claimReq)
+		if err != nil || claimResp.StatusCode != http.StatusOK {
+			if claimResp != nil {
+				claimResp.Body.Close()
+			}
+			t.Fatalf("claim: err=%v status=%d", err, statusOf(claimResp))
+		}
+		var out map[string]any
+		_ = json.NewDecoder(claimResp.Body).Decode(&out)
+		claimResp.Body.Close()
+		claimedID, _ := out["id"].(string)
+		if claimedID == "" {
+			t.Fatalf("claim returned no id (queue empty before draining all 40 tasks)")
+		}
+
+		submitReq, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/codeq/tasks/"+claimedID+"/result",
+			strings.NewReader(`{"status":"COMPLETED","result":{"ok":true}}`))
+		submitReq.Header.Set("Authorization", "Bearer dev-token")
+		submitReq.Header.Set("Content-Type", "application/json")
+		submitResp, err := http.DefaultClient.Do(submitReq)
+		if err != nil || submitResp.StatusCode != http.StatusOK {
+			if submitResp != nil {
+				submitResp.Body.Close()
+			}
+			t.Fatalf("submit %s: err=%v status=%d", claimedID, err, statusOf(submitResp))
+		}
+		submitResp.Body.Close()
+	}
+}
+
+func statusOf(r *http.Response) int {
+	if r == nil {
+		return 0
+	}
+	return r.StatusCode
+}
+
+// createTaskWithRetry posts a create and retries on transient "not
+// leader" errors. Each task ID is fresh per attempt — fnv64a hash on
+// a new UUID reshuffles which shard the write targets, so retrying
+// after the slow-elector finishes electing succeeds quickly.
+func createTaskWithRetry(t *testing.T, baseURL, body string, timeout time.Duration) (string, error) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastBody string
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest(http.MethodPost, baseURL+"/v1/codeq/tasks", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer dev-token")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			time.Sleep(30 * time.Millisecond)
+			continue
+		}
+		if resp.StatusCode == http.StatusAccepted {
+			var out map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&out)
+			resp.Body.Close()
+			id, _ := out["id"].(string)
+			return id, nil
+		}
+		// Capture the body for diagnostics; on "not leader" retry.
+		b := make([]byte, 512)
+		n, _ := resp.Body.Read(b)
+		resp.Body.Close()
+		lastBody = string(b[:n])
+		if !strings.Contains(lastBody, "not leader") {
+			return "", fmt.Errorf("status %d body=%s", resp.StatusCode, lastBody)
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+	return "", fmt.Errorf("timeout waiting for leader (last=%s)", lastBody)
+}
+
+// waitWritesAccepted polls POST /v1/codeq/tasks until a write succeeds.
+// With multi-shard raft, every shard's leader has to be elected before
+// we can guarantee every routed write lands; the helper waits until at
+// least one write returns 202 (sentinel that the cluster has settled
+// for the shard that uuid happens to hash to).
+func waitWritesAccepted(t *testing.T, srv *httptest.Server, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	body := `{"command":"GENERATE_MASTER","payload":{"probe":true},"priority":5}`
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/codeq/tasks", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer dev-token")
+		req.Header.Set("Content-Type", "application/json")
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		req = req.WithContext(ctx)
+		resp, err := http.DefaultClient.Do(req)
+		cancel()
+		if err == nil && resp != nil && resp.StatusCode == http.StatusAccepted {
+			resp.Body.Close()
+			return true
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+	return false
+}
+
+// pickContiguousFreePorts returns a base port such that base+0..base+n-1
+// are all currently free on 127.0.0.1. Strategy: probe upward from a
+// random high port, opening a listener at each candidate to confirm
+// availability, then close them.
+//
+// There's a small race between this function returning and the test
+// binding the same ports, but on a single-machine test run with no
+// other listeners in that range, it's effectively zero.
+func pickContiguousFreePorts(t *testing.T, n int) int {
+	t.Helper()
+	const startRange = 25000
+	const endRange = 30000
+	for attempt := 0; attempt < 32; attempt++ {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("seed listener: %v", err)
+		}
+		_, portStr, _ := net.SplitHostPort(l.Addr().String())
+		_ = l.Close()
+		var base int
+		fmt.Sscanf(portStr, "%d", &base)
+		if base < startRange || base > endRange-n {
+			// Re-roll into the high range
+			base = startRange + (base % (endRange - startRange))
+		}
+		listeners := make([]net.Listener, 0, n)
+		ok := true
+		for i := 0; i < n; i++ {
+			ll, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", base+i))
+			if err != nil {
+				ok = false
+				break
+			}
+			listeners = append(listeners, ll)
+		}
+		for _, ll := range listeners {
+			_ = ll.Close()
+		}
+		if ok {
+			return base
+		}
+	}
+	t.Fatalf("could not find %d contiguous free ports after 32 attempts", n)
+	return 0
+}

--- a/pkg/app/raft_multishard_3node_test.go
+++ b/pkg/app/raft_multishard_3node_test.go
@@ -1,0 +1,230 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/static"
+	"github.com/osvaldoandrade/codeq/pkg/config"
+)
+
+// TestRaft_MultiShard_3Node failover is the M2 endgame proof:
+// 3 codeq processes × 4 Pebble shards = 12 independent raft groups.
+// Each shard's quorum is 2/3; failover survives any single-node loss.
+// Writes hash to a shard via fnv64a (taskID), then to that shard's
+// leader (whichever node currently holds it).
+func TestRaft_MultiShard_3Node(t *testing.T) {
+	const numShards = 4
+	const numNodes = 3
+
+	// Pre-grab numNodes × numShards contiguous ports, then split into
+	// per-node blocks of numShards consecutive ports each.
+	base := pickContiguousFreePorts(t, numNodes*numShards)
+	nodeBases := make([]int, numNodes)
+	for i := range nodeBases {
+		nodeBases[i] = base + i*numShards
+	}
+
+	peers := map[string]string{
+		"node-1": fmt.Sprintf("127.0.0.1:%d", nodeBases[0]),
+		"node-2": fmt.Sprintf("127.0.0.1:%d", nodeBases[1]),
+		"node-3": fmt.Sprintf("127.0.0.1:%d", nodeBases[2]),
+	}
+
+	// Start followers FIRST so their transports are listening before
+	// node-1 bootstraps and starts dialing peers. Otherwise node-1's
+	// initial election rounds hit connection-refused on every peer
+	// and the cluster takes much longer to settle (or never does
+	// within the test timeout).
+	nodes := make([]*raftTestNode, numNodes)
+	for i, id := range []string{"node-2", "node-3"} {
+		nodes[i+1] = startMultiShardRaftNode(t, id, peers, numShards, false /* bootstrap */)
+	}
+	nodes[0] = startMultiShardRaftNode(t, "node-1", peers, numShards, true /* bootstrap */)
+	t.Cleanup(func() {
+		for _, n := range nodes {
+			if n != nil && !n.closed.Load() {
+				_ = n.shutdown()
+			}
+		}
+	})
+
+	survivors := func() []*raftTestNode {
+		out := make([]*raftTestNode, 0, len(nodes))
+		for _, n := range nodes {
+			if !n.closed.Load() {
+				out = append(out, n)
+			}
+		}
+		return out
+	}
+
+	// No explicit "wait for ready" — submitTasksAcrossNodes retries
+	// on the next node on every ErrNotLeader, so the first few writes
+	// naturally probe until the cluster has settled. Each call gets a
+	// fresh UUID, so retries hash to a fresh shard.
+	ids := submitTasksAcrossNodes(t, survivors(), 40, 5*time.Second)
+
+	// Every node must answer GET /tasks/:id consistently.
+	for _, n := range survivors() {
+		for _, id := range ids {
+			body := getTask(t, n, id)
+			if !strings.Contains(body, id) {
+				t.Fatalf("node %s missing task %s after initial writes", n.id, id)
+			}
+		}
+	}
+
+	// Kill the first node. Each of its 4 raft groups had ~1/3 chance
+	// of being leader; the other 2 nodes' groups for those shards will
+	// trigger elections.
+	t.Logf("killing %s", nodes[0].id)
+	if err := nodes[0].shutdown(); err != nil {
+		t.Fatalf("shutdown node-1: %v", err)
+	}
+
+	// Submit 20 more tasks against the 2 survivors. Retries on
+	// ErrNotLeader drive re-election convergence — the test doesn't
+	// need to know which shard re-elected on which survivor.
+	moreIDs := submitTasksAcrossNodes(t, survivors(), 20, 5*time.Second)
+	ids = append(ids, moreIDs...)
+
+	// Final consistency check: every surviving node sees every task.
+	for _, n := range survivors() {
+		for _, id := range ids {
+			body := getTask(t, n, id)
+			if !strings.Contains(body, id) {
+				t.Errorf("survivor %s missing task %s after failover", n.id, id)
+			}
+		}
+	}
+}
+
+func startMultiShardRaftNode(t *testing.T, id string, peers map[string]string, numShards int, bootstrap bool) *raftTestNode {
+	t.Helper()
+	pebbleDir := t.TempDir() + "/pebble"
+	pcfg, _ := json.Marshal(map[string]any{
+		"path":      pebbleDir,
+		"numShards": numShards,
+	})
+	cfg := &config.Config{
+		Port:                               0,
+		Timezone:                           "UTC",
+		LogLevel:                           "error",
+		LogFormat:                          "json",
+		Env:                                "dev",
+		DefaultLeaseSeconds:                60,
+		RequeueInspectLimit:                50,
+		LocalArtifactsDir:                  t.TempDir(),
+		MaxAttemptsDefault:                 5,
+		BackoffPolicy:                      "fixed",
+		BackoffBaseSeconds:                 1,
+		BackoffMaxSeconds:                  3,
+		WebhookHmacSecret:                  "secret",
+		WorkerAudience:                     "codeq-worker",
+		SubscriptionMinIntervalSeconds:     5,
+		SubscriptionCleanupIntervalSeconds: 60,
+		ResultWebhookMaxAttempts:           3,
+		ResultWebhookBaseBackoffSeconds:    1,
+		ResultWebhookMaxBackoffSeconds:     2,
+		ProducerAuthProvider:               "static",
+		ProducerAuthConfig:                 json.RawMessage(`{"token":"dev-token","subject":"producer-dev","email":"dev@codeq.local","raw":{"role":"ADMIN","tenantId":"dev-tenant"}}`),
+		WorkerAuthProvider:                 "static",
+		WorkerAuthConfig:                   json.RawMessage(`{"token":"dev-token","subject":"worker-dev","scopes":["codeq:claim","codeq:heartbeat","codeq:abandon","codeq:nack","codeq:result","codeq:subscribe"],"eventTypes":["*"],"raw":{"tenantId":"dev-tenant"}}`),
+		PersistenceProvider:                "pebble",
+		PersistenceConfig:                  pcfg,
+		RedisAddr:                          "127.0.0.1:0",
+		Raft: config.RaftConfig{
+			Enabled:             true,
+			SelfID:              id,
+			BindAddr:            peers[id],
+			Bootstrap:           bootstrap,
+			Peers:               peers,
+			HeartbeatMS:         50,
+			ElectionMS:          50,
+			LeaderLeaseMS:       50,
+			CommitMS:            10,
+			ApplyTimeoutSeconds: 3,
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("[%s] validate: %v", id, err)
+	}
+	app, err := NewApplication(cfg)
+	if err != nil {
+		t.Fatalf("[%s] NewApplication: %v", id, err)
+	}
+	SetupMappings(app)
+	server := httptest.NewServer(app.Engine)
+	return &raftTestNode{
+		id:       id,
+		app:      app,
+		server:   server,
+		bindAddr: peers[id],
+	}
+}
+
+// submitTasksAcrossNodes creates n tasks, rotating across the provided
+// nodes on every attempt. On ErrNotLeader the next attempt picks the
+// next node + generates a new UUID, so retries hash to fresh shards
+// and converge on leaders within a few election timeouts.
+func submitTasksAcrossNodes(t *testing.T, nodes []*raftTestNode, n int, timeout time.Duration) []string {
+	t.Helper()
+	if len(nodes) == 0 {
+		t.Fatalf("submitTasksAcrossNodes: no nodes")
+	}
+	out := make([]string, 0, n)
+	var counter atomic.Int64
+	for i := 0; i < n; i++ {
+		body := fmt.Sprintf(`{"command":"GENERATE_MASTER","payload":{"i":%d},"priority":5}`, i)
+		id, err := createOnAny(t, nodes, body, timeout, &counter)
+		if err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+		out = append(out, id)
+	}
+	return out
+}
+
+func createOnAny(t *testing.T, nodes []*raftTestNode, body string, timeout time.Duration, counter *atomic.Int64) (string, error) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastBody string
+	for time.Now().Before(deadline) {
+		node := nodes[int(counter.Add(1))%len(nodes)]
+		req, _ := http.NewRequest(http.MethodPost, node.server.URL+"/v1/codeq/tasks", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer dev-token")
+		req.Header.Set("Content-Type", "application/json")
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		req = req.WithContext(ctx)
+		resp, err := http.DefaultClient.Do(req)
+		cancel()
+		if err != nil {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		if resp.StatusCode == http.StatusAccepted {
+			var out map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&out)
+			resp.Body.Close()
+			id, _ := out["id"].(string)
+			return id, nil
+		}
+		b := make([]byte, 512)
+		nn, _ := resp.Body.Read(b)
+		resp.Body.Close()
+		lastBody = string(b[:nn])
+		if !strings.Contains(lastBody, "not leader") {
+			return "", fmt.Errorf("status %d body=%s", resp.StatusCode, lastBody)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return "", fmt.Errorf("timeout waiting for leader across %d nodes (last=%s)", len(nodes), lastBody)
+}

--- a/pkg/app/raft_multishard_bench_test.go
+++ b/pkg/app/raft_multishard_bench_test.go
@@ -1,0 +1,213 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/static"
+)
+
+// TestRaftBench_MultiShardScale measures throughput on a 3-node raft
+// cluster with numShards=1 vs numShards=4. The hypothesis: multi-raft
+// scales because each shard's commit pipeline runs in its own raft
+// group, with independent quorum + parallel fsync.
+//
+// The bench drives the realistic write path (REST create → claim →
+// submit), rotating across nodes on every operation. Each cycle is
+// three writes that route to potentially three different shards.
+//
+// Skipped under -short. Run with:
+//   go test -v -run TestRaftBench_MultiShardScale -count=1 -timeout=120s ./pkg/app
+func TestRaftBench_MultiShardScale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("bench is long; run without -short")
+	}
+
+	const (
+		warmup     = 1 * time.Second
+		window     = 5 * time.Second
+		concurrent = 32
+		numNodes   = 3
+	)
+
+	measure := func(t *testing.T, numShards int) float64 {
+		t.Helper()
+		base := pickContiguousFreePorts(t, numNodes*numShards)
+		peers := map[string]string{
+			"node-1": fmt.Sprintf("127.0.0.1:%d", base+0*numShards),
+			"node-2": fmt.Sprintf("127.0.0.1:%d", base+1*numShards),
+			"node-3": fmt.Sprintf("127.0.0.1:%d", base+2*numShards),
+		}
+		nodes := make([]*raftTestNode, numNodes)
+		for i, id := range []string{"node-2", "node-3"} {
+			nodes[i+1] = startMultiShardRaftNode(t, id, peers, numShards, false)
+		}
+		nodes[0] = startMultiShardRaftNode(t, "node-1", peers, numShards, true)
+		t.Cleanup(func() {
+			for _, n := range nodes {
+				if n != nil && !n.closed.Load() {
+					_ = n.shutdown()
+				}
+			}
+		})
+
+		// Warmup probe — guarantees every shard has elected before
+		// the measurement window opens.
+		_ = submitTasksAcrossNodes(t, nodes, 8, 5*time.Second)
+
+		var ops atomic.Int64
+
+		// Real warmup loop (results discarded).
+		wctx, wcancel := context.WithTimeout(context.Background(), warmup)
+		runMultiShardCycle(wctx, nodes, concurrent, nil)
+		wcancel()
+
+		// Measurement window.
+		mctx, mcancel := context.WithTimeout(context.Background(), window)
+		start := time.Now()
+		runMultiShardCycle(mctx, nodes, concurrent, &ops)
+		mcancel()
+		elapsed := time.Since(start)
+		return float64(ops.Load()) / elapsed.Seconds()
+	}
+
+	var single, multi float64
+	t.Run("3-node × 1-shard", func(t *testing.T) {
+		single = measure(t, 1)
+		t.Logf("1-shard cycles/s: %.0f", single)
+	})
+	t.Run("3-node × 4-shard", func(t *testing.T) {
+		multi = measure(t, 4)
+		t.Logf("4-shard cycles/s: %.0f", multi)
+	})
+
+	if single == 0 || multi == 0 {
+		t.Skip("one of the subtests didn't measure")
+	}
+	ratio := multi / single
+	t.Logf("multi-shard / single-shard ratio: %.2fx", ratio)
+
+	// Lower bound: multi-raft should at LEAST match single-raft. The
+	// real expectation is a meaningful speedup, but loopback gRPC
+	// contention + small workload may keep the ratio < 4×. Anything
+	// below 0.9× would indicate a regression in the wrapper.
+	if ratio < 0.9 {
+		t.Errorf("multi-shard throughput %.0f is %.2fx single-shard %.0f — expected ≥0.9×",
+			multi, ratio, single)
+	}
+}
+
+// runMultiShardCycle is the multi-node variant of runCycleLoop: each
+// goroutine rotates its target node on every operation, so a write
+// that hits a non-leader shard recovers on the next attempt with a
+// fresh UUID against a different node.
+func runMultiShardCycle(ctx context.Context, nodes []*raftTestNode, concurrency int, ops *atomic.Int64) {
+	var wg sync.WaitGroup
+	client := &http.Client{Timeout: 5 * time.Second}
+	var counter atomic.Int64
+	for g := 0; g < concurrency; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for {
+				if ctx.Err() != nil {
+					return
+				}
+				node := nodes[int(counter.Add(1))%len(nodes)]
+				if node.closed.Load() {
+					continue
+				}
+				taskID := postWithRetry(ctx, client, nodes, &counter, fmt.Sprintf(`{"command":"GENERATE_MASTER","payload":{"g":%d},"priority":5}`, id))
+				if taskID == "" {
+					return
+				}
+				claimed := postWithRetry(ctx, client, nodes, &counter, `{"commands":["GENERATE_MASTER"],"leaseSeconds":60,"waitSeconds":0}`)
+				// claimed is the response from /claim; parse the id
+				if claimed == "" {
+					continue
+				}
+				// extract task id from claimed body
+				var out map[string]any
+				_ = json.Unmarshal([]byte(claimed), &out)
+				cid, _ := out["id"].(string)
+				if cid == "" {
+					continue
+				}
+				// submit result to whichever node we can
+				submitWithRetry(ctx, client, nodes, &counter, cid)
+				if ops != nil {
+					ops.Add(1)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// postWithRetry posts to /v1/codeq/tasks (create) or /tasks/claim and
+// rotates nodes on transient "not leader". Returns the response body
+// on the first 2xx. /tasks endpoint is auto-detected by the body
+// shape: bodies starting with `{"commands":` go to /claim.
+func postWithRetry(ctx context.Context, client *http.Client, nodes []*raftTestNode, counter *atomic.Int64, body string) string {
+	path := "/v1/codeq/tasks"
+	if strings.HasPrefix(body, `{"commands":`) {
+		path = "/v1/codeq/tasks/claim"
+	}
+	for attempt := 0; attempt < 10; attempt++ {
+		if ctx.Err() != nil {
+			return ""
+		}
+		node := nodes[int(counter.Add(1))%len(nodes)]
+		if node.closed.Load() {
+			continue
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, node.server.URL+path, strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer dev-token")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusOK {
+			b := make([]byte, 1024)
+			n, _ := resp.Body.Read(b)
+			resp.Body.Close()
+			return string(b[:n])
+		}
+		resp.Body.Close()
+	}
+	return ""
+}
+
+func submitWithRetry(ctx context.Context, client *http.Client, nodes []*raftTestNode, counter *atomic.Int64, taskID string) {
+	body := `{"status":"COMPLETED","result":{"ok":true}}`
+	for attempt := 0; attempt < 10; attempt++ {
+		if ctx.Err() != nil {
+			return
+		}
+		node := nodes[int(counter.Add(1))%len(nodes)]
+		if node.closed.Load() {
+			continue
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, node.server.URL+"/v1/codeq/tasks/"+taskID+"/result", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer dev-token")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return
+		}
+		resp.Body.Close()
+	}
+}
+


### PR DESCRIPTION
## Summary

Milestone 2 of the raft work: lifts the M1 single-shard restriction. Each Pebble shard now gets its own raft group, listening on \`BindAddr + shardIdx\`, with its own LogStore/StableStore/SnapshotStore prefix on the same Pebble. The repository code is unchanged; the application layer loops over shards and opens one raft node per shard.

### What landed

| Task | Title | Tests |
|---|---|---|
| M2.T1 | Multi-shard raft topology (N raft groups, port offset) | 9 helper + 1 integration |
| M2.T2 | Per-shard reaper LeaderGate | reused M1.T8 tests |
| M2.T4 | 1-node × 4-shard integration | 1 (250 ms) |
| M2.T5 | 3-node × 4-shard failover | 1 (2.7 s) |
| M2.T6 | Bench multi-raft vs single-raft + ShardedTask wrapper bug fix | 1 |
| M2.T3 | gRPC multiplexed transport | **deferred** (separable optimization; refactor heavy) |

### Files

- \`pkg/app/raft_addr.go\` — \`bindAddrForShard\` / \`peersForShard\` helpers
- \`pkg/app/application_pebble.go\` — loop over shards when wiring raft + per-shard reaper LeaderGate
- \`internal/repository/pebble/sharded_task_repository.go\` — \`isNotLeader\` helper, fan-out methods skip non-leader shards (bug fix uncovered by the multi-shard bench)
- \`pkg/app/raft_addr_test.go\`, \`raft_multishard_1node_test.go\`, \`raft_multishard_3node_test.go\`, \`raft_multishard_bench_test.go\` — tests

### Behavior

- **3-node × 4-shard cluster** boots cleanly, 12 independent raft groups elect within ~200 ms.
- **Failover**: killing one node leaves 4 shards × 2 survivors each with quorum 2/3. Each shard re-elects independently in ~election timeout, writes continue.
- **Reads**: stay local (followers serve their replicated state).
- **Writes**: \`Replicator.Replicate\` per shard. Non-leader shards return \`pebble.ErrNotLeader\`; the \`ShardedTaskRepository\` fan-out methods now skip these.

### Bench results (3-node loopback, 12-core)

| Topology | Cycles/s |
|---|---|
| 3-node × 1-shard (M1 reference) | ~760 |
| 3-node × 4-shard | ~710 |
| Ratio | 0.93× |

Multi-raft works, but raw HTTP throughput is **the same** as single-shard. The reason: every \"cycle\" is 3 writes (create, claim, submit) and the bench rotates nodes naïvely; with 4 shards on a 3-node cluster, a given node leads ~1.33 shards, so ~3 retries per write are needed before a leader is hit. Per-shard commit parallelism is masked by HTTP-level retry overhead.

The unlock is **server-side leader forwarding** (or streaming session that pins to leader) — that's a follow-up, not M2.

### What's not in this PR

- \`M2.T3\` **gRPC multiplexed transport** — replacing N TCP listeners (one per shard) with 1 gRPC server demuxing by groupID. Refactor-heavy (~500 lines + protobuf); separable from the topology change in this PR. Can land as its own follow-up.
- Server-side leader forwarding — needed to actually realize multi-raft throughput speedups.
- Smart producer/worker SDK leader pinning.

### Test plan

- [x] \`go build ./...\` clean
- [x] All M1 raft tests still pass (no regressions)
- [x] Unit tests for \`bindAddrForShard\` / \`peersForShard\`
- [x] 1-node × 4-shard integration (\`TestRaft_MultiShard_1Node\`)
- [x] 3-node × 4-shard failover (\`TestRaft_MultiShard_3Node\`)
- [x] Multi-shard bench (\`TestRaftBench_MultiShardScale\`) — passes the 0.9× floor, documents the no-speedup observation
- [ ] Manual: \`codeq install --target docker\` with multi-shard raft — Compose templates aren't raft-aware yet (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)