### PR TITLE
docs(_STYLE): codify voice, port labels, code citations, removed-tech list

### DIFF
--- a/docs/_STYLE.md
+++ b/docs/_STYLE.md
@@ -24,8 +24,8 @@ you must update the docs that quote it.
 > table. The result on a 12-core Linux box is 83,420 tasks/s for the
 > full create → claim → complete cycle, or 136,392 creates/s producer-
 > only. No Redis, no broker, no coordinator required in the default
-> mode. Cluster (consistent-hash + gRPC routing) and a legacy Redis
-> backend are opt-in for HA and multi-node deployments.
+> mode. RAFT replication (leader lease + AppendEntries log replication)
+> is opt-in for HA and multi-node deployments.
 
 ### Comparativos (use verbatim or as a base)
 
@@ -33,7 +33,7 @@ you must update the docs that quote it.
 |---|---|---|---|---|---|
 | External dependency | None (embedded Pebble) | Redis | Redis | Redis or RabbitMQ | ZooKeeper or KRaft cluster |
 | Throughput (single node, full cycle) | 83k tasks/s | ~10k tasks/s | ~5k tasks/s | ~3k tasks/s | 100k+ msgs/s, but no task semantics |
-| Language affinity | Go (HTTP + gRPC; SDKs for Java, Node, Python, Go) | Go | Node only | Python only | Polyglot |
+| Language affinity | Go server; HTTP `:8080` + gRPC `:9091`/`:9092` for any client | Go | Node only | Python only | Polyglot |
 | Durability | Pebble batch + group-commit; optional fsync | Redis AOF / RDB | Redis AOF / RDB | Broker-dependent | Replicated log |
 | Multi-tenant native | Yes (JWT tenantId namespacing built in) | No | No | No | No |
 | Learning curve | One binary, HTTP + curl in minutes | Moderate (Redis ops) | Moderate (Node + Redis) | High (broker + result backend) | High (broker, consumer groups, schema registry) |
@@ -55,8 +55,10 @@ What they care about, ranked:
    were measured on. No "blazing fast", no "10x". Cite the benchmark.
 2. **Operational cost** — how many processes, how many config knobs, how
    long until they can `curl` a task.
-3. **Language affinity** — Go server, but with first-class SDKs for the
-   reader's stack.
+3. **Language affinity** — Go server, with HTTP `:8080` and gRPC
+   (`:9091` worker, `:9092` producer) wire protocols any language can
+   speak directly. There are no language SDKs as of 2026-05-18 (see
+   § 8).
 4. **Durability and at-least-once** — what survives a crash, and how
    they prove it.
 5. **Multi-tenant** — whether they can run one queue server for many
@@ -70,33 +72,82 @@ basic concepts like "what is a task". Do define codeq-specific terms
 
 ## 3. Voice and tone
 
-### Numbers first, narrative second
+The voice rules below are non-negotiable. They override every other
+preference: if a sentence reads well but violates a rule, rewrite it.
 
-Bad:
+### Rule 1 — No buzzwords, no marketing
 
-> codeq is blazing fast and can handle massive workloads.
+Forbidden words and phrases (case-insensitive): `blazingly fast`,
+`production-ready`, `enterprise-grade`, `modern`, `next-generation`,
+`cutting-edge`, `seamless`, `robust`, `powerful`, `amazing`,
+`world-class`, `revolutionary`, `lightning`, `massive`, `blazing`,
+`10x`.
 
-Good:
+- BAD: "codeq is a blazingly fast task queue."
+- GOOD: "codeq sustains 76,639 tasks/s single-node via gRPC streaming
+  (`internal/bench/profile_full_cycle_test.go`)."
 
-> codeq sustains 83,420 tasks/s for a full create → claim → complete
-> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
-> batch=8, 128 worker slots, 20s measurement window
-> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
-> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
+If you cannot measure it, do not claim it. Replace adjectives with
+numbers. Replace value judgements with citations.
 
-Every throughput claim cites:
+### Rule 2 — CS concepts by textbook name
 
-- The exact test name in `internal/bench/`.
-- The env vars used to parameterize it.
-- The hardware class (cores, OS).
-- The measurement window.
+Use the canonical computer-science term, not a paraphrase. Recommended
+vocabulary (use these by name; link to a definition the first time):
 
-### Honest about limitations
+`LSM tree`, `memtable`, `SSTable`, `WAL`, `group commit`,
+`commitPipeline`, `fsync`, `Raft consensus`, `leader lease`,
+`AppendEntries`, `log replication`, `FSM`, `log compaction`,
+`majority quorum`, `backpressure`, `consistent hash`, `bloom filter`,
+`token bucket`, `lease table`, `scatter-gather`, `bidirectional gRPC
+stream`.
 
