### PR TITLE
feat(raft): MuxAcceptor — single port per node (M2.T3)

### DIFF
--- a/internal/raft/db.go
+++ b/internal/raft/db.go
@@ -42,6 +42,12 @@ type Config struct {
 	CommitMS        int               // raft commit timeout (default 50)
 	SnapshotEntries uint64            // log entries before snapshot (default 8192)
 	ApplyTimeout    time.Duration     // per-write raft.Apply timeout (default 10s)
+	// StreamLayer is an optional override for the underlying transport
+	// layer. When non-nil (mux mode), Open uses
+	// hraft.NewNetworkTransport on top of it instead of opening its own
+	// TCP listener via NewTCPTransport. Used by the per-node
+	// MuxAcceptor so every shard shares one listener.
+	StreamLayer     hraft.StreamLayer
 }
 
 func (c Config) heartbeat() time.Duration {
@@ -189,9 +195,18 @@ func openInternal(ctx context.Context, cfg Config, pdb *pebbledb.DB, ownPebble b
 	}
 	d.fsm = newFSM(pdb)
 
-	trans, err := hraft.NewTCPTransport(cfg.BindAddr, nil, 3, 10*time.Second, os.Stderr)
-	if err != nil {
-		return nil, fmt.Errorf("tcp transport: %w", err)
+	var trans hraft.Transport
+	if cfg.StreamLayer != nil {
+		// Mux mode: the caller pre-built a StreamLayer that demuxes
+		// connections from a shared listener. NewNetworkTransport
+		// drives raft's wire protocol on top.
+		trans = hraft.NewNetworkTransport(cfg.StreamLayer, 3, 10*time.Second, os.Stderr)
+	} else {
+		t, err := hraft.NewTCPTransport(cfg.BindAddr, nil, 3, 10*time.Second, os.Stderr)
+		if err != nil {
+			return nil, fmt.Errorf("tcp transport: %w", err)
+		}
+		trans = t
 	}
 	d.trans = trans
 

--- a/internal/raft/mux_transport.go
+++ b/internal/raft/mux_transport.go
@@ -1,0 +1,230 @@
+package raft
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	hraft "github.com/hashicorp/raft"
+)
+
+// MuxAcceptor owns one TCP listener and demultiplexes incoming raft
+// connections to per-shard StreamLayers by a uint32 group ID written
+// on the connection as the first 4 bytes after dial.
+//
+// This is the M2.T3 foundation: instead of every Pebble shard binding
+// its own TCP port for raft, every shard shares one port. The wire
+// shape is intentionally minimal — a 4-byte BE group ID prefix on
+// every accept, then the raw hraft.NetworkTransport protocol takes
+// over. No new RPCs, no protobuf, no breaking change to hashicorp/raft.
+type MuxAcceptor struct {
+	listener net.Listener
+
+	mu     sync.Mutex
+	groups map[uint32]*muxStreamLayer
+	closed bool
+
+	logger io.Writer
+}
+
+// NewMuxAcceptor opens a TCP listener at bindAddr and starts the
+// accept loop. Each call to RegisterGroup returns a StreamLayer that
+// receives connections whose group-ID prefix matches.
+func NewMuxAcceptor(bindAddr string, logOut io.Writer) (*MuxAcceptor, error) {
+	if logOut == nil {
+		logOut = io.Discard
+	}
+	l, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		return nil, fmt.Errorf("mux listen %s: %w", bindAddr, err)
+	}
+	a := &MuxAcceptor{
+		listener: l,
+		groups:   make(map[uint32]*muxStreamLayer),
+		logger:   logOut,
+	}
+	go a.acceptLoop()
+	return a, nil
+}
+
+// Addr returns the actual bind address of the underlying listener
+// (useful when bindAddr was passed as ":0" for an ephemeral port).
+func (a *MuxAcceptor) Addr() net.Addr { return a.listener.Addr() }
+
+// Close stops the accept loop and closes the underlying listener and
+// every registered StreamLayer. After Close, all registered
+// StreamLayers' Accept() unblock with a "closed" error.
+func (a *MuxAcceptor) Close() error {
+	a.mu.Lock()
+	if a.closed {
+		a.mu.Unlock()
+		return nil
+	}
+	a.closed = true
+	groups := a.groups
+	a.groups = nil
+	a.mu.Unlock()
+
+	_ = a.listener.Close()
+	for _, g := range groups {
+		g.closeQueue()
+	}
+	return nil
+}
+
+// RegisterGroup returns a StreamLayer that owns connections matching
+// the given groupID. Each groupID must be registered exactly once per
+// MuxAcceptor — duplicate registration returns an error.
+//
+// The returned StreamLayer dials peers at `peerAddr` (the peer's
+// MuxAcceptor address) using the same wire shape — emits the groupID
+// prefix on connect, then yields the raw connection.
+func (a *MuxAcceptor) RegisterGroup(groupID uint32) (hraft.StreamLayer, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return nil, errors.New("mux: acceptor closed")
+	}
+	if _, exists := a.groups[groupID]; exists {
+		return nil, fmt.Errorf("mux: groupID %d already registered", groupID)
+	}
+	sl := newMuxStreamLayer(a, groupID)
+	a.groups[groupID] = sl
+	return sl, nil
+}
+
+// acceptLoop drives the underlying listener. For each connection it
+// reads the 4-byte BE group ID, looks up the StreamLayer, and pushes
+// the connection onto that layer's queue. Malformed or unknown
+// connections are closed.
+func (a *MuxAcceptor) acceptLoop() {
+	for {
+		conn, err := a.listener.Accept()
+		if err != nil {
+			a.mu.Lock()
+			closed := a.closed
+			a.mu.Unlock()
+			if closed {
+				return
+			}
+			fmt.Fprintf(a.logger, "mux: accept error: %v\n", err)
+			continue
+		}
+		go a.routeConn(conn)
+	}
+}
+
+func (a *MuxAcceptor) routeConn(conn net.Conn) {
+	// Reading the prefix is a tiny operation — a 1s deadline keeps a
+	// half-open connection from blocking the route goroutine forever.
+	_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	var idBuf [4]byte
+	if _, err := io.ReadFull(conn, idBuf[:]); err != nil {
+		_ = conn.Close()
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{}) // clear deadline; raft uses its own
+	groupID := binary.BigEndian.Uint32(idBuf[:])
+
+	a.mu.Lock()
+	sl, ok := a.groups[groupID]
+	a.mu.Unlock()
+	if !ok {
+		fmt.Fprintf(a.logger, "mux: unknown groupID %d, dropping connection\n", groupID)
+		_ = conn.Close()
+		return
+	}
+	sl.push(conn)
+}
+
+// muxStreamLayer is the per-group StreamLayer surface that hraft's
+// NetworkTransport sees. Accept() pops connections routed to this
+// group's ID; Dial() opens a new TCP connection to the target and
+// writes the group ID prefix before handing off.
+type muxStreamLayer struct {
+	parent  *MuxAcceptor
+	groupID uint32
+
+	queue  chan net.Conn
+	closed chan struct{}
+}
+
+func newMuxStreamLayer(parent *MuxAcceptor, groupID uint32) *muxStreamLayer {
+	return &muxStreamLayer{
+		parent:  parent,
+		groupID: groupID,
+		queue:   make(chan net.Conn, 32),
+		closed:  make(chan struct{}),
+	}
+}
+
+func (l *muxStreamLayer) push(conn net.Conn) {
+	select {
+	case l.queue <- conn:
+	case <-l.closed:
+		_ = conn.Close()
+	}
+}
+
+func (l *muxStreamLayer) closeQueue() {
+	select {
+	case <-l.closed:
+	default:
+		close(l.closed)
+	}
+	// Drain anything queued.
+drain:
+	for {
+		select {
+		case c := <-l.queue:
+			_ = c.Close()
+		default:
+			break drain
+		}
+	}
+}
+
+// --- net.Listener ---
+
+// Accept returns the next routed connection for this group. Blocks
+// until a connection arrives or the layer is closed.
+func (l *muxStreamLayer) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.queue:
+		return c, nil
+	case <-l.closed:
+		return nil, errors.New("mux: stream layer closed")
+	}
+}
+
+func (l *muxStreamLayer) Close() error {
+	l.closeQueue()
+	return nil
+}
+
+func (l *muxStreamLayer) Addr() net.Addr { return l.parent.Addr() }
+
+// --- hraft.StreamLayer ---
+
+// Dial opens a TCP connection to address and prefixes it with this
+// group's ID. The returned conn is the raw connection (the prefix
+// has already been written) — hraft.NetworkTransport then runs its
+// usual handshake + RPC protocol on top.
+func (l *muxStreamLayer) Dial(address hraft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	d := net.Dialer{Timeout: timeout}
+	conn, err := d.Dial("tcp", string(address))
+	if err != nil {
+		return nil, err
+	}
+	var idBuf [4]byte
+	binary.BigEndian.PutUint32(idBuf[:], l.groupID)
+	if _, err := conn.Write(idBuf[:]); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("mux dial %s: write groupID: %w", address, err)
+	}
+	return conn, nil
+}

