### PR TITLE
docs(u16): reposition cluster docs as Phase 5 legacy; sweep Redis refs

### DIFF
--- a/docs/05-cluster-architecture.md
+++ b/docs/05-cluster-architecture.md
@@ -1,5 +1,14 @@
 # Cluster Architecture
 
+> **Status: Legacy (Phase 5).** This document describes the consistent-hash
+> cluster mode that predates RAFT replication. For high availability and
+> automatic failover in new deployments, use **RAFT** (see
+> [40-raft-replication.md](40-raft-replication.md) and
+> [41-deployment-modes.md](41-deployment-modes.md) for the decision guide).
+> Cluster mode is preserved for existing deployments and reference; the
+> mode is mutually exclusive with `raft.enabled`
+> (`pkg/config/config.go:662-683`).
+
 ## Overview
 
 codeQ supports horizontal scaling through a **consistent hash ring** cluster topology. Multiple nodes form a cluster where task ownership is determined by hashing the task ID to a node. This enables:

--- a/docs/28-troubleshooting.md
+++ b/docs/28-troubleshooting.md
@@ -110,6 +110,10 @@ This guide covers common issues, their symptoms, and resolution steps. For metri
 
 ### 7. Cluster bloom gossip lag (cross-node ID lookups miss)
 
+> Note: bloom gossip is a cluster-mode (Phase 5) optimization. If you're
+> running RAFT ([40-raft-replication.md](40-raft-replication.md)), this
+> section doesn't apply.
+
 **Symptoms:** In cluster mode, `GetResult` or `GetTask` by ID intermittently returns `not found` for tasks that exist on another node; the request eventually succeeds on retry. Logs in `internal/cluster/` show bloom misses or stale routing decisions.
 
 **Possible causes:**

--- a/docs/39-multi-tenancy.md
+++ b/docs/39-multi-tenancy.md
@@ -172,11 +172,9 @@ task, ok, err := h.svc.ClaimTask(ctx, claims.Subject, req.Commands,
     req.LeaseSeconds, 0, tenantID)
 ```
 
-Under Pebble this resolves to a `PrefixPendingPrio(cmd, tenantID, prio)`
-scan — the worker literally cannot iterate another tenant's pending
-queue because the prefix doesn't include it. Under the Redis backend
-the inprog set and pending list are tenant-keyed via the same
-`(cmd, tenantID)` tuple.
+This resolves to a `PrefixPendingPrio(cmd, tenantID, prio)` scan over
+the local Pebble store — the worker literally cannot iterate another
+tenant's pending queue because the prefix doesn't include it.
 
 ```mermaid
 sequenceDiagram
@@ -218,16 +216,22 @@ the service hands it to the repository. This avoids two failure modes:
 ### The Phase 6 race fix
 
 Before the Phase 6 finalization fix, `UpdateTaskOnComplete` took only
-`(taskID, cmd, status, errorMsg)` — no tenant. Under the Redis backend
-this meant the inprog key used at finalization could be on the wrong
-tenant prefix relative to the claim path, which caused a rare
-resurrection race for completed tasks. The fix added `tenantID` to the
-signature so the finalize path and the claim path target the exact
-same inprog key. Details and the measured `-43%` DLQ depth improvement
-are in
+`(taskID, cmd, status, errorMsg)` — no tenant. Without the tenant in
+the signature, the inprog key used at finalization could land on a
+different tenant prefix than the one the claim path wrote, causing a
+rare resurrection race for completed tasks. The fix added `tenantID`
+to the signature so the finalize path and the claim path target the
+exact same inprog key. Details and the measured `-43%` DLQ depth
+improvement are in
 [Performance tuning § Result Submission Race](./17-performance-tuning.md#15-result-submission-race-condition-atomic-finalization).
 
 ## 5. Multi-tenant + cluster routing
+
+> Note: this section describes Phase 5 cluster mode
+> ([`docs/05-cluster-architecture.md`](./05-cluster-architecture.md)).
+> RAFT mode ([`docs/40-raft-replication.md`](./40-raft-replication.md))
+> is the recommended HA path; cluster mode is preserved for existing
+> deployments and is mutually exclusive with `raft.enabled`.
 
 Cluster mode uses a consistent-hash ring keyed by **task ID**, not by
 tenant. The ring layout, virtual nodes, and `Owner(key)` lookup are


### PR DESCRIPTION
## Summary

U16 of the docs overhaul: reposition the consistent-hash cluster docs as legacy (Phase 5) now that RAFT replication is the recommended HA path, and sweep remaining Redis-backend mentions from the affected files.

- **docs/05-cluster-architecture.md** — add a Legacy (Phase 5) banner at the top pointing to `40-raft-replication.md` / `41-deployment-modes.md`, citing `pkg/config/config.go:662-683` for the `raft.enabled` vs `cluster.enabled` mutex.
- **docs/28-troubleshooting.md** — scope the "cluster bloom gossip lag" section to cluster-mode (Phase 5); RAFT users can ignore it.
- **docs/39-multi-tenancy.md** — remove stale Redis-backend mentions from the claim-path explanation and the Phase 6 race-fix narrative (technical content preserved); add a Phase 5 clarifier to section 5 (Multi-tenant + cluster routing).
- **docs/27-persistence-plugin-system.md** — unchanged (already Pebble-only).

## Voice & sweep checks

- Zero buzzwords (`blazingly|production-ready|enterprise-grade|...`) across the four files.
- Zero stale refs (`kvrocks|legacy Redis|Redis primary|Redis HA`) in the swept files.
- `docs/05` carries no "primary HA" framing.
- All four files retain code citations (`pkg/config/config.go:662-683`, `internal/repository/pebble/keys.go`, etc.).

## Test plan

- [x] `go build ./...` — passes
- [x] `go test -short ./...` — all packages green
- [x] Voice/sweep grep recipe — zero hits
- [ ] Reviewer: confirm the banner wording in `docs/05` matches the coordinator's spec verbatim
- [ ] Reviewer: confirm `docs/41-deployment-modes.md` is being created by another parallel unit (link target)

Generated with [Claude Code](https://claude.com/claude-code)