-Always name the trade-offs. Examples to use as templates:
+- BAD: "the storage engine writes things to disk in a smart way."
+- GOOD: "writes go through Pebble's `commitPipeline` (LSM memtable +
+  WAL); fsync is configurable via `fsyncOnCommit` (default false; see
+  `internal/repository/pebble/db.go:140`)."
 
-- "HA is only available via the Redis backend or by running a cluster of
-  Pebble nodes. A single Pebble process loses availability while it
+### Rule 3 — Measured numbers with citation
+
+Every throughput, latency, or memory claim cites a file path. The
+format is:
+
+> N tasks/s (`internal/bench/<file>.go::<TestName>`, env: `KEY=VAL`,
+> hardware: 12-core Linux).
+
+- BAD: "the system can handle a lot of writes."
+- GOOD: "the producer-only stream path sustains 136,392 creates/s on a
+  12-core Linux box
+  (`internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath`)."
+
+See § 9 for the full benchmark catalog.
+
+### Rule 4 — Diagrams with port labels
+
+Every architectural diagram MUST label ports and protocols. See § 5.1
+for the canonical port table and rendering rules.
+
+- BAD: "Producer → Server → Pebble"
+- GOOD: "Producer SDK --(`gRPC stream :9092`)--> Server --(`Pebble
+  batch`)--> Pebble shards"
+
+### Rule 5 — Code citations
+
+When you document behavior, cite the source: `path/to/file.go:line` or
+`path/to/file.go:start-end`. The reader must be able to jump to the
+implementation in one click. See § 7 for the canonical citation
+catalog.
+
+- BAD: "the coalescer batches commits."
+- GOOD: "the group-commit coalescer accumulates concurrent writers into
+  a single Pebble batch (`internal/repository/pebble/db.go:71-82`)."
+
+### Rule 6 — Honest tradeoffs
+
+Always name the trade-off. Examples to use as templates:
+
+- "HA is only available via RAFT replication or by running a multi-node
+  Pebble cluster. A single Pebble process loses availability while it
   restarts; recovery is fast (in-memory lease table rebuilt from the
   `KeyInprog` scan at Open) but not instantaneous."
 - "Cluster mode and intra-process sharding (`numShards > 1`) are
@@ -105,14 +156,26 @@ Always name the trade-offs. Examples to use as templates:
 - "Delivery is at-least-once, not exactly-once. A worker that crashes
   between completion and ACK will see its task re-delivered after the
   lease expires."
+- "`fsyncOnCommit=true` costs ~20% throughput in our harness. Default
+  is false."
 
-### No marketing fluff
+### Throughput claims: required fields
 
-Banned words: blazing, massive, lightning, seamless, robust,
-cutting-edge, world-class, next-gen, revolutionary.
+Rule 3 covers the general format. In addition, every throughput claim
+must cite:
 
-Replace adjectives with measurements. If you cannot measure it, do not
-claim it.
+- The exact test name in `internal/bench/`.
+- The env vars used to parameterize it.
+- The hardware class (cores, OS).
+- The measurement window.
+
+Reference example:
+
+> codeq sustains 83,420 tasks/s for a full create → claim → complete
+> cycle on a 12-core Linux box, 4 Pebble shards, 32 producer slots at
+> batch=8, 128 worker slots, 20s measurement window
+> (`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+> `PHASE8_SHARDS=4 PHASE6_BATCH=32 PHASE6_PROD_BATCH=8`).
 
 ### Opinionated
 
@@ -121,8 +184,8 @@ Tell the reader what to pick:
 - "For single-node deployments use Pebble with `numShards: 4`."
 - "Do not enable `fsyncOnCommit` unless you have measured the latency
   impact in your workload — it costs ~20% throughput in our harness."
-- "Use Redis only if you need multi-node HA today and cannot deploy the
-  cluster mode."
+- "Use RAFT replication only if you need multi-node HA today; otherwise
+  run a single Pebble node with `numShards: 4`."
 
 ## 4. Markdown conventions
 
@@ -152,13 +215,56 @@ Tell the reader what to pick:
 - **Links**: prefer descriptive text over "click here". Relative links
   for in-repo references (see §6).
 
-## 5. Mermaid conventions
+## 5. Diagrams (mermaid)
 
 All diagrams must render on the GitHub default theme in both light and
 dark mode. **Never set inline colors or styles** — let the renderer
-pick.
+pick. Prefer mermaid over ASCII: mermaid renders inline on GitHub and
+supports edge labels for protocols and ports.
 