--- a/internal/raft/mux_transport_test.go
+++ b/internal/raft/mux_transport_test.go
@@ -1,0 +1,231 @@
+package raft
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	hraft "github.com/hashicorp/raft"
+)
+
+// TestMux_TwoGroupsRouteIndependently is the core mux property:
+// two RegisterGroup calls on the same MuxAcceptor receive only the
+// connections destined for THEIR groupID. Cross-group leaks would
+// break raft (a request meant for group 0 applied on group 1 = wrong
+// FSM, wrong log, divergence).
+func TestMux_TwoGroupsRouteIndependently(t *testing.T) {
+	acc, err := NewMuxAcceptor("127.0.0.1:0", nil)
+	if err != nil {
+		t.Fatalf("acceptor: %v", err)
+	}
+	t.Cleanup(func() { _ = acc.Close() })
+
+	g0, err := acc.RegisterGroup(0)
+	if err != nil {
+		t.Fatalf("register 0: %v", err)
+	}
+	g1, err := acc.RegisterGroup(1)
+	if err != nil {
+		t.Fatalf("register 1: %v", err)
+	}
+
+	target := hraft.ServerAddress(acc.Addr().String())
+
+	// Dial each group; on the other side, Accept should yield the
+	// matching connection. Sequence the dials so accept order is
+	// deterministic (per-group queues remain independent regardless).
+	c0Out, err := g0.Dial(target, time.Second)
+	if err != nil {
+		t.Fatalf("dial g0: %v", err)
+	}
+	c0In, err := g0.Accept()
+	if err != nil {
+		t.Fatalf("accept g0: %v", err)
+	}
+
+	c1Out, err := g1.Dial(target, time.Second)
+	if err != nil {
+		t.Fatalf("dial g1: %v", err)
+	}
+	c1In, err := g1.Accept()
+	if err != nil {
+		t.Fatalf("accept g1: %v", err)
+	}
+
+	// Send distinct bytes on each side and verify they land on the
+	// peer-side accept of the same group.
+	if err := writeAndExpect(c0Out, c0In, []byte("group-zero-msg")); err != nil {
+		t.Errorf("g0 round-trip: %v", err)
+	}
+	if err := writeAndExpect(c1Out, c1In, []byte("group-one-msg")); err != nil {
+		t.Errorf("g1 round-trip: %v", err)
+	}
+
+	_ = c0Out.Close()
+	_ = c0In.Close()
+	_ = c1Out.Close()
+	_ = c1In.Close()
+}
+
+func TestMux_DuplicateRegistrationErrors(t *testing.T) {
+	acc, err := NewMuxAcceptor("127.0.0.1:0", nil)
+	if err != nil {
+		t.Fatalf("acceptor: %v", err)
+	}
+	t.Cleanup(func() { _ = acc.Close() })
+
+	if _, err := acc.RegisterGroup(7); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if _, err := acc.RegisterGroup(7); err == nil {
+		t.Error("duplicate register: want error, got nil")
+	}
+}
+
+func TestMux_UnknownGroupClosesConn(t *testing.T) {
+	acc, err := NewMuxAcceptor("127.0.0.1:0", nil)
+	if err != nil {
+		t.Fatalf("acceptor: %v", err)
+	}
+	t.Cleanup(func() { _ = acc.Close() })
+
+	// Register groupID=0 so the acceptor is fully wired; dial with
+	// a different groupID (manually emit the prefix so we can mimic a
+	// malformed peer).
+	if _, err := acc.RegisterGroup(0); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	d := net.Dialer{Timeout: time.Second}
+	conn, err := d.Dial("tcp", acc.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Emit groupID=99 — unknown.
+	if _, err := conn.Write([]byte{0x00, 0x00, 0x00, 0x63}); err != nil {
+		t.Fatalf("write groupID: %v", err)
+	}
+
+	// The server should close the connection. A subsequent Read
+	// should observe EOF (or RST → EOF/Connection reset).
+	_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 4)
+	_, err = conn.Read(buf)
+	if err == nil {
+		t.Error("expected connection close on unknown groupID")
+	}
+}
+
+func TestMux_AcceptUnblocksOnClose(t *testing.T) {
+	acc, err := NewMuxAcceptor("127.0.0.1:0", nil)
+	if err != nil {
+		t.Fatalf("acceptor: %v", err)
+	}
+	g, _ := acc.RegisterGroup(0)
+
+	done := make(chan struct{})
+	go func() {
+		_, err := g.Accept()
+		if err == nil {
+			t.Errorf("Accept after Close: want error, got nil")
+		}
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	_ = acc.Close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Accept did not unblock within 1s of Close")
+	}
+}
+
+// TestMux_ConcurrentTraffic verifies a barrage of concurrent dials on
+// two groups all reach the right side without crossover. Each
+// goroutine sends a tagged bytes; the receiver asserts the tag
+// matches its group.
+func TestMux_ConcurrentTraffic(t *testing.T) {
+	acc, err := NewMuxAcceptor("127.0.0.1:0", nil)
+	if err != nil {
+		t.Fatalf("acceptor: %v", err)
+	}
+	t.Cleanup(func() { _ = acc.Close() })
+
+	g0, _ := acc.RegisterGroup(0)
+	g1, _ := acc.RegisterGroup(1)
+	target := hraft.ServerAddress(acc.Addr().String())
+
+	const perGroup = 10
+	var wg sync.WaitGroup
+
+	// Accept loops: pull `perGroup` connections, read a tag byte, and
+	// fail if it doesn't match the expected group tag.
+	acceptLoop := func(layer hraft.StreamLayer, want byte) {
+		defer wg.Done()
+		for i := 0; i < perGroup; i++ {
+			conn, err := layer.Accept()
+			if err != nil {
+				t.Errorf("accept: %v", err)
+				return
+			}
+			tag := make([]byte, 1)
+			if _, err := io.ReadFull(conn, tag); err != nil {
+				t.Errorf("read tag: %v", err)
+			}
+			if tag[0] != want {
+				t.Errorf("group tag mismatch: want %d, got %d", want, tag[0])
+			}
+			_ = conn.Close()
+		}
+	}
+	wg.Add(2)
+	go acceptLoop(g0, 0)
+	go acceptLoop(g1, 1)
+
+	// Dialers.
+	dialLoop := func(layer hraft.StreamLayer, tag byte) {
+		defer wg.Done()
+		for i := 0; i < perGroup; i++ {
+			conn, err := layer.Dial(target, time.Second)
+			if err != nil {
+				t.Errorf("dial: %v", err)
+				return
+			}
+			if _, err := conn.Write([]byte{tag}); err != nil {
+				t.Errorf("write tag: %v", err)
+			}
+			_ = conn.Close()
+		}
+	}
+	wg.Add(2)
+	go dialLoop(g0, 0)
+	go dialLoop(g1, 1)
+
+	wg.Wait()
+}
+
+// writeAndExpect writes payload to w and verifies r reads it.
+// Returns the first mismatch / IO error.
+func writeAndExpect(w net.Conn, r net.Conn, payload []byte) error {
+	_, err := w.Write(payload)
+	if err != nil {
+		return err
+	}
+	got := make([]byte, len(payload))
+	_ = r.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, err := io.ReadFull(r, got); err != nil {
+		return err
+	}
+	_ = r.SetReadDeadline(time.Time{})
+	if !bytes.Equal(got, payload) {
+		return errors.New("payload mismatch: got " + string(got))
+	}
+	return nil
+}

