### PR TITLE
chore(deploy): compose template defaults to mux + 307 smart routing

### DIFF
--- a/deploy/docker-compose/raft-cluster/README.md
+++ b/deploy/docker-compose/raft-cluster/README.md
@@ -4,6 +4,16 @@ Spins up three codeq processes joined into a raft cluster. Every Pebble
 write is consensus-replicated across the three replicas; the leader
 fails over automatically when a node dies.
 
+The template uses the **mux transport** (`RAFT_MUX_ENABLED=true`) so
+every shard's raft group shares one TCP port per node — only port
+8080 (HTTP) and 7000 (raft) are exposed on each container, regardless
+of how many shards are configured.
+
+It also wires `RAFT_PEER_HTTP_ADDRS` so server-side 307 redirects work
+out of the box: a write that lands on a follower comes back as
+`307 Temporary Redirect` with `Location: <leader URL>`. Standard HTTP
+clients follow automatically.
+
 See [`docs/40-raft-replication.md`](../../../docs/40-raft-replication.md)
 for the architecture, configuration knobs, status endpoint, and current
 limitations.
@@ -68,9 +78,11 @@ curl -s http://localhost:8081/v1/codeq/raft/status | jq .
 ## Going multi-shard (M2)
 
 For per-shard raft groups (one group per Pebble shard), add
-`"numShards": 4` to `PERSISTENCE_CONFIG` and reserve N consecutive
-ports per node. The compose template uses container-local port 7000 as
-the base; each shard binds 7000 + shardIdx. Adjust as needed.
+`"numShards": 4` to `PERSISTENCE_CONFIG`. With the mux transport
+already enabled (`RAFT_MUX_ENABLED=true`), no port-range changes are
+needed — every shard's raft group shares port 7000, demuxed by group
+ID prefix. The 12 raft groups (3 nodes × 4 shards) come up on just
+3 listeners total.
 
 ## Mutual exclusion
 

--- a/deploy/docker-compose/raft-cluster/compose.yaml
+++ b/deploy/docker-compose/raft-cluster/compose.yaml
@@ -48,9 +48,21 @@ services:
       PERSISTENCE_PROVIDER: pebble
       PERSISTENCE_CONFIG: '{"path":"/var/lib/codeq/pebble"}'
       RAFT_ENABLED: "true"
+      # RAFT_MUX_ENABLED=true makes every Pebble shard's raft group
+      # share a single TCP listener per node (port 7000 inside the
+      # container, demuxed by group ID prefix). Without this, each
+      # shard binds its own port at bindAddr+shardIdx. Mux is the
+      # recommended deployment topology for new clusters; switching
+      # an existing cluster requires re-bootstrap because the wire
+      # shape changes.
+      RAFT_MUX_ENABLED: "true"
       # RAFT_PEERS is "id=host:port,..." resolved via docker DNS.
       # All three peers run raft on container-local port 7000.
       RAFT_PEERS: "node-a=node-a:7000,node-b=node-b:7000,node-c=node-c:7000"
+      # RAFT_PEER_HTTP_ADDRS surfaces leader HTTP URLs in
+      # /v1/codeq/raft/status and powers the server-side 307
+      # redirect when a follower receives a write.
+      RAFT_PEER_HTTP_ADDRS: "node-a=http://node-a:8080,node-b=http://node-b:8080,node-c=http://node-c:8080"
       PRODUCER_AUTH_PROVIDER: static
       PRODUCER_AUTH_CONFIG: |-
         {"token":"dev-token","subject":"producer-dev","email":"dev@codeq.local","raw":{"role":"ADMIN","tenantId":"dev-tenant"}}

--- a/docs/40-raft-replication.md
+++ b/docs/40-raft-replication.md
@@ -96,6 +96,16 @@ on `bindAddr`, shard 1 on `bindAddr+1`, etc. The `peers` map contains
 each peer's BASE address; per-shard addresses derive automatically.
 Reserve 4 consecutive ports per node.
 
+**Mux transport (recommended for new clusters)**: set
+`raft.muxEnabled: true` (or `RAFT_MUX_ENABLED=true`) to share one TCP
+listener across every shard's raft group on a node. The wire shape
+gains a 4-byte BE group ID prefix on every connection; rest of the
+protocol is unchanged. With mux on, you DON'T reserve consecutive
+ports — every shard listens on `bindAddr` itself, demuxed by group
+ID. The `deploy/docker-compose/raft-cluster/` template defaults to
+mux. Flipping mux on a live cluster requires re-bootstrap (the wire
+format is not compatible with stock hashicorp/raft TCP transport).
+
 **Bootstrap**: `bootstrap: true` on exactly ONE node when forming a
 fresh cluster. After the first successful bootstrap raft writes its
 state to the local Pebble and ignores the flag on subsequent restarts
@@ -158,10 +168,13 @@ on the next tick after election — no manual intervention.
   returns an error and the client retries. The realistic deployment
   needs either smart-routing clients or server-side forwarding to
   realize the multi-shard throughput speedup.
-- **gRPC multiplexed transport** (M2.T3): today each shard binds its
-  own TCP port for raft RPCs. With 4 shards × 3 nodes that's 12
-  listeners across the cluster. A multiplexed gRPC transport would
-  reduce that to 3 (one per node) but doesn't change semantics.
+- **gRPC multiplexed transport** (M2.T3 — shipped): set
+  `raft.muxEnabled: true` to share a single TCP listener per node
+  across every shard's raft group. The deploy/docker-compose/raft-
+  cluster template defaults to mux. **Status**: in main. A future
+  follow-up could swap the underlying TCP transport for gRPC streams
+  to share more infrastructure with the codeq HTTP server; the
+  current implementation uses raw TCP with a 4-byte group ID prefix.
 - **Operational tooling**: no `codeq install --target docker` flag for
   raft clusters yet. Compose templates are single-node.
 


### PR DESCRIPTION
## Summary

Updates the 3-node raft compose template to ship best-practice defaults out of the box, exercising every feature we've added in the recent raft PRs (mux transport, leader HTTP URL, 307 redirect).

## Changes

\`compose.yaml\`:
- \`RAFT_MUX_ENABLED=true\` — all shards' raft groups share container port 7000. Bumping \`numShards\` no longer needs port plumbing changes.
- \`RAFT_PEER_HTTP_ADDRS\` wired to each peer's HTTP base → server-side 307 redirects work transparently. Standard \`http.Client\` follows \`Location: <leader URL>\` automatically.

\`README.md\`:
- Quick-start mentions the mux + 307 defaults
- \"Going multi-shard\" section drops the port-range reservation step (mux handles it)

\`docs/40-raft-replication.md\`:
- Mux noted as the recommended deployment (with re-bootstrap caveat for live clusters)
- \"What's NOT covered\" entry for M2.T3 updated: shipped + reference to the mux feature

## Test plan

- [x] All pre-existing raft tests still pass — no code change, just config
- [ ] Manual: \`docker compose -f deploy/docker-compose/raft-cluster/compose.yaml up -d\` and verify the 3 containers come up healthy on ports 8080/8081/8082, only one raft port (7000) per container

🤖 Generated with [Claude Code](https://claude.com/claude-code)