-### Flow diagrams
+### 5.1 Port and protocol labels (mandatory)
+
+Every architectural diagram MUST label ports and protocols on the
+edges that carry traffic. Use the canonical port assignments:
+
+| Service | Port | Protocol | Source |
+|---|---|---|---|
+| HTTP REST API | `:8080` | HTTP/1.1 + JSON | `pkg/app/application.go` |
+| Producer gRPC | `:9092` | gRPC bidirectional stream | `pkg/app/application.go` |
+| Worker gRPC | `:9091` | gRPC bidirectional stream | `pkg/app/application.go` |
+| RAFT transport mux | `:7000+` | TCP (Raft AppendEntries / RequestVote) | `internal/raft/transport.go` |
+
+Edge label conventions:
+
+- Always quote the protocol verb: `AppendEntries`, `RequestVote`,
+  `Produce`, `Claim`, `SubmitResult`, `HTTP POST`, `gRPC stream`.
+- Always show the port when an external boundary is crossed.
+- Always show the direction with an arrowhead (`-->`, `-->>`,
+  `..>`).
+
+Example (correct):
+
+```mermaid
+graph LR
+  P[Producer SDK]
+  W[Worker SDK]
+  S[codeq server]
+  PEB[(Pebble shards)]
+  RP[Raft peers]
+  P -- "gRPC stream :9092 Produce" --> S
+  W -- "gRPC stream :9091 Claim/SubmitResult" --> S
+  S -- "LSM batch + WAL" --> PEB
+  S -- "AppendEntries :7000+" --> RP
+```
+
+Example (BAD — no ports, no protocols):
+
+```mermaid
+graph LR
+  P[Producer] --> S[Server] --> PEB[Pebble]
+```
+
+### 5.2 Flow diagrams
 
 Use `graph TB` for top-to-bottom layered architecture, `graph LR` for
 left-to-right pipelines. Always use `subgraph` to delimit logical
@@ -170,21 +276,21 @@ graph TB
     P1[Producer SDK]
   end
   subgraph Server[codeq server]
-    HTTP[HTTP API]
-    GRPC[gRPC stream]
+    HTTP[HTTP API :8080]
+    GRPC[gRPC stream :9092]
   end
   subgraph Storage
     PEB[Pebble shards]
   end
-  P1 --> GRPC
-  GRPC --> PEB
-  HTTP --> PEB
+  P1 -- "gRPC stream :9092 Produce" --> GRPC
+  GRPC -- "LSM batch + WAL" --> PEB
+  HTTP -- "HTTP POST /tasks" --> PEB
 ```
 
 Aim for 8 to 12 nodes max in a single diagram. If it grows past that,
 split it.
 
-### Sequence diagrams
+### 5.3 Sequence diagrams
 
 Use `sequenceDiagram` for flows over time. Participant names start
 capitalized.
@@ -194,13 +300,13 @@ sequenceDiagram
   participant Producer
   participant Server
   participant Pebble
-  Producer->>Server: Produce(task)
-  Server->>Pebble: BatchCommit
+  Producer->>Server: gRPC :9092 Produce(task)
+  Server->>Pebble: BatchCommit (LSM + WAL)
   Pebble-->>Server: ack
   Server-->>Producer: TaskID
 ```
 
-### State machines
+### 5.4 State machines
 
 Use `stateDiagram-v2` for task lifecycle. Transition labels describe
 the **trigger action**, not the resulting state.
@@ -216,7 +322,7 @@ stateDiagram-v2
   DLQ --> [*]
 ```
 
-### No inline colors
+### 5.5 No inline colors
 
 Bad:
 
@@ -257,7 +363,67 @@ When you cite the value prop, link to this file:
 See [_STYLE.md § Value proposition](./_STYLE.md#1-value-proposition).
 ```
 
