### PR TITLE
feat(raft): leader HTTP URL in /raft/status

### DIFF
--- a/internal/controllers/raft_status_controller.go
+++ b/internal/controllers/raft_status_controller.go
@@ -15,6 +15,7 @@ type RaftGroupStatus interface {
 	SelfID() string
 	BindAddr() string
 	LeaderInfo() (id, addr string)
+	LeaderHTTPAddr() string
 }
 
 // raftStatusController exposes the local node's per-shard raft state.
@@ -31,13 +32,14 @@ func NewRaftStatusController(groups []RaftGroupStatus) *raftStatusController {
 }
 
 type raftGroupView struct {
-	ShardIdx    int    `json:"shardIdx"`
-	IsLeader    bool   `json:"isLeader"`
-	SelfID      string `json:"selfId"`
-	SelfAddr    string `json:"selfAddr"`
-	LeaderID    string `json:"leaderId"`
-	LeaderAddr  string `json:"leaderAddr"`
-	HasLeader   bool   `json:"hasLeader"`
+	ShardIdx       int    `json:"shardIdx"`
+	IsLeader       bool   `json:"isLeader"`
+	SelfID         string `json:"selfId"`
+	SelfAddr       string `json:"selfAddr"`
+	LeaderID       string `json:"leaderId"`
+	LeaderAddr     string `json:"leaderAddr"`
+	LeaderHTTPAddr string `json:"leaderHTTPAddr,omitempty"`
+	HasLeader      bool   `json:"hasLeader"`
 }
 
 type raftStatusResponse struct {
@@ -56,13 +58,14 @@ func (h *raftStatusController) Handle(c *gin.Context) {
 	for i, g := range h.groups {
 		leaderID, leaderAddr := g.LeaderInfo()
 		resp.Groups = append(resp.Groups, raftGroupView{
-			ShardIdx:   i,
-			IsLeader:   g.IsLeader(),
-			SelfID:     g.SelfID(),
-			SelfAddr:   g.BindAddr(),
-			LeaderID:   leaderID,
-			LeaderAddr: leaderAddr,
-			HasLeader:  leaderID != "",
+			ShardIdx:       i,
+			IsLeader:       g.IsLeader(),
+			SelfID:         g.SelfID(),
+			SelfAddr:       g.BindAddr(),
+			LeaderID:       leaderID,
+			LeaderAddr:     leaderAddr,
+			LeaderHTTPAddr: g.LeaderHTTPAddr(),
+			HasLeader:      leaderID != "",
 		})
 	}
 	c.JSON(http.StatusOK, resp)

--- a/internal/raft/db.go
+++ b/internal/raft/db.go
@@ -30,7 +30,12 @@ type Config struct {
 	SelfID          string
 	BindAddr        string
 	Bootstrap       bool
-	PeerAddrs       map[string]string // id → bind addr
+	PeerAddrs       map[string]string // id → raft bind addr
+	// PeerHTTPAddrs maps peer ID → HTTP base URL ("http://host:port").
+	// Optional. When set, LeaderHTTPAddr() returns the leader's HTTP
+	// URL so the status endpoint + smart clients can route writes
+	// directly to the leader.
+	PeerHTTPAddrs   map[string]string
 	HeartbeatMS     int               // raft heartbeat (default 1000)
 	ElectionMS      int               // raft election (default 1000)
 	LeaderLeaseMS   int               // raft leader lease (default 500)
@@ -341,6 +346,18 @@ func (d *DB) LeaderInfo() (id, addr string) {
 	}
 	rawAddr, rawID := d.raft.LeaderWithID()
 	return string(rawID), string(rawAddr)
+}
+
+// LeaderHTTPAddr returns the leader's HTTP base URL when cfg.PeerHTTPAddrs
+// has an entry for the leader, or "" otherwise. Used by the status
+// endpoint and (future) smart clients to route writes directly at the
+// leader's HTTP listener instead of relying on retry-on-not-leader.
+func (d *DB) LeaderHTTPAddr() string {
+	id, _ := d.LeaderInfo()
+	if id == "" || len(d.cfg.PeerHTTPAddrs) == 0 {
+		return ""
+	}
+	return d.cfg.PeerHTTPAddrs[id]
 }
 
 // SelfID returns the configured raft ServerID for this node.

--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -33,6 +33,7 @@ type RaftGroupStatus interface {
 	SelfID() string
 	BindAddr() string
 	LeaderInfo() (id, addr string)
+	LeaderHTTPAddr() string
 }
 
 type Application struct {

--- a/pkg/app/application_pebble.go
+++ b/pkg/app/application_pebble.go
@@ -221,6 +221,7 @@ func newPebbleApplication(
 				BindAddr:      shardBind,
 				Bootstrap:     cfg.Raft.Bootstrap,
 				PeerAddrs:     shardPeers,
+				PeerHTTPAddrs: cfg.Raft.PeerHTTPAddrs,
 				HeartbeatMS:   cfg.Raft.HeartbeatMS,
 				ElectionMS:    cfg.Raft.ElectionMS,
 				LeaderLeaseMS: cfg.Raft.LeaderLeaseMS,

--- a/pkg/app/raft_status_endpoint_test.go
+++ b/pkg/app/raft_status_endpoint_test.go
@@ -18,13 +18,14 @@ type raftStatusResp struct {
 	Enabled   bool `json:"enabled"`
 	NumGroups int  `json:"numGroups"`
 	Groups    []struct {
-		ShardIdx   int    `json:"shardIdx"`
-		IsLeader   bool   `json:"isLeader"`
-		SelfID     string `json:"selfId"`
-		SelfAddr   string `json:"selfAddr"`
-		LeaderID   string `json:"leaderId"`
-		LeaderAddr string `json:"leaderAddr"`
-		HasLeader  bool   `json:"hasLeader"`
+		ShardIdx       int    `json:"shardIdx"`
+		IsLeader       bool   `json:"isLeader"`
+		SelfID         string `json:"selfId"`
+		SelfAddr       string `json:"selfAddr"`
+		LeaderID       string `json:"leaderId"`
+		LeaderAddr     string `json:"leaderAddr"`
+		LeaderHTTPAddr string `json:"leaderHTTPAddr"`
+		HasLeader      bool   `json:"hasLeader"`
 	} `json:"groups"`
 }
 
@@ -116,6 +117,9 @@ func TestRaftStatusEndpoint_SingleShard_Leader(t *testing.T) {
 	if !g.HasLeader || g.LeaderID != "node-1" {
 		t.Errorf("LeaderID: want node-1 + HasLeader=true, got %q + %v", g.LeaderID, g.HasLeader)
 	}
+	if g.LeaderHTTPAddr != "http://127.0.0.1:8080" {
+		t.Errorf("LeaderHTTPAddr: want http://127.0.0.1:8080, got %q", g.LeaderHTTPAddr)
+	}
 }
 
 type singleNodeRaftApp struct {
@@ -160,6 +164,7 @@ func openSingleNodeRaftApp(t *testing.T) singleNodeRaftApp {
 			SelfID:              "node-1",
 			BindAddr:            "127.0.0.1:" + portString(port),
 			Bootstrap:           true,
+			PeerHTTPAddrs:       map[string]string{"node-1": "http://127.0.0.1:8080"},
 			HeartbeatMS:         50,
 			ElectionMS:          50,
 			LeaderLeaseMS:       50,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,6 +131,12 @@ type RaftConfig struct {
 	BindAddr      string            `yaml:"bindAddr"` // e.g. ":7000"
 	Bootstrap     bool              `yaml:"bootstrap"`
 	Peers         map[string]string `yaml:"peers"` // id → bindAddr (including self)
+	// PeerHTTPAddrs maps each raft peer ID to its HTTP base URL (e.g.
+	// "http://node-1:8080"). Surfaced in /v1/codeq/raft/status so ops
+	// tooling and smart clients can route writes directly at the
+	// leader's HTTP listener. Optional; status reports an empty URL
+	// when a peer's HTTP addr isn't configured.
+	PeerHTTPAddrs map[string]string `yaml:"peerHTTPAddrs"`
 	HeartbeatMS   int               `yaml:"heartbeatMS"`
 	ElectionMS    int               `yaml:"electionMS"`
 	LeaderLeaseMS int               `yaml:"leaderLeaseMS"`
@@ -270,6 +276,23 @@ func applyEnvAndDefaults(c *Config) {
 		}
 		if len(peers) > 0 {
 			c.Raft.Peers = peers
+		}
+	}
+	if v := os.Getenv("RAFT_PEER_HTTP_ADDRS"); v != "" {
+		http := make(map[string]string)
+		for _, pair := range strings.Split(v, ",") {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			eq := strings.Index(pair, "=")
+			if eq <= 0 || eq == len(pair)-1 {
+				continue
+			}
+			http[strings.TrimSpace(pair[:eq])] = strings.TrimSpace(pair[eq+1:])
+		}
+		if len(http) > 0 {
+			c.Raft.PeerHTTPAddrs = http
 		}
 	}
 	if v := os.Getenv("RAFT_HEARTBEAT_MS"); v != "" {

--- a/pkg/config/raft_env_test.go
+++ b/pkg/config/raft_env_test.go
@@ -72,6 +72,24 @@ func TestLoadConfigOptional_RaftDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestLoadConfigOptional_RaftPeerHTTPAddrs(t *testing.T) {
+	t.Setenv("RAFT_PEER_HTTP_ADDRS", "node-1=http://host1:8080,node-2=http://host2:8080,node-3=http://host3:8080")
+	cfg, err := LoadConfigOptional("")
+	if err != nil {
+		t.Fatalf("LoadConfigOptional: %v", err)
+	}
+	want := map[string]string{
+		"node-1": "http://host1:8080",
+		"node-2": "http://host2:8080",
+		"node-3": "http://host3:8080",
+	}
+	for id, url := range want {
+		if got := cfg.Raft.PeerHTTPAddrs[id]; got != url {
+			t.Errorf("PeerHTTPAddrs[%s]: want %q, got %q", id, url, got)
+		}
+	}
+}
+
 func TestLoadConfigOptional_RaftPeersIgnoresMalformed(t *testing.T) {
 	t.Setenv("RAFT_PEERS", "node-1=ok:7000,malformed-no-equals,=missing-id,trailing-empty=,node-2=ok:7001,")
 	cfg, err := LoadConfigOptional("")


### PR DESCRIPTION
## Summary

The \`/v1/codeq/raft/status\` endpoint now reports each shard's leader HTTP URL alongside its raft bind address. Foundation for smart routing: clients (or a future server-side 307 forwarder) can poll this and route writes directly at the leader instead of relying on retry-on-not-leader.

## What landed

- \`cfg.Raft.PeerHTTPAddrs map[string]string\` — peer ID → HTTP base URL (\`http://host:port\`). Optional; peers without an entry report empty URL.
- \`RAFT_PEER_HTTP_ADDRS\` env var with the standard \`\"id=url,id=url,...\"\` shape (same parsing as \`RAFT_PEERS\`).
- \`internal/raft.DB.LeaderHTTPAddr()\` resolves the current leader's URL from the configured map; returns \`\"\"\` if leader is unknown or unconfigured.
- \`GET /v1/codeq/raft/status\` response gains \`leaderHTTPAddr\` per group (omitted from JSON when empty).

Example payload:

\`\`\`json
{
  \"enabled\": true,
  \"numGroups\": 4,
  \"groups\": [
    {
      \"shardIdx\": 0,
      \"isLeader\": false,
      \"selfId\": \"node-1\",
      \"selfAddr\": \"127.0.0.1:7000\",
      \"leaderId\": \"node-2\",
      \"leaderAddr\": \"127.0.0.2:7000\",
      \"leaderHTTPAddr\": \"http://node-2:8080\",
      \"hasLeader\": true
    }
  ]
}
\`\`\`

## Test plan

- [x] \`TestRaftStatusEndpoint_SingleShard_Leader\` updated to seed \`PeerHTTPAddrs\` and assert \`leaderHTTPAddr\` lands in the response
- [x] \`TestLoadConfigOptional_RaftPeerHTTPAddrs\` covers the env-var parser
- [x] All existing raft / pebble / app tests still pass

## Why this and not full 307 forwarding

Scope. Server-side 307 redirects on \`ErrNotLeader\` require:
- A typed error that threads the leader URL up from \`raft.DB.Replicate\` through every controller
- ~10 controllers updated to detect and respond with the redirect

Each of those is doable but adds up. This PR is the smallest piece that ships value immediately and unblocks the rest: any future routing logic (server-side forwarding, client-side pinning, Prometheus exporter) can read this endpoint to discover topology + leader URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)