### PR TITLE
feat(ratelimit): in-memory token bucket for pure-Pebble path

### DIFF
--- a/docs/14-configuration.md
+++ b/docs/14-configuration.md
@@ -290,10 +290,16 @@ The following fields are deprecated in favor of the new plugin-based authenticat
 
 ## Rate limiting
 
-Rate limiting is optional and disabled by default. The token-bucket
-implementation is currently Redis-backed, so in a pure-Pebble
-deployment the limiter resolves to a no-op (every request is allowed).
-Wiring a Pebble-native limiter is a tracked follow-up.
+Rate limiting is optional and disabled by default. Two implementations:
+
+- **Pure-Pebble path** (default): an in-process token-bucket limiter
+  enforces the configured limits **per-node**. In a cluster of N nodes,
+  the effective ceiling per (scope, subject) is N × `requestsPerMinute`.
+  No external coordinator; state is in-process memory, GC'd after 10
+  minutes of idle per bucket.
+- **Redis-backed path** (legacy): Lua-script token bucket with shared
+  state across all codeq instances connected to the same Redis. Used
+  automatically when `persistenceProvider != pebble`.
 
 Rate limit configuration is per scope (producer, worker, webhook, admin). Each scope has two parameters:
 

--- a/internal/ratelimit/inmemory.go
+++ b/internal/ratelimit/inmemory.go
@@ -1,0 +1,190 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"time"
+)
+
+// InMemoryLimiter is a process-local token-bucket rate limiter. Each
+// (scope, subject) pair gets its own bucket. There is no
+// cross-process coordination: in a cluster of N codeq nodes the
+// effective per-tenant ceiling is N × bucket.RequestsPerMinute. That
+// is acceptable for typical codeq deployments (legitimate clients
+// don't get rebalanced across nodes mid-burst), and avoids dragging a
+// Redis dependency into the pure-Pebble path.
+//
+// Without this, the pebble code path used a noopLimiter that allowed
+// everything — silent foot-gun if operators configured rate limits
+// expecting them to work. This limiter ENFORCES the configured limits
+// per-node so the configuration takes effect.
+//
+// Concurrency model: a top-level mutex protects buckets map; each
+// bucket carries its own mutex for the refill+decrement critical
+// section. For typical workloads with one bucket per JWT subject the
+// per-bucket mutex never contends.
+//
+// Bucket GC: a background loop reaps buckets idle longer than 2×
+// refill-to-full window so the map stays bounded under churn (many
+// short-lived tokens).
+type InMemoryLimiter struct {
+	mu      sync.RWMutex
+	buckets map[string]*memBucketState
+	now     func() time.Time
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+}
+
+type memBucketState struct {
+	mu       sync.Mutex
+	tokens   float64
+	capacity float64
+	lastTS   time.Time
+}
+
+// NewInMemoryLimiter constructs an in-memory limiter and starts a
+// janitor goroutine that reaps idle buckets. Call Close on shutdown
+// to stop the janitor.
+func NewInMemoryLimiter() *InMemoryLimiter {
+	l := &InMemoryLimiter{
+		buckets: make(map[string]*memBucketState),
+		now:     time.Now,
+		stopCh:  make(chan struct{}),
+	}
+	go l.janitor()
+	return l
+}
+
+// Close stops the janitor goroutine. Idempotent.
+func (l *InMemoryLimiter) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.stopOnce.Do(func() { close(l.stopCh) })
+	return nil
+}
+
+// Allow consumes one token from the bucket identified by (scope,
+// subject). Returns Decision{Allowed: true} when a token was
+// available; otherwise Decision{Allowed: false, RetryAfter: d} where
+// d is the minimum wait until a token would be available.
+func (l *InMemoryLimiter) Allow(ctx context.Context, scope string, subject string, bucket Bucket) (Decision, error) {
+	if l == nil || !bucket.Enabled() {
+		return Decision{Allowed: true}, nil
+	}
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = "default"
+	}
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		subject = "unknown"
+	}
+	key := fmt.Sprintf("%s:%s", scope, sha256Hex(subject))
+
+	ratePerSec := float64(bucket.RequestsPerMinute) / 60.0
+	capacity := float64(bucket.BurstSize)
+
+	state := l.bucketFor(key, capacity)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	// Capacity can change on the fly (operator reconfig). Clamp tokens
+	// to the new ceiling on every Allow so a downward change takes
+	// effect without restart.
+	if state.capacity != capacity {
+		state.capacity = capacity
+		if state.tokens > capacity {
+			state.tokens = capacity
+		}
+	}
+
+	now := l.now()
+	elapsed := now.Sub(state.lastTS).Seconds()
+	if elapsed > 0 {
+		state.tokens = math.Min(capacity, state.tokens+elapsed*ratePerSec)
+	}
+	state.lastTS = now
+
+	if state.tokens >= 1.0 {
+		state.tokens -= 1.0
+		_ = ctx
+		return Decision{Allowed: true}, nil
+	}
+	// Not enough tokens. Compute the wait until the bucket refills
+	// enough for one token; round up to the next second so clients
+	// don't poll busy.
+	var retryAfter time.Duration
+	if ratePerSec > 0 {
+		needed := 1.0 - state.tokens
+		secs := math.Ceil(needed / ratePerSec)
+		if secs < 1 {
+			secs = 1
+		}
+		retryAfter = time.Duration(secs) * time.Second
+	} else {
+		retryAfter = 60 * time.Second
+	}
+	return Decision{Allowed: false, RetryAfter: retryAfter}, nil
+}
+
+func (l *InMemoryLimiter) bucketFor(key string, capacity float64) *memBucketState {
+	l.mu.RLock()
+	state, ok := l.buckets[key]
+	l.mu.RUnlock()
+	if ok {
+		return state
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if state, ok = l.buckets[key]; ok {
+		return state
+	}
+	state = &memBucketState{
+		tokens:   capacity,
+		capacity: capacity,
+		lastTS:   l.now(),
+	}
+	l.buckets[key] = state
+	return state
+}
+
+// janitor reaps buckets that haven't been touched in idleThreshold.
+// Keeps the map bounded under per-token (per-subject) churn.
+func (l *InMemoryLimiter) janitor() {
+	const (
+		tick          = 5 * time.Minute
+		idleThreshold = 10 * time.Minute
+	)
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-l.stopCh:
+			return
+		case <-t.C:
+			l.gcOnce(idleThreshold)
+		}
+	}
+}
+
+func (l *InMemoryLimiter) gcOnce(idleThreshold time.Duration) {
+	cutoff := l.now().Add(-idleThreshold)
+	l.mu.Lock()
+	for key, state := range l.buckets {
+		state.mu.Lock()
+		idle := state.lastTS.Before(cutoff)
+		state.mu.Unlock()
+		if idle {
+			delete(l.buckets, key)
+		}
+	}
+	l.mu.Unlock()
+}
+
+// Compile-time check.
+var _ Limiter = (*InMemoryLimiter)(nil)