-## 7. Numbers must come from measurement
+## 7. Code citations
+
+Documenting behavior without pointing at the implementation is a style
+violation. Every claim about how codeq behaves cites a source file and
+line range. Format:
+
+```text
+`path/to/file.go:line`
+`path/to/file.go:start-end`
+```
+
+Use repo-rooted paths (no leading `./`, no leading `/`). Cite the
+narrowest range that contains the behavior — function signatures or
+multi-line blocks are preferred over whole files.
+
+Canonical citations to keep in your mental cache:
+
+| Behavior | Citation |
+|---|---|
+| Group commit coalescer (write path) | `internal/repository/pebble/db.go:71-82` |
+| Pebble `commitPipeline` + WAL fsync flag | `internal/repository/pebble/db.go:140` |
+| Shard routing via FNV-1a over `taskID` | `internal/repository/pebble/sharded_task_repository.go:61-65` |
+| FSM Apply path (Raft log → Pebble write) | `internal/raft/fsm.go:43-62` |
+| Application bootstrap (HTTP `:8080`, gRPC `:9091`/`:9092`) | `pkg/app/application.go` |
+| Worker stream loop | `pkg/app/worker_stream.go` |
+| MoveDueDelayed fast-path | `internal/repository/pebble/db.go` |
+
+Rule: when you change one of these line numbers in a PR, you also grep
+the docs and update every citation. Stale `:line` references are worse
+than no citation.
+
+## 8. Removed tech (forbidden mentions)
+
+The technologies listed below are NOT part of codeq as of 2026-05-18.
+Documentation must not mention them outside of historical changelogs.
+If you find a mention while writing or editing a doc, delete it or
+restate the behavior using the current stack.
+
+| Removed | Replacement / status | Removed in |
+|---|---|---|
+| Java SDK | Use HTTP `:8080` or gRPC `:9092` directly | PRs #596-604 |
+| Python SDK | Use HTTP `:8080` or gRPC `:9092` directly | PRs #596-604 |
+| JavaScript / Node SDK | Use HTTP `:8080` or gRPC `:9092` directly | PRs #596-604 |
+| `sdks/go/` REST client | Use HTTP `:8080` directly or generated gRPC client | PR #600 |
+| KVRocks backend | Pebble is the only persistence engine | 2026-05-17 |
+| "legacy Redis backend" | Pebble is the only persistence engine | 2026-05-17 |
+| "Redis primary / HA mode" | RAFT replication is the only HA path | 2026-05-17 |
+| Cluster mode (Phase 5 consistent-hash) | Preserved for reference only; not a recommended deployment | — |
+
+Phrasing rules:
+
+- Do not write "codeq supports Pebble, KVRocks, or Redis". codeq is
+  100% Pebble. Period.
+- Do not write "the Java SDK". There is no Java SDK. Cite the HTTP or
+  gRPC API instead.
+- Cluster mode (the Phase 5 consistent-hash + gRPC scatter-gather
+  prototype) may be mentioned ONLY with the qualifier "preserved for
+  reference" and a link to the relevant ADR. It is not recommended for
+  new deployments; RAFT replication is.
+
+## 9. Numbers must come from measurement
 
 Every throughput, latency, or memory claim in any doc must be traceable
 to a test in `internal/bench/`. The format is:


### PR DESCRIPTION
## Summary

Update `docs/_STYLE.md` (U3 of the 16-unit docs overhaul) to lock in the technical, CS-grounded voice the rest of the documentation will follow.

- Drop "legacy Redis backend" from the value proposition. Per the Pebble-only positioning (since 2026-05-17), codeq is 100% Pebble; RAFT replication is the opt-in HA path.
- Add six explicit Voice rules — no buzzwords, CS textbook vocabulary, measured numbers with citation, diagram port labels, code citations, honest tradeoffs — each with BAD/GOOD examples.
- Mandate port + protocol labels on every architectural diagram. Add the canonical port table (`:8080` HTTP, `:9091` Worker gRPC, `:9092` Producer gRPC, `:7000+` RAFT mux) with source-file references. Updated the existing flow + sequence diagram examples to carry the labels.
- Add §7 "Code citations" with a canonical citation catalog (group-commit coalescer, FSM Apply path, FNV-1a shard routing, app bootstrap, worker stream loop).
- Add §8 "Removed tech (forbidden mentions)" enumerating the deleted SDKs (Java/Python/JS, `sdks/go/`) and the retired persistence stories (KVRocks, "legacy Redis backend", "Redis primary"). Cluster mode (Phase 5 consistent-hash) preserved for reference only.
- Drop stale "SDKs for Java, Node, Python, Go" claim from the comparativos table and audience profile; replace with the HTTP + gRPC wire-protocol story.
- Collapse the duplicated "Numbers first" / "Honest about limitations" / "No marketing fluff" subsections to thin pointers at the new Rules to avoid drift.

Scope: only `docs/_STYLE.md`. README, `docs/01-overview.md`, and `docs/README.md` are owned by other parallel units.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -short ./...` green across all packages
- [x] `grep -niE 'blazingly|production-ready|enterprise-grade|next-generation|cutting-edge|seamless|robust|powerful|amazing|world-class' docs/_STYLE.md` only matches inside the forbidden-list and BAD example
- [x] `grep -niE 'kvrocks|legacy Redis|Redis primary' docs/_STYLE.md` only matches inside the removed-tech table and phrasing rules
- [x] Canonical ports `:8080`, `:9091`, `:9092`, `:7000+` all present
- [x] Recommended CS vocabulary (LSM, group commit, Raft, FSM, WAL, quorum, lease, backpressure) appears as the recommended list

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>