### PR TITLE
docs(overview): rewrite 01-overview for Pebble-only, RAFT HA, port labels

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -6,65 +6,144 @@
 
 ## What is codeq
 
-codeq is a task queue written in Go that runs as a single process and
-stores everything in an embedded LSM (Pebble, the RocksDB-style engine
+codeq is a task queue written in Go. The server is a single process; the
+state lives in an embedded LSM tree (Pebble, the RocksDB-style engine
 from CockroachDB). The hot path is bidirectional gRPC streams from
 producers and workers; under the streams sits an intra-process shard
 table (up to N independent Pebble instances) and an in-memory lease
-table. On a 12-core Linux box the single binary sustains
-**83,420 tasks/s** for the full create → claim → complete cycle and
-**136,392 creates/s** for producer-only workloads.
+table.
 
-No Redis, no broker, no coordinator required in the default mode.
-Cluster (consistent-hash ring + gRPC routing) and a legacy Redis backend
-are opt-in for HA and multi-node deployments.
+Three modes share that core:
+
+1. **Single-node** — one Pebble LSM, one process, one disk directory.
+2. **Multi-shard single-node** — N independent Pebble LSMs in the same
+   process, keyed by `FNV-1a(taskID) mod N`
+   ([`internal/repository/pebble/sharded_task_repository.go:61`](../internal/repository/pebble/sharded_task_repository.go)).
+3. **RAFT replication** — every write is wrapped as a `raft.Apply` log
+   entry, replicated to a majority quorum, and applied by an FSM that
+   commits to each replica's local Pebble
+   ([`internal/raft/fsm.go:43`](../internal/raft/fsm.go)).
+
+The Pebble (1) and RAFT (3) modes are mutually exclusive with the
+historical consistent-hash cluster mode; the check lives in
+[`pkg/config/config.go:662`](../pkg/config/config.go). Multi-shard (2)
+can be combined with RAFT (3) for one raft group per shard.
+
+## Deployment scenarios
+
+| Mode | Storage | Replication | Parallelism | Measured throughput |
+|---|---|---|---|---:|
+| Single-node | Pebble (1 LSM) | none | 1 shard | 76,639 tasks/s |
+| Multi-shard single-node | Pebble (N LSMs) | none | N shards in parallel | scales with N |
+| RAFT (HA) | Pebble + raft log | majority quorum | 1 raft group | ~3.9k cycles/s (HTTP) |
+| RAFT + multi-shard | Pebble × N + N raft groups | per-shard quorum | N groups in parallel | ~10k cycles/s |
+
+Citations:
+
+- Single-node 76,639 tasks/s for the full create → claim → complete
+  cycle: [`internal/bench/profile_full_cycle_test.go`](../internal/bench/profile_full_cycle_test.go).
+- RAFT 3-node, HTTP front-end, smart routing benchmark:
+  [`pkg/app/raft_smart_routing_bench_test.go`](../pkg/app/raft_smart_routing_bench_test.go)
+  (logs `cycles/s` for 1-shard and 4-shard runs).
+
+The full decision guide — fault model, failover budget, fsync
+trade-off, hardware sizing — lives in
+[41-deployment-modes.md](./41-deployment-modes.md). This page does not
+duplicate it. Picking the right mode: single-node when one machine has
+enough disk and CPU headroom and short unavailability during restarts
+is acceptable; multi-shard single-node when one Pebble LSM is the
+bottleneck (CPU idle but `commitPipeline` hot, or compaction loops
+serialized behind a single store); RAFT when an SLO requires automatic
+failover with f=1 fault tolerance and you accept the per-write cost of
+majority quorum replication.
+
+## Why it goes fast (the CS, not the marketing)
+
+Throughput claims have to point at a primitive. Three primitives carry
+most of the budget:
+
+1. **Group commit coalescer on the Pebble write path.** Phase 0
+   profiling pinned Pebble's internal `commitPipeline` mutex at 96% of
+   the mutex profile and 44% of the block profile around 26k req/s.
+   `CommitBatch` now submits to a single coalescer goroutine that
+   merges up to `maxMergeBatch = 64` concurrently-arriving batches into
+   one Pebble `Commit` before unblocking submitters
+   ([`internal/repository/pebble/db.go:71`](../internal/repository/pebble/db.go),
+   [`internal/repository/pebble/db.go:341`](../internal/repository/pebble/db.go)).
+   N batches → one lock acquisition → one fsync (when fsync is on).
+   Tail latency cost is one merge cycle for a late joiner; the design
+   trades latency for throughput on purpose.
+2. **gRPC bidirectional streams.** Producers and workers open one
+   long-lived stream and exchange many messages on it. JWT validation,
+   tenant extraction, rate limiting, and TLS handshakes amortize across
+   the stream lifetime instead of recurring per request. Multiple
+   requests can be in flight before responses arrive (HTTP/2 pipelining
+   in practice).
+3. **Intra-process Pebble sharding.** `numShards` opens N independent
+   Pebble instances under one process. Writes for different task IDs
+   hit different `commitPipeline` mutexes; compaction loops run in
+   parallel. The shard count is a tunable, not a topological change
+   — same binary, same config file.
+
+RAFT changes the math: when replication is attached, the Pebble
+coalescer is bypassed and writes flow through `raft.Apply` instead
+([`internal/repository/pebble/db.go:79`](../internal/repository/pebble/db.go)).
+The raft library does its own log-entry batching, so layering another
+coalescer on top would just add latency. Replication uses a 4-byte
+big-endian group ID prefix per connection so every shard's raft group
+multiplexes onto a single listener
+([`internal/raft/mux_transport.go:15`](../internal/raft/mux_transport.go)).
 
 ## Goals
 
 - **Single binary.** Server, persistence, lease table, HTTP + gRPC API
-  all in one process. One disk directory. One systemd unit. No external
-  database required.
-- **80k+ tasks/s on one machine.** Full create → claim → complete cycle
-  measured by `internal/bench/profile_full_cycle_test.go` with 4 Pebble
-  shards, batched producer + worker streams.
+  all in one process. One disk directory. One systemd unit. No
+  external database required for the single-node and multi-shard
+  modes; RAFT mode adds peer connectivity but no extra process types.
+- **Throughput on commodity hardware.** Full create → claim → complete
+  cycle measured at 76,639 tasks/s on a 12-core Linux box, loopback
+  gRPC, `fsyncOnCommit=false`, 4 Pebble shards, batched producer +
+  worker streams
+  ([`internal/bench/profile_full_cycle_test.go`](../internal/bench/profile_full_cycle_test.go)).
 - **gRPC streaming as a first-class API.** Long-lived bidirectional
-  streams amortize auth and middleware; multiple requests can be in
-  flight before responses arrive.
+  streams amortize auth, tenant extraction, and middleware overhead
+  over many requests. HTTP/REST exists but is the convenience surface,
+  not the hot path.
 - **Multi-tenant by construction.** Every queue key is namespaced by
-  `tenantId` extracted from the JWT. Workers can only claim tasks from
-  their own tenant. No application code required to keep tenants
-  isolated.
-- **Cluster opt-in.** When one machine is no longer enough, run a
-  consistent-hash cluster (no consensus, no coordinator — static
-  membership + gRPC routing).
-- **Configurable durability.** `fsyncOnCommit` is a per-deployment knob.
-  Off by default for throughput; turn it on when your SLO demands it.
+  `tenantId` extracted from the JWT. Workers can only claim tasks
+  whose tenant matches their JWT subject. Tenant isolation is a
+  property of the keyspace, not a property of application code.
+- **Configurable durability.** `fsyncOnCommit` is a per-deployment
+  knob. Off by default (NoSync) for throughput; turn it on when your
+  SLO demands fsync-per-batch.
+- **HA via in-tree consensus.** RAFT replication is built in
+  (`internal/raft/`), not bolted on. Three nodes survive one node
+  failure (f=1 with N=3). Pebble is the state machine; raft is the
+  replication log.
 
 ## Non-goals
 
 - **Kafka-scale event streaming.** codeq is a task queue, not a
-  partitioned log. If you want millions of messages/s with consumer
-  groups, use Kafka.
-- **Distributed consensus by default.** Single-node and consistent-hash
-  cluster modes ship without consensus — node membership is configured
-  at startup. **Raft replication is opt-in** (see
-  [40-raft-replication.md](./40-raft-replication.md)): when enabled,
-  every Pebble write goes through `raft.Apply` and lands on every
-  replica's local Pebble via the FSM. Mutually exclusive with the
-  static-ring cluster mode.
+  partitioned log. No retention window measured in days, no consumer
+  groups, no replay. If you want millions of events/s, use Kafka.
+- **Cross-task transactions.** codeq is single-task atomic only. No
+  two-phase commit, no SAGAs, no cross-shard transactions. Multi-step
+  workflows must be composed above codeq with an outbox pattern or
+  delegated to a workflow engine (Temporal, Cadence, Step Functions).
 - **HA without explicit setup.** A single Pebble process loses
-  availability while it restarts. HA requires an opt-in configuration:
-  either raft replication (3+ nodes, automatic failover) or a static
-  consistent-hash cluster (no consensus, no replication). Each is a
-  trade-off the operator picks consciously.
+  availability while it restarts. HA requires opting into RAFT (3+
+  nodes, majority quorum, automatic failover under leader lease).
+  Static consistent-hash cluster mode is preserved for reference; use
+  RAFT for HA.
 - **Exactly-once delivery.** Delivery is at-least-once. A worker that
   crashes between completion and ACK will see the task re-delivered
-  after the lease expires.
+  after the lease expires. Idempotency is the application's job.
 - **Global FIFO across all commands.** Ordering is per-(command,
   tenant, priority) within a Pebble shard. Cross-shard ordering is not
-  defined.
+  defined; the FNV-1a routing is uniform, not order-preserving.
 - **Worker discovery or scheduling.** codeq does not register workers
-  or assign work; workers pull when they are ready.
+  or assign work. Workers pull when they are ready; backpressure is
+  implicit (an idle worker just doesn't issue a claim).
 
 ## Data model summary
 
@@ -72,11 +151,11 @@ are opt-in for HA and multi-node deployments.
   (routing key), `payload` (opaque JSON bytes), `priority` (0-9),
   optional `webhook` URL, and lifecycle state.
 - **Result** — completion record. Stored separately from the task body
-  so completion can be GC'd on a different schedule than the task
-  metadata.
-- **Subscription** — webhook registration. A worker (or coordinator)
-  registers a callback URL for one or more event types; codeq pings it
-  when new work appears.
+  so completion can be garbage-collected on a different schedule than
+  the task metadata.
+- **Subscription** — webhook registration. A worker or coordinator
+  registers a callback URL for one or more event types; codeq calls it
+  when matching work appears.
 
 Task lifecycle:
 
@@ -100,137 +179,126 @@ Full schema and state semantics in
 
 ## Architecture summary
 
+Ports and protocols:
+
+| Port | Protocol | Surface |
+|---|---|---|
+| `:8080` | HTTP/1.1 + HTTP/2 (Gin) | REST API, health, metrics, admin |
+| `:9092` | gRPC | Producer stream (bidi) |
+| `:9091` | gRPC | Worker stream (bidi) |
+| `:7000+` | TCP (raft + mux prefix) | RAFT inter-node transport; one shared listener per node, 4-byte BE group ID prefix per connection |
+
 ```mermaid
 graph TB
   subgraph Clients
-    SDK[Producer / Worker SDKs]
-    HTTPCLI[HTTP clients -- curl, browsers]
+    PROD[Producers]
+    WORK[Workers]
+    HTTPCLI[HTTP clients]
   end
-  subgraph Server[codeq server]
-    API[HTTP API -- Gin]
-    PGRPC[Producer gRPC stream]
-    WGRPC[Worker gRPC stream]
-    LEASE[In-memory lease table]
+  subgraph Server[codeq server -- single process]
+    API[":8080 -- HTTP API (Gin)"]
+    PGRPC[":9092 -- Producer gRPC stream"]
+    WGRPC[":9091 -- Worker gRPC stream"]
     SCHED[Scheduler core]
+    LEASE[In-memory lease table]
   end
-  subgraph Storage[Embedded persistence -- default]
+  subgraph Storage[Embedded persistence -- Pebble]
     P[Pebble shards 0..N-1]
   end
-  subgraph OptIn[Opt-in modes]
-    CL[Cluster -- consistent-hash + gRPC routing]
-    REDIS[Redis backend -- legacy, HA]
+  subgraph HA[Opt-in RAFT replication]
+    MUX[":7000 -- mux (4-byte BE group ID)"]
+    PEER1[Peer 1]
+    PEER2[Peer 2]
   end
-  SDK --> PGRPC
-  SDK --> WGRPC
-  HTTPCLI --> API
+  PROD -- "gRPC :9092" --> PGRPC
+  WORK -- "gRPC :9091" --> WGRPC
+  HTTPCLI -- "HTTP :8080" --> API
   API --> SCHED
   PGRPC --> SCHED
   WGRPC --> SCHED
   SCHED --> LEASE
   SCHED --> P
-  Server -.-> CL
-  Server -.-> REDIS
+  P -. "raft.Apply via FSM" .-> MUX
+  MUX -. "TCP :7000" .-> PEER1
+  MUX -. "TCP :7000" .-> PEER2
 ```
 
 Request flow at a glance:
 
 1. Producer or worker opens a gRPC stream (or sends an HTTP request).
 2. The middleware chain validates the JWT, extracts `tenantId`, and
-   applies rate limits.
+   applies rate limits. Stream-level middleware runs once per stream.
 3. The scheduler routes the operation to its Pebble shard
-   (`hash(taskID) % numShards`) and updates the in-memory lease table.
-4. Pebble commits the batch; the group-commit coalescer (Phase 1.1)
-   merges concurrent writers into one fsync.
-5. On worker stream, ready tasks are pushed back through the same long-
-   lived connection — no per-claim handshake.
+   (`FNV-1a(taskID) mod N`) and updates the in-memory lease table.
+4. In single-node / multi-shard mode, the write enters the group commit
+   coalescer; up to 64 concurrent batches merge into one Pebble
+   `Commit`. In RAFT mode, the coalescer is bypassed and the write
+   flows through `raft.Apply`; the FSM applies the committed log entry
+   to each replica's local Pebble.
+5. On the worker stream, ready tasks are pushed back through the same
+   long-lived connection — no per-claim handshake.
 
 Package-level breakdown in [03-architecture.md](./03-architecture.md).
+RAFT details in [40-raft-replication.md](./40-raft-replication.md).
 
 ## When to use codeq
 
 - **Single-node task queue for a backend service.** You want claims,
-  leases, retries, DLQ, and results without standing up Redis or a
-  broker.
+  leases, retries, DLQ, and results without a separate broker. One
+  binary, one disk directory.
 - **Embedded sidecar in your own Go binary.** Import `pkg/app` and run
-  codeq in-process alongside your application.
+  codeq in-process alongside your application. Same lifecycle, same
+  process supervisor.
 - **Multi-tenant SaaS background jobs.** Per-tenant queue isolation is
-  built in; you do not have to namespace keys yourself.
-- **High-throughput producers with small payloads.** The batched
-  producer stream sustains 100k+ creates/s on commodity hardware.
-- **Polyglot worker fleets.** Workers in Go, Java, Node, or Python can
-  all share the same queue via the official SDKs.
-- **Local development without external services.** `docker run codeq`
-  is enough; no Redis container, no compose dance.
+  enforced in the keyspace and the worker claim check, not by
+  application code.
+- **Throughput-bound producers with small payloads.** The batched
+  producer stream and the group commit coalescer are designed for the
+  case where N small writes arrive concurrently from different
+  goroutines.
+- **HA with f=1 fault tolerance.** Three RAFT nodes survive any one
+  node failure; failover is automatic under the leader lease.
 
 ## When NOT to use codeq
 
-- **Kafka-scale event streaming.** Millions of events/s with consumer
-  groups, replay, and a retention window measured in days — use Kafka.
-- **Distributed transactions.** codeq has no two-phase commit and no
-  cross-shard transactions. If your business logic needs atomic updates
-  across multiple tasks, build it above codeq with an outbox pattern or
-  pick a workflow engine.
-- **HA without Redis or cluster mode.** A single Pebble process is
-  unavailable during restart. If your SLO does not tolerate a few
-  seconds of unavailability, you need the Redis backend (multi-node) or
-  a Pebble cluster.
+- **Kafka-scale event streaming.** No retention window, no consumer
+  groups, no replay window. Different problem, different tool.
+- **Cross-task transactions.** codeq is single-task atomic only — no
+  2PC, no SAGAs, no transactional outbox primitive. Compose above
+  codeq if you need multi-task atomicity.
+- **HA without explicit setup.** A single Pebble process is
+  unavailable during restart. Enable RAFT (3+ nodes) before you put
+  the queue in front of an SLO that doesn't tolerate a few seconds of
+  downtime.
 - **Workflow orchestration with branching, child tasks, timers, and
-  long-running state.** Use Temporal, Cadence, or Step Functions — they
-  are purpose-built for that. codeq is a queue.
-- **Exactly-once delivery semantics.** codeq is at-least-once. Idempotent
-  handlers are the operator's responsibility.
+  long-running state.** Use Temporal, Cadence, or Step Functions.
+  codeq is a queue, not a workflow engine.
+- **Exactly-once delivery semantics.** Delivery is at-least-once.
+  Idempotent handlers are the application's responsibility.
+- **Order-preserving routing across shards.** Multi-shard mode routes
+  by `FNV-1a(taskID) mod N`; the hash is uniform, not stable across
+  shard counts and not order-preserving.
 
 ## Performance baselines
 
-Measured on a 12-core Linux box, Go 1.25.0, loopback gRPC, Pebble with
-`fsyncOnCommit=false`, 20s measurement window after a 2s warm-up.
-
-| Workload | Throughput | Harness |
+| Workload | Measured throughput | Harness |
 |---|---:|---|
-| Full cycle, 4 shards, batched | **83,420 tasks/s** | `internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle` (`PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`) |
-| Producer-only, batched stream | **136,392 creates/s** | `internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath` (32 goroutines, batch=16) |
-| Worker-only, batched stream | **23,518 tasks/s** | `internal/bench/worker_stream_saturation_test.go::TestSaturation_StreamPath` (c=4, `PHASE6_BATCH=32`) |
-| Shard sweep | 1 shard: 42k; 2: 65k; **4: 83k**; 6: 68k; 8: 67k | same as full cycle, `PHASE8_SHARDS` swept |
+| Single-node, full cycle, batched | **76,639 tasks/s** | [`internal/bench/profile_full_cycle_test.go`](../internal/bench/profile_full_cycle_test.go) |
+| 3-node RAFT + HTTP smart-routing | **~3.9k cycles/s** | [`pkg/app/raft_smart_routing_bench_test.go`](../pkg/app/raft_smart_routing_bench_test.go) |
 
-Sweet spot is 4 shards on this hardware. Past that, the cost of more
-commit pipelines + compaction loops outweighs the parallelism win. See
-[30-performance-baselines.md](./30-performance-baselines.md) for raw
-output, allocator stats, and the per-release history.
-
-## Comparativos resumidos
-
-| Dimension | codeq | Asynq | BullMQ | Kafka |
-|---|---|---|---|---|
-| External dependency | **None** | Redis | Redis | ZooKeeper / KRaft |
-| Single-node full-cycle throughput | **83k tasks/s** | ~10k | ~5k | n/a (no task semantics) |
-| Language | Go server, multi-language SDKs | Go | Node | Polyglot |
-| Multi-tenant native | **Yes** | DIY | DIY | DIY |
-| HA model | Cluster (consistent-hash ring, opt-in) | Redis | Redis | Replicated log |
-
-Full table with Sidekiq, Celery, and Temporal lives in
-[_STYLE.md § Comparativos](./_STYLE.md#comparativos-use-verbatim-or-as-a-base).
-
-## What changed (Phases 1-8 summary)
-
-codeq is built around an embedded Pebble store. The performance
-evolution that got it to its current numbers:
-
-| Phase | Theme | Effect |
-|---|---|---|
-| 1 | Pebble embedded backend | Single-binary deployment with an LSM-backed store. Single-shard throughput ~42k tasks/s. |
-| 1.1 | Pebble fast-paths + group-commit coalescer | `MoveDueDelayed` fast-path; concurrent writers coalesce into one fsync. |
-| 2 | Streaming groundwork | gRPC streaming surfaces designed. Auth amortized across stream lifetime. |
-| 5 | Cluster mode | Consistent-hash ring + gRPC routing between Pebble nodes. No consensus; static membership. |
-| 6 | Batched stream paths | Producer and worker streams gain batch APIs. `PHASE6_BATCH` / `PHASE6_PROD_BATCH` env knobs. |
-| 8 | Intra-process Pebble sharding | `numShards` opens N independent Pebble instances under one process. 4 shards → ~83k tasks/s on a 12-core box. **Mutually exclusive with cluster mode.** |
-
-PRs #527-#547 landed Phases 1.1, 6, and 8.
+Workload conditions, raw numbers, allocator stats, and per-release
+history live in [30-performance-baselines.md](./30-performance-baselines.md).
+Tuning knobs (shard counts, batch sizes, fsync trade-offs) are
+documented in [17-performance-tuning.md](./17-performance-tuning.md).
 
 ## See also
 
 - [_STYLE.md](./_STYLE.md) — documentation voice, numbers, diagrams.
 - [Architecture](./03-architecture.md) — package layout and request
   flows.
+- [Deployment modes](./41-deployment-modes.md) — decision guide.
+- [RAFT replication](./40-raft-replication.md) — consensus, FSM,
+  snapshot, mux transport.
 - [HTTP API](./04-http-api.md) — REST surface.
 - [Streaming API guide](./34-streaming-api-guide.md) — gRPC producer
   and worker streams.
@@ -238,9 +306,7 @@ PRs #527-#547 landed Phases 1.1, 6, and 8.
   output and per-release history.
 - [Performance tuning](./17-performance-tuning.md) — shard counts,
   batch sizes, fsync trade-offs.
-- [Cluster architecture](./05-cluster-architecture.md) — multi-node
-  consistent-hash deployment.
 - [Storage layout (Pebble)](./07b-storage-pebble.md) — keyspace and
   sharding internals.
 - [Persistence plugin system](./27-persistence-plugin-system.md) —
-  choosing and configuring backends.
+  backend selection.


### PR DESCRIPTION
## Summary

- Rewrite of `docs/01-overview.md` (U2 of the documentation overhaul). Removes the stale "legacy Redis backend" / "Redis primary" HA framing — HA is RAFT (`internal/raft/`), not Redis — and restructures the overview around three concrete deployment scenarios: single-node Pebble, multi-shard single-node, and RAFT replication.
- Adds a deployment scenarios table with measured throughput citations (76,639 tasks/s from `internal/bench/profile_full_cycle_test.go`, ~3.9k cycles/s from `pkg/app/raft_smart_routing_bench_test.go`) and a "Why it goes fast" section that grounds the throughput in CS primitives (group commit coalescer with `maxMergeBatch=64`, gRPC bidi streams amortizing middleware, intra-process Pebble sharding with FNV-1a routing).
- Labels every port on the architecture diagram (`:8080` HTTP, `:9091` worker gRPC, `:9092` producer gRPC, `:7000+` RAFT mux with 4-byte BE group ID prefix per `internal/raft/mux_transport.go:15`). Tightens Non-goals so each bullet names a concrete CS reason (no 2PC, no SAGAs, at-least-once delivery, FNV-1a is uniform but not order-preserving). Hands off to `docs/41-deployment-modes.md` for the full decision guide rather than duplicating it.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test -short ./...` — all packages pass
- [x] Buzzword grep (`blazingly|production-ready|enterprise-grade|...`) — zero hits
- [x] Removed-tech grep (`sdks/(java|python|nodejs)|kvrocks|legacy Redis|Redis primary`) — zero hits
- [x] CS-terminology grep (`LSM|group commit|raft|FSM|quorum|consensus|lease|backpressure`) — multiple hits
- [x] Port labels grep (`:[0-9]{4}`) — 13 lines including `:8080`, `:9091`, `:9092`, `:7000`
- [ ] Visual review of the mermaid diagram on GitHub render

Scope: touches only `docs/01-overview.md` per U2 boundary.