--- a/internal/ratelimit/inmemory_test.go
+++ b/internal/ratelimit/inmemory_test.go
@@ -1,0 +1,191 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestInMemoryLimiter_Disabled(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+	dec, err := l.Allow(context.Background(), "producer", "subj", Bucket{})
+	if err != nil {
+		t.Fatalf("Allow: %v", err)
+	}
+	if !dec.Allowed {
+		t.Errorf("disabled bucket should always allow")
+	}
+}
+
+func TestInMemoryLimiter_BlocksAfterBurst(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+	frozen := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l.now = func() time.Time { return frozen }
+
+	b := Bucket{RequestsPerMinute: 60, BurstSize: 3} // 1 token/sec, capacity 3
+	// Consume the burst.
+	for i := 0; i < 3; i++ {
+		dec, _ := l.Allow(context.Background(), "producer", "subj", b)
+		if !dec.Allowed {
+			t.Errorf("burst %d: want allowed, got blocked", i)
+		}
+	}
+	// Next one should block.
+	dec, _ := l.Allow(context.Background(), "producer", "subj", b)
+	if dec.Allowed {
+		t.Errorf("post-burst: want blocked, got allowed")
+	}
+	if dec.RetryAfter < time.Second {
+		t.Errorf("RetryAfter %v < 1s", dec.RetryAfter)
+	}
+}
+
+func TestInMemoryLimiter_RefillsAfterWindow(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l.now = func() time.Time { return now }
+
+	b := Bucket{RequestsPerMinute: 60, BurstSize: 2} // 1/sec, capacity 2
+	// Drain.
+	_, _ = l.Allow(context.Background(), "producer", "subj", b)
+	_, _ = l.Allow(context.Background(), "producer", "subj", b)
+	dec, _ := l.Allow(context.Background(), "producer", "subj", b)
+	if dec.Allowed {
+		t.Fatal("expected blocked after drain")
+	}
+	// Advance 2 seconds → refill 2 tokens → allow 2 more.
+	now = now.Add(2 * time.Second)
+	for i := 0; i < 2; i++ {
+		dec, _ := l.Allow(context.Background(), "producer", "subj", b)
+		if !dec.Allowed {
+			t.Errorf("refill %d: want allowed, got blocked (RetryAfter=%v)", i, dec.RetryAfter)
+		}
+	}
+}
+
+func TestInMemoryLimiter_IsolatesPerSubject(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l.now = func() time.Time { return now }
+
+	b := Bucket{RequestsPerMinute: 60, BurstSize: 1}
+
+	// Subject A consumes its single token.
+	if dec, _ := l.Allow(context.Background(), "producer", "subj-A", b); !dec.Allowed {
+		t.Fatal("subj-A first call should be allowed")
+	}
+	if dec, _ := l.Allow(context.Background(), "producer", "subj-A", b); dec.Allowed {
+		t.Error("subj-A second call should be blocked")
+	}
+	// Subject B has its own token.
+	if dec, _ := l.Allow(context.Background(), "producer", "subj-B", b); !dec.Allowed {
+		t.Error("subj-B should be unaffected by subj-A's drain")
+	}
+}
+
+func TestInMemoryLimiter_IsolatesPerScope(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l.now = func() time.Time { return now }
+
+	b := Bucket{RequestsPerMinute: 60, BurstSize: 1}
+
+	// Same subject, different scopes → independent buckets.
+	if dec, _ := l.Allow(context.Background(), "producer", "x", b); !dec.Allowed {
+		t.Fatal("producer scope first call")
+	}
+	if dec, _ := l.Allow(context.Background(), "producer", "x", b); dec.Allowed {
+		t.Error("producer scope second call should block")
+	}
+	if dec, _ := l.Allow(context.Background(), "worker", "x", b); !dec.Allowed {
+		t.Error("worker scope should be independent")
+	}
+}
+
+func TestInMemoryLimiter_CapacityChangeClamps(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l.now = func() time.Time { return now }
+
+	big := Bucket{RequestsPerMinute: 60, BurstSize: 100}
+	small := Bucket{RequestsPerMinute: 60, BurstSize: 2}
+
+	// Initialize bucket at capacity=100 (use 1 token to register state).
+	_, _ = l.Allow(context.Background(), "producer", "subj", big)
+	// Reconfigure to capacity=2 — token count should clamp.
+	for i := 0; i < 2; i++ {
+		dec, _ := l.Allow(context.Background(), "producer", "subj", small)
+		if !dec.Allowed {
+			t.Errorf("after clamp, call %d should still allow", i)
+		}
+	}
+	dec, _ := l.Allow(context.Background(), "producer", "subj", small)
+	if dec.Allowed {
+		t.Error("after clamp + drain, should block")
+	}
+}
+
+func TestInMemoryLimiter_ConcurrentSameSubject(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+
+	b := Bucket{RequestsPerMinute: 60_000, BurstSize: 1000}
+
+	var allowed, blocked int64
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	const concurrency = 32
+	const perGoroutine = 100
+	for g := 0; g < concurrency; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				dec, _ := l.Allow(context.Background(), "producer", "shared-subj", b)
+				mu.Lock()
+				if dec.Allowed {
+					allowed++
+				} else {
+					blocked++
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	total := allowed + blocked
+	if total != int64(concurrency*perGoroutine) {
+		t.Fatalf("total calls: got %d, want %d", total, concurrency*perGoroutine)
+	}
+	if allowed > int64(b.BurstSize)+50 { // small slop for refill during the test
+		t.Errorf("allowed=%d exceeds burst capacity %d by more than slop", allowed, b.BurstSize)
+	}
+}
+
+func TestInMemoryLimiter_JanitorReapsIdle(t *testing.T) {
+	l := NewInMemoryLimiter()
+	defer l.Close()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l.now = func() time.Time { return now }
+
+	b := Bucket{RequestsPerMinute: 60, BurstSize: 1}
+	_, _ = l.Allow(context.Background(), "producer", "subj", b)
+
+	if len(l.buckets) != 1 {
+		t.Fatalf("seed: want 1 bucket, got %d", len(l.buckets))
+	}
+
+	// Idle threshold inside gcOnce is 10 minutes; advance 15.
+	now = now.Add(15 * time.Minute)
+	l.gcOnce(10 * time.Minute)
+	if len(l.buckets) != 0 {
+		t.Errorf("post-GC: want 0 buckets, got %d", len(l.buckets))
+	}
+}

--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -89,10 +89,11 @@ func newShardClient(addr, password string, db, poolSize int) (*redis.Client, err
 func NewApplication(cfg *config.Config, opts ...ApplicationOption) (*Application, error) {
 	// Persistence dispatch happens *before* any Redis-specific setup so a
 	// Pebble deployment doesn't need a reachable Redis at all. The Pebble
-	// path owns its own ratelimiter (no-op) since there's no shared bucket
-	// to enforce across processes.
+	// path uses an in-process token-bucket limiter — per-node enforcement
+	// (cluster total = N × bucket.RequestsPerMinute), which is the right
+	// trade for a deployment without an external coordinator.
 	if cfg.PersistenceProvider == "pebble" {
-		return newPebbleApplication(cfg, nil, noopLimiter{}, nil, nil, nil, nil, nil, opts...)
+		return newPebbleApplication(cfg, nil, ratelimit.NewInMemoryLimiter(), nil, nil, nil, nil, nil, opts...)
 	}
 
 	redisClient := providers.NewRedisProvider(cfg.RedisAddr, cfg.RedisPassword)


### PR DESCRIPTION
## Summary

The pure-Pebble path used a \`noopLimiter\` that allowed every request even when rate limits were configured. Silent foot-gun: operators saw the YAML knobs (\`producer.requestsPerMinute\`, \`burstSize\`, …) and trusted them; runtime ignored them.

This PR ships an in-process token-bucket limiter for the pure-Pebble path. Configuration now actually takes effect.

## Design

- **Per-node enforcement**: in a cluster of N codeq nodes, the effective per-(scope, subject) ceiling is N × \`requestsPerMinute\`. No external coordinator; state is in-process memory.
- **Trade-off**: dragging a Redis dep into the embedded path would defeat the purpose of \"100% Pebble\". Per-node enforcement is the right knob — legitimate clients don't get rebalanced across nodes mid-burst, and the alternative (cluster-wide via raft) would add a write per Allow which is much worse than the limit it's protecting.
- **Concurrency**: top-level RWMutex protects the buckets map; each bucket has its own \`sync.Mutex\` for refill + decrement. Typical workloads with one bucket per JWT subject never contend.
- **GC**: janitor reaps buckets idle > 10 min so the map stays bounded under per-token churn.

## What landed

- \`internal/ratelimit/inmemory.go\`: \`InMemoryLimiter\` with the standard \`Limiter\` interface.
- \`pkg/app/application.go\`: when \`cfg.PersistenceProvider==\"pebble\"\` wire \`NewInMemoryLimiter()\` instead of the noop.
- \`docs/14-configuration.md\` \"Rate limiting\" section corrected — the \"no-op in pure-Pebble\" claim was wrong post-merge.

## Test plan

- [x] 8 unit tests for InMemoryLimiter (disabled bucket, burst → block → refill, isolation per subject + per scope, capacity reconfig, concurrent stress, janitor)
- [x] \`go test ./pkg/app\` passes — no regressions wiring the new limiter into the Application
- [ ] Manual: set \`rateLimit.producer.requestsPerMinute: 6\` + \`burstSize: 3\` on a single-node pebble deploy; verify the 4th request in a burst returns 429 with \`Retry-After\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)