--- a/pkg/app/application_pebble.go
+++ b/pkg/app/application_pebble.go
@@ -193,24 +193,27 @@ func newPebbleApplication(
 	// lifecycle as the shard's Pebble (raft.Close must run BEFORE
 	// pebble.Close — see TracingShutdown and cleanupStartupFailure).
 	raftNodes := make([]*raftpkg.DB, len(dbs))
+	var muxAcceptor *raftpkg.MuxAcceptor
 	if cfg.Raft.Enabled {
+		// Mux mode: open one TCP listener at BindAddr and demux by
+		// group ID. Every shard's raft group uses the same port.
+		// Non-mux mode keeps the M1/M2 per-shard +offset behavior.
+		if cfg.Raft.MuxEnabled {
+			acc, err := raftpkg.NewMuxAcceptor(cfg.Raft.BindAddr, os.Stderr)
+			if err != nil {
+				bgCancel()
+				for _, d := range dbs {
+					_ = d.Close()
+				}
+				return nil, fmt.Errorf("raft mux acceptor: %w", err)
+			}
+			muxAcceptor = acc
+		}
 		for i, shardDB := range dbs {
-			shardBind, err := bindAddrForShard(cfg.Raft.BindAddr, i)
-			if err != nil {
-				bgCancel()
-				for _, d := range dbs {
-					_ = d.Close()
-				}
-				return nil, fmt.Errorf("raft bind addr shard %d: %w", i, err)
-			}
-			shardPeers, err := peersForShard(cfg.Raft.Peers, i)
-			if err != nil {
-				bgCancel()
-				for _, d := range dbs {
-					_ = d.Close()
-				}
-				return nil, fmt.Errorf("raft peers shard %d: %w", i, err)
-			}
+			var (
+				shardBind  string
+				shardPeers map[string]string
+			)
 			shardPath := pc.Path
 			if numShards > 1 {
 				shardPath = fmt.Sprintf("%s/shard%d", pc.Path, i)
@@ -218,21 +221,59 @@ func newPebbleApplication(
 			raftCfg := raftpkg.Config{
 				Path:          shardPath,
 				SelfID:        cfg.Raft.SelfID,
-				BindAddr:      shardBind,
 				Bootstrap:     cfg.Raft.Bootstrap,
-				PeerAddrs:     shardPeers,
 				PeerHTTPAddrs: cfg.Raft.PeerHTTPAddrs,
 				HeartbeatMS:   cfg.Raft.HeartbeatMS,
 				ElectionMS:    cfg.Raft.ElectionMS,
 				LeaderLeaseMS: cfg.Raft.LeaderLeaseMS,
 				CommitMS:      cfg.Raft.CommitMS,
 			}
+			if muxAcceptor != nil {
+				sl, err := muxAcceptor.RegisterGroup(uint32(i))
+				if err != nil {
+					_ = muxAcceptor.Close()
+					bgCancel()
+					for _, d := range dbs {
+						_ = d.Close()
+					}
+					return nil, fmt.Errorf("raft mux register shard %d: %w", i, err)
+				}
+				// In mux mode every shard binds the SAME port (the
+				// acceptor's). Peers come through unchanged.
+				shardBind = muxAcceptor.Addr().String()
+				shardPeers = cfg.Raft.Peers
+				raftCfg.StreamLayer = sl
+			} else {
+				addr, err := bindAddrForShard(cfg.Raft.BindAddr, i)
+				if err != nil {
+					bgCancel()
+					for _, d := range dbs {
+						_ = d.Close()
+					}
+					return nil, fmt.Errorf("raft bind addr shard %d: %w", i, err)
+				}
+				peers, err := peersForShard(cfg.Raft.Peers, i)
+				if err != nil {
+					bgCancel()
+					for _, d := range dbs {
+						_ = d.Close()
+					}
+					return nil, fmt.Errorf("raft peers shard %d: %w", i, err)
+				}
+				shardBind = addr
+				shardPeers = peers
+			}
+			raftCfg.BindAddr = shardBind
+			raftCfg.PeerAddrs = shardPeers
 			if cfg.Raft.ApplyTimeoutSeconds > 0 {
 				raftCfg.ApplyTimeout = time.Duration(cfg.Raft.ApplyTimeoutSeconds) * time.Second
 			}
 			rdb, err := raftpkg.OpenWithPebble(bgCtx, raftCfg, shardDB.Raw())
 			if err != nil {
 				bgCancel()
+				if muxAcceptor != nil {
+					_ = muxAcceptor.Close()
+				}
 				// Close any raft nodes already opened (lifecycle:
 				// raft.Close before pebble.Close).
 				for _, r := range raftNodes[:i] {
@@ -459,9 +500,15 @@ func newPebbleApplication(
 		// Close raft BEFORE pebble. Raft's apply pipeline holds the
 		// pebble handle (FSM) and panics on closed-DB writes.
 		for _, r := range raftNodes {
+			if r == nil {
+				continue
+			}
 			if cerr := r.Close(); cerr != nil {
 				logger.Warn("raft close after startup failure", "err", cerr)
 			}
+		}
+		if muxAcceptor != nil {
+			_ = muxAcceptor.Close()
 		}
 		for _, d := range dbs {
 			if cerr := d.Close(); cerr != nil {
@@ -527,8 +574,16 @@ func newPebbleApplication(
 			_ = clientPool.Close()
 		}
 		for _, r := range raftNodes {
+			if r == nil {
+				continue
+			}
 			if err := r.Close(); err != nil {
 				logger.Warn("raft close", "err", err)
+			}
+		}
+		if muxAcceptor != nil {
+			if err := muxAcceptor.Close(); err != nil {
+				logger.Warn("mux acceptor close", "err", err)
 			}
 		}
 		for _, d := range dbs {

--- a/pkg/app/raft_mux_3node_test.go
+++ b/pkg/app/raft_mux_3node_test.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/static"
+	"github.com/osvaldoandrade/codeq/pkg/config"
+)
+
+// TestRaft_Mux_3Node_4Shard verifies the M2.T3 end-state: every Pebble
+// shard's raft group shares a single TCP port per node. 3 nodes × 4
+// shards = 12 raft groups across just 3 listeners (one per node).
+// Same correctness checks as TestRaft_MultiShard_3Node — writes
+// replicate, kill node, failover, all 60 tasks consistent on
+// survivors — but with the mux transport.
+func TestRaft_Mux_3Node_4Shard(t *testing.T) {
+	const numShards = 4
+	const numNodes = 3
+
+	// Mux mode needs only one port per node — no contiguous range.
+	// Pre-grab 3 free ports (any free ports, not contiguous).
+	ports := pickThreeFreePorts(t)
+	peers := map[string]string{
+		"node-1": "127.0.0.1:" + ports[0],
+		"node-2": "127.0.0.1:" + ports[1],
+		"node-3": "127.0.0.1:" + ports[2],
+	}
+
+	nodes := make([]*raftTestNode, numNodes)
+	for i, id := range []string{"node-2", "node-3"} {
+		nodes[i+1] = startMuxRaftNode(t, id, peers, numShards, false)
+	}
+	nodes[0] = startMuxRaftNode(t, "node-1", peers, numShards, true)
+	t.Cleanup(func() {
+		for _, n := range nodes {
+			if n != nil && !n.closed.Load() {
+				_ = n.shutdown()
+			}
+		}
+	})
+
+	survivors := func() []*raftTestNode {
+		out := make([]*raftTestNode, 0, len(nodes))
+		for _, n := range nodes {
+			if !n.closed.Load() {
+				out = append(out, n)
+			}
+		}
+		return out
+	}
+
+	ids := submitTasksAcrossNodes(t, survivors(), 40, 5*time.Second)
+	for _, n := range survivors() {
+		for _, id := range ids {
+			body := getTask(t, n, id)
+			if !strings.Contains(body, id) {
+				t.Fatalf("node %s missing task %s after initial writes", n.id, id)
+			}
+		}
+	}
+
+	t.Logf("killing %s", nodes[0].id)
+	if err := nodes[0].shutdown(); err != nil {
+		t.Fatalf("shutdown node-1: %v", err)
+	}
+
+	moreIDs := submitTasksAcrossNodes(t, survivors(), 20, 5*time.Second)
+	ids = append(ids, moreIDs...)
+
+	for _, n := range survivors() {
+		for _, id := range ids {
+			body := getTask(t, n, id)
+			if !strings.Contains(body, id) {
+				t.Errorf("survivor %s missing task %s after failover", n.id, id)
+			}
+		}
+	}
+}
+
+func startMuxRaftNode(t *testing.T, id string, peers map[string]string, numShards int, bootstrap bool) *raftTestNode {
+	t.Helper()
+	pebbleDir := t.TempDir() + "/pebble"
+	pcfg, _ := json.Marshal(map[string]any{
+		"path":      pebbleDir,
+		"numShards": numShards,
+	})
+	cfg := &config.Config{
+		Port:                               0,
+		Timezone:                           "UTC",
+		LogLevel:                           "error",
+		LogFormat:                          "json",
+		Env:                                "dev",
+		DefaultLeaseSeconds:                60,
+		RequeueInspectLimit:                50,
+		LocalArtifactsDir:                  t.TempDir(),
+		MaxAttemptsDefault:                 5,
+		BackoffPolicy:                      "fixed",
+		BackoffBaseSeconds:                 1,
+		BackoffMaxSeconds:                  3,
+		WebhookHmacSecret:                  "secret",
+		WorkerAudience:                     "codeq-worker",
+		SubscriptionMinIntervalSeconds:     5,
+		SubscriptionCleanupIntervalSeconds: 60,
+		ResultWebhookMaxAttempts:           3,
+		ResultWebhookBaseBackoffSeconds:    1,
+		ResultWebhookMaxBackoffSeconds:     2,
+		ProducerAuthProvider:               "static",
+		ProducerAuthConfig:                 json.RawMessage(`{"token":"dev-token","subject":"producer-dev","email":"dev@codeq.local","raw":{"role":"ADMIN","tenantId":"dev-tenant"}}`),
+		WorkerAuthProvider:                 "static",
+		WorkerAuthConfig:                   json.RawMessage(`{"token":"dev-token","subject":"worker-dev","scopes":["codeq:claim","codeq:heartbeat","codeq:abandon","codeq:nack","codeq:result","codeq:subscribe"],"eventTypes":["*"],"raw":{"tenantId":"dev-tenant"}}`),
+		PersistenceProvider:                "pebble",
+		PersistenceConfig:                  pcfg,
+		RedisAddr:                          "127.0.0.1:0",
+		Raft: config.RaftConfig{
+			Enabled:             true,
+			SelfID:              id,
+			BindAddr:            peers[id],
+			Bootstrap:           bootstrap,
+			Peers:               peers,
+			MuxEnabled:          true,
+			HeartbeatMS:         50,
+			ElectionMS:          50,
+			LeaderLeaseMS:       50,
+			CommitMS:            10,
+			ApplyTimeoutSeconds: 3,
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("[%s] validate: %v", id, err)
+	}
+	app, err := NewApplication(cfg)
+	if err != nil {
+		t.Fatalf("[%s] NewApplication: %v", id, err)
+	}
+	SetupMappings(app)
+	server := httptest.NewServer(app.Engine)
+	return &raftTestNode{
+		id:       id,
+		app:      app,
+		server:   server,
+		bindAddr: peers[id],
+	}
+}
+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,6 +131,13 @@ type RaftConfig struct {
 	BindAddr      string            `yaml:"bindAddr"` // e.g. ":7000"
 	Bootstrap     bool              `yaml:"bootstrap"`
 	Peers         map[string]string `yaml:"peers"` // id → bindAddr (including self)
+	// MuxEnabled puts every Pebble shard's raft group on a single TCP
+	// listener at BindAddr, demuxed by a uint32 group ID prefix. With
+	// MuxEnabled=false (default), each shard gets its own TCP port
+	// (BindAddr + shardIdx) — the M1/M2 behavior. Opt-in for new
+	// deployments; cluster topology changes so it's NOT a rolling
+	// upgrade for live clusters.
+	MuxEnabled    bool              `yaml:"muxEnabled"`
 	// PeerHTTPAddrs maps each raft peer ID to its HTTP base URL (e.g.
 	// "http://node-1:8080"). Surfaced in /v1/codeq/raft/status so ops
 	// tooling and smart clients can route writes directly at the
@@ -319,6 +326,9 @@ func applyEnvAndDefaults(c *Config) {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			c.Raft.ApplyTimeoutSeconds = n
 		}
+	}
+	if v := os.Getenv("RAFT_MUX_ENABLED"); v != "" {
+		c.Raft.MuxEnabled = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
 	}
 	if v := os.Getenv("TRACING_ENABLED"); v != "" {
 		c.TracingEnabled = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")


### PR DESCRIPTION
## Summary

Closes M2.T3. Every Pebble shard's raft group can now share one TCP listener per node, opt-in via \`cfg.Raft.MuxEnabled\` (env: \`RAFT_MUX_ENABLED=true\`). 4-shard 3-node deployment goes from 12 listeners to 3.

The non-mux path (M1/M2 per-shard +offset) stays intact so existing deployments don't break — flipping the flag on a live cluster requires re-bootstrap because the wire format gains a 4-byte BE group ID prefix.

## Architecture

\`\`\`
node-1
└── TCP listener :7000 (MuxAcceptor)
    ├── conn[groupID=0] → shard 0 raft group
    ├── conn[groupID=1] → shard 1 raft group
    ├── conn[groupID=2] → shard 2 raft group
    └── conn[groupID=3] → shard 3 raft group
\`\`\`

Wire format on each accept: 4-byte BE \`uint32\` group ID, then raft's existing \`NetworkTransport\` protocol takes over. No new RPCs, no protobuf — the demux is at the bottom of the stack.

## What landed

### Part 1 — \`MuxAcceptor\` foundation (commit 1 in the branch)

- \`internal/raft/mux_transport.go\` — \`MuxAcceptor\` owns one \`net.Listener\` + per-group queues; \`RegisterGroup(groupID)\` returns a \`hraft.StreamLayer\`. \`Accept()\` pops connections routed to its group; \`Dial()\` writes the group prefix then hands off the raw \`net.Conn\` to hashicorp/raft.
- 5 unit tests: two-group routing, duplicate registration error, unknown-group cleanup, accept-unblocks-on-close, concurrent traffic (10 dials per group × 2 groups).

### Part 2 — wireup (commit 2)

- \`internal/raft.Config\` gains \`StreamLayer\` (optional). When set, \`openInternal\` uses \`hraft.NewNetworkTransport\` on top of it; otherwise it falls back to the existing TCP transport.
- \`pkg/config.RaftConfig.MuxEnabled\` + \`RAFT_MUX_ENABLED\` env var.
- \`application_pebble.go\` opens one \`MuxAcceptor\` per node when enabled, registers a group per shard, threads the \`StreamLayer\` through. Peer addresses pass through unchanged (no \`+shardIdx\` offset in mux mode).
- Shutdown order: \`raft.Close → muxAcceptor.Close → pebble.Close\`. Both startup-failure cleanup and \`TracingShutdown\` honor it.

## Test plan

- [x] 5 \`MuxAcceptor\` unit tests pass
- [x] \`TestRaft_Mux_3Node_4Shard\` — 3 nodes × 4 shards = 12 raft groups via 3 listeners. Same failover correctness as M2.T5 (kill node, re-elect, 60 tasks consistent on survivors). ~2.8 s.
- [x] All pre-existing raft + pebble + app tests still pass — non-mux path unchanged
- [ ] Manual: enable \`muxEnabled: true\` on the deploy compose template, verify a 3-node bring-up only opens port 7000 on each container

🤖 Generated with [Claude Code](https://claude.com/claude-code)