### PR TITLE
docs(raft): document M1+M2 + status endpoint + ops runbook

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -45,12 +45,17 @@ are opt-in for HA and multi-node deployments.
 - **Kafka-scale event streaming.** codeq is a task queue, not a
   partitioned log. If you want millions of messages/s with consumer
   groups, use Kafka.
-- **Distributed consensus by default.** No Raft, no Paxos. Cluster mode
-  uses a static consistent-hash ring; node membership is configured at
-  startup, not gossiped.
+- **Distributed consensus by default.** Single-node and consistent-hash
+  cluster modes ship without consensus — node membership is configured
+  at startup. **Raft replication is opt-in** (see
+  [40-raft-replication.md](./40-raft-replication.md)): when enabled,
+  every Pebble write goes through `raft.Apply` and lands on every
+  replica's local Pebble via the FSM. Mutually exclusive with the
+  static-ring cluster mode.
 - **HA without explicit setup.** A single Pebble process loses
-  availability while it restarts. HA requires either the Redis backend
-  (legacy, multi-node) or running a cluster of Pebble nodes — each is a
+  availability while it restarts. HA requires an opt-in configuration:
+  either raft replication (3+ nodes, automatic failover) or a static
+  consistent-hash cluster (no consensus, no replication). Each is a
   trade-off the operator picks consciously.
 - **Exactly-once delivery.** Delivery is at-least-once. A worker that
   crashes between completion and ACK will see the task re-delivered

--- a/docs/14-configuration.md
+++ b/docs/14-configuration.md
@@ -101,6 +101,57 @@ persistenceProvider: memory
 persistenceConfig: {}
 ````
 
+## Raft replication (opt-in HA)
+
+`cfg.Raft` enables [hashicorp/raft](https://github.com/hashicorp/raft)
+replication on top of the embedded Pebble store. Each Pebble shard
+becomes its own raft group; the leader applies writes locally and
+replicates them via the consensus log to followers' FSMs. Reads stay
+local on every node.
+
+Full architecture, failover, and operational details in
+[`docs/40-raft-replication.md`](40-raft-replication.md).
+
+Config fields under `raft`:
+
+- `enabled` (bool, default false): enable raft.
+- `selfId` (string, required when enabled): stable raft server ID.
+  Must be unique per node and appear in `peers`.
+- `bindAddr` (string, required when enabled): base TCP address for
+  this node's raft transports, e.g. `127.0.0.1:7000`. Multi-shard
+  uses `bindAddr+shardIdx` per group.
+- `bootstrap` (bool): set true on exactly ONE node when forming a new
+  cluster. Ignored on subsequent restarts (raft preserves state).
+- `peers` (map[string]string): peer ID → base bind address for every
+  node including self.
+- `heartbeatMS` / `electionMS` / `leaderLeaseMS` / `commitMS` (int,
+  optional): raft timing knobs; defaults match hashicorp/raft defaults
+  (1000 / 1000 / 500 / 50).
+- `applyTimeoutSeconds` (int, optional, default 10): per-write
+  raft.Apply timeout.
+
+**Mutual exclusion**: raft is rejected at startup if `cluster.enabled`
+or `sharding.enabled` is also set, or if `persistenceProvider != pebble`.
+
+### Example: 3-node raft cluster
+
+````yaml
+persistenceProvider: pebble
+persistenceConfig:
+  path: /var/lib/codeq/pebble
+  numShards: 4
+
+raft:
+  enabled: true
+  selfId: node-1            # different per node
+  bindAddr: 127.0.0.1:7000  # different per node
+  bootstrap: true           # ONLY on node-1 during initial cluster formation
+  peers:
+    node-1: 127.0.0.1:7000
+    node-2: 127.0.0.2:7000
+    node-3: 127.0.0.3:7000
+````
+
 ## Tracing (OpenTelemetry)
 
 Distributed tracing is optional and disabled by default. When enabled, codeQ exports spans via OTLP gRPC (compatible with Jaeger and Grafana Tempo).

--- a/docs/29-operational-runbooks.md
+++ b/docs/29-operational-runbooks.md
@@ -1558,6 +1558,98 @@ Key points:
 
 ---
 
+## 10. Raft Replication Runbook
+
+When `cfg.Raft.Enabled` is true codeq runs every Pebble write through
+a raft consensus log shared by all cluster nodes. Full architecture
+in [40-raft-replication.md](./40-raft-replication.md). This section
+covers the day-2 procedures.
+
+### 10.1 Observing leadership
+
+Each node exposes its local view at `GET /v1/codeq/raft/status`:
+
+```bash
+curl -s http://node-1:8080/v1/codeq/raft/status | jq .
+```
+
+Use this in two ways:
+- **Health checks**: alert when any group reports `hasLeader=false`
+  for more than ~5 seconds. That window means re-election is taking
+  longer than expected — usually because of a network partition or
+  an unhealthy node holding up quorum.
+- **Routing hints**: future client-side smart routing (and current
+  Prometheus dashboards) consume the `leaderId` / `leaderAddr` fields
+  to address writes directly at the shard's leader.
+
+### 10.2 Adding a node to an existing cluster
+
+Joining a new node to a running raft cluster is a two-step process —
+update peer config on the running nodes first, then start the new
+node with `bootstrap: false` and matching peer config.
+
+1. **Edit** `cfg.Raft.Peers` on every running node to include the new
+   node's `id → bindAddr`. Rolling restart picks the new config up.
+2. **Start** the new node with `bootstrap: false` and the full peer
+   map. The current leader will catch it up via raft replication
+   (AppendEntries + snapshot install for shards that have outgrown
+   the log retention window).
+3. **Verify** `/v1/codeq/raft/status` on the new node reports
+   `enabled=true`, `hasLeader=true` for every group within ~5 s.
+
+> **Note**: codeq currently uses a static peer list — there is no
+> live `AddVoter`/`RemoveVoter` admin API. Membership change is a
+> rolling config update + restart.
+
+### 10.3 Removing a failed node
+
+1. **Drain** in-flight work: stop sending new requests to the failed
+   node's HTTP endpoint (load balancer pool removal).
+2. **Update** `cfg.Raft.Peers` on every surviving node to remove the
+   failed node's entry.
+3. **Rolling restart** the survivors. Each restart picks up the new
+   peer set; the cluster continues serving via the remaining quorum.
+4. **Verify**: `/v1/codeq/raft/status` no longer references the
+   removed node ID.
+
+> **Quorum warning**: a 3-node cluster tolerates one node loss
+> (quorum 2/3). Removing a second node before re-adding leaves you
+> at 1/2 — no quorum, no writes. Always re-add before draining the
+> next failure.
+
+### 10.4 Backup with raft
+
+Raft replication is **not a backup**. Three replicas of corrupt data
+is still corrupt data. The Pebble backup procedure in
+[§6.1](#61-backup-and-restore-pebble) applies per-node: take a Pebble
+checkpoint on one healthy node, store it off-cluster. To restore from
+backup after total cluster loss:
+
+1. Stop all nodes.
+2. Restore the Pebble checkpoint to one node's data dir.
+3. Start that node with `bootstrap: true` and an empty `peers` map
+   (single-node bootstrap of the restored data).
+4. Once it has elected, switch its `bootstrap` to false and add
+   peers per §10.2.
+
+The restored cluster has the data from the backup point; any tasks
+created between the backup and the failure are lost.
+
+### 10.5 Reaper behavior under raft
+
+Each shard's reaper consults the shard's raft leadership. Followers
+do not sweep — only the leader requeues expired leases and trims TTL
+indexes. Failover catches up on the next reaper tick after the new
+leader is elected (default 2 s lease interval).
+
+This is invisible day-to-day. The thing to watch: if a leader is
+unhealthy enough to lose leadership but still healthy enough to keep
+crashing-and-recovering, sweeps may stutter. Look for
+`codeq_lease_expired_total` rate dips correlated with raft term
+churn (`raft: entering leader/follower state` log lines).
+
+---
+
 ## See also
 
 - [Cluster architecture](./05-cluster-architecture.md) — design of

--- a/docs/40-raft-replication.md
+++ b/docs/40-raft-replication.md
@@ -1,0 +1,178 @@
+# Raft replication
+
+codeq's opt-in HA path: every Pebble write flows through
+[hashicorp/raft](https://github.com/hashicorp/raft) before landing
+locally. Followers receive the same write through the consensus log
+and apply it via the FSM, so all replicas converge on identical state.
+Leader fails over automatically when a node dies.
+
+Status: M1 (single-shard, single-raft per node) and M2 (multi-shard,
+one raft group per shard) are in main. Server-side leader forwarding
+and a multiplexed gRPC transport are tracked follow-ups.
+
+## When to enable
+
+| Scenario | Use raft? |
+|---|---|
+| Single-node dev / lab | No. Default Pebble path is fine. |
+| One box, durability tolerant of host loss via disk replication | No. Use storage-layer replication beneath Pebble (ZFS / EBS-style). |
+| Multi-node, automatic failover required, dataset fits one box | **Yes**. M1 single-raft. |
+| Multi-node, horizontal scale required | **Yes**. M2 multi-shard raft (one group per Pebble shard). |
+
+Raft is **mutually exclusive** with `cluster.enabled` (the legacy
+static-ring mode) and with `sharding.enabled` (the legacy
+multi-backend `ShardSupplier`). The startup path enforces this at
+config validation.
+
+## Architecture
+
+```mermaid
+graph TB
+  subgraph node1[codeq node-1]
+    H1[HTTP API :8080]
+    R1S0[raft group shard 0 :7000]
+    R1S1[raft group shard 1 :7001]
+    P1S0[Pebble shard 0]
+    P1S1[Pebble shard 1]
+    H1 --> R1S0
+    H1 --> R1S1
+    R1S0 --> P1S0
+    R1S1 --> P1S1
+  end
+  subgraph node2[codeq node-2]
+    R2S0[raft group shard 0 :7000]
+    R2S1[raft group shard 1 :7001]
+    P2S0[Pebble shard 0]
+    P2S1[Pebble shard 1]
+    R2S0 --> P2S0
+    R2S1 --> P2S1
+  end
+  subgraph node3[codeq node-3]
+    R3S0[raft group shard 0 :7000]
+    R3S1[raft group shard 1 :7001]
+    P3S0[Pebble shard 0]
+    P3S1[Pebble shard 1]
+    R3S0 --> P3S0
+    R3S1 --> P3S1
+  end
+  R1S0 -. AppendEntries .- R2S0
+  R1S0 -. AppendEntries .- R3S0
+  R1S1 -. AppendEntries .- R2S1
+  R1S1 -. AppendEntries .- R3S1
+```
+
+In M2 multi-shard mode, each Pebble shard becomes an independent raft
+group spanning all cluster nodes. A given node may lead some shards
+and follow others; leadership is decided per group.
+
+## Configuration
+
+`cfg.Raft` enables and tunes the raft path. Minimal 3-node config:
+
+```yaml
+persistenceProvider: pebble
+persistenceConfig:
+  path: /var/lib/codeq/pebble
+  numShards: 4            # optional — multi-shard raft (M2)
+
+raft:
+  enabled: true
+  selfId: node-1          # must be unique per node
+  bindAddr: 127.0.0.1:7000  # base port; multi-shard uses bindAddr+shardIdx
+  bootstrap: true         # ONLY on the first node during initial cluster formation
+  peers:
+    node-1: 127.0.0.1:7000
+    node-2: 127.0.0.2:7000
+    node-3: 127.0.0.3:7000
+  heartbeatMS: 1000
+  electionMS: 1000
+  leaderLeaseMS: 500
+  commitMS: 50
+  applyTimeoutSeconds: 10
+```
+
+**Multi-shard port convention**: with `numShards: 4`, shard 0 listens
+on `bindAddr`, shard 1 on `bindAddr+1`, etc. The `peers` map contains
+each peer's BASE address; per-shard addresses derive automatically.
+Reserve 4 consecutive ports per node.
+
+**Bootstrap**: `bootstrap: true` on exactly ONE node when forming a
+fresh cluster. After the first successful bootstrap raft writes its
+state to the local Pebble and ignores the flag on subsequent restarts
+— the leader replicates the cluster configuration to the other peers
+automatically. Set `bootstrap: false` on the other nodes.
+
+**Startup ordering**: followers (`bootstrap: false`) must be listening
+before the bootstrapper (`bootstrap: true`) starts — otherwise its
+initial dial attempts hit `connection refused` and election takes
+longer. Production deployments use systemd `After=` or k8s readiness
+gates; tests start followers first explicitly.
+
+## Operational model
+
+### Leadership
+
+- Each shard's raft group has one leader at a time.
+- Leadership migrates on node loss; election completes in
+  `heartbeatTimeout + electionTimeout` (default 2 s, ~100 ms with the
+  tightened test config).
+- Reads are local on every node, with no consensus round; followers
+  may serve stale data. Strong reads must hit the leader.
+- Writes only succeed on the leader. Hitting a follower returns
+  `pebble: not leader`; clients retry against another node (or in
+  M3 follow-up work, the server forwards internally).
+
+### Observing leadership
+
+`GET /v1/codeq/raft/status` returns per-shard state:
+
+```json
+{
+  "enabled": true,
+  "numGroups": 4,
+  "groups": [
+    {"shardIdx": 0, "isLeader": true,  "selfId": "node-1",
+     "selfAddr": "127.0.0.1:7000",
+     "leaderId": "node-1", "leaderAddr": "127.0.0.1:7000", "hasLeader": true},
+    {"shardIdx": 1, "isLeader": false, "selfId": "node-1",
+     "selfAddr": "127.0.0.1:7001",
+     "leaderId": "node-2", "leaderAddr": "127.0.0.2:7001", "hasLeader": true}
+  ]
+}
+```
+
+Use this for ops monitoring (alert when `hasLeader=false` for more
+than a few seconds), Prometheus scraping, or to drive future
+client-side smart routing.
+
+### Reaper coordination
+
+In raft mode only the leader sweeps expired leases and TTL entries.
+Each raft group's reaper checks its own
+`raft.DB.IsLeader()` and skips ticks otherwise. Failover catches up
+on the next tick after election — no manual intervention.
+
+## What's NOT covered yet
+
+- **Server-side leader forwarding**: when a write hits a follower it
+  returns an error and the client retries. The realistic deployment
+  needs either smart-routing clients or server-side forwarding to
+  realize the multi-shard throughput speedup.
+- **gRPC multiplexed transport** (M2.T3): today each shard binds its
+  own TCP port for raft RPCs. With 4 shards × 3 nodes that's 12
+  listeners across the cluster. A multiplexed gRPC transport would
+  reduce that to 3 (one per node) but doesn't change semantics.
+- **Operational tooling**: no `codeq install --target docker` flag for
+  raft clusters yet. Compose templates are single-node.
+
+## See also
+
+- [05-cluster-architecture.md](./05-cluster-architecture.md) — the
+  legacy consistent-hash mode (mutually exclusive with raft)
+- [07b-storage-pebble.md](./07b-storage-pebble.md) — Pebble layout
+- [14-configuration.md](./14-configuration.md) — full config reference
+  including `cfg.Raft`
+- [29-operational-runbooks.md](./29-operational-runbooks.md) — ops
+  procedures including raft failover
+- [hashicorp/raft](https://github.com/hashicorp/raft) — the consensus
+  library codeq builds on

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ layer, lease table, and gRPC + HTTP API all in one process.
 22. `docs/21-developer-guide.md` - Developer guide for contributors
 28. `docs/27-persistence-plugin-system.md` - Persistence plugin interface (Pebble is the supported backend; memory provider for tests)
 34. `docs/34-streaming-api-guide.md` - gRPC streaming API protocol reference, throughput characteristics, and concurrency model
+40. `docs/40-raft-replication.md` - Opt-in HA via hashicorp/raft: single-shard, multi-shard, failover, status endpoint, limitations
 
 ### Integration Guides
 
@@ -70,7 +71,7 @@ layer, lease table, and gRPC + HTTP API all in one process.
 
 ### Explanation (Understanding-Oriented)
 
-- `docs/migration.md` - General migration guide
+- `docs/40-raft-replication.md` - When to enable raft, mutual exclusion with the static-ring cluster mode, current limitations and follow-ups
 
 ### Design Documents (Architecture-Oriented)
 


### PR DESCRIPTION
## Summary

The raft feature shipped across 3 PRs (M1, M2, status endpoint) but \`docs/\` still said codeq had \"no Raft, no Paxos\" and there was no operator-facing content. Fixes the narrative.

## What landed

- **docs/40-raft-replication.md** (new): when to enable raft, architecture diagram (mermaid) for the multi-shard / multi-node topology, configuration walk-through, startup ordering, leadership observation via the status endpoint, reaper coordination, and current limitations (server-side forwarding + gRPC mux transport as tracked follow-ups).
- **docs/14-configuration.md**: new \"Raft replication\" section with the full \`cfg.Raft\` schema and a 3-node YAML example. Cross-links to \`40-raft-replication.md\` for the full picture.
- **docs/29-operational-runbooks.md**: new §10 \"Raft Replication Runbook\" covering observability via \`/v1/codeq/raft/status\`, adding / removing nodes through rolling config + restart, backup semantics (\"raft is not a backup\"), and reaper-on-leader behavior under term churn.
- **docs/01-overview.md**: rewrites the two Non-goals entries that claimed no consensus and no opt-in HA. Raft is now first-class opt-in; mutually exclusive with the static-ring cluster mode.
- **docs/README.md**: adds the new doc to the Technical Reference index and links it from Explanation. Also drops the stale link to \`docs/migration.md\` (deleted in the pebble-only PR).

## Test plan

- [x] All M1+M2 raft tests still pass — \`go test ./pkg/app -run TestRaft -count=1\` clean
- [x] No code changes — pure docs
- [ ] Manual: render the new doc on GitHub and verify the mermaid diagram + cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)