### PR TITLE
docs(u15): refresh examples, add Go SDK tutorial

### DIFF
--- a/docs/13-examples.md
+++ b/docs/13-examples.md
@@ -1,14 +1,26 @@
-# Usage Examples
+# Usage examples
 
-This document provides practical examples of using CodeQ via HTTP API, CLI, and the official Go SDK.
+Short, copy-pasteable recipes for the three ways to talk to a codeq
+server: raw HTTP (`curl`), the `codeq` CLI, and the Go SDK. For the
+full walkthrough that builds a runnable producer + worker service, see
+[Go SDK tutorial](./44-tutorial-go-sdk.md).
 
-## Table of Contents
+## Table of contents
 
-- [HTTP API Examples](#http-api-examples)
-- [CLI Examples](#cli-examples)
-- [Go SDK Examples](#go-sdk-examples)
+- [HTTP API examples](#http-api-examples)
+- [CLI examples](#cli-examples)
+- [Go SDK examples](#go-sdk-examples)
+- [OpenTelemetry distributed tracing](#opentelemetry-distributed-tracing)
+- [Additional resources](#additional-resources)
 
-## HTTP API Examples
+## HTTP API examples
+
+The HTTP API is for one-off calls and non-Go clients. Long-running
+producers and workers should prefer the gRPC streaming SDKs
+(`pkg/producerclient`, `pkg/workerclient`) because each HTTP request
+pays the full middleware tax (TLS handshake amortised by keep-alive,
+JSON parse, auth, request logging) — the streaming path skips all of
+that after the initial Hello handshake.
 
 ### Producer: create task
 
@@ -19,7 +31,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"priority":3}'
 ```
 
-## Producer: create scheduled task
+### Producer: create scheduled task
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks \
@@ -28,7 +40,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks \
   -d '{"command":"GENERATE_MASTER","payload":{"jobId":"j-123"},"runAt":"2026-01-25T13:10:00Z"}'
 ```
 
-## Worker: claim task
+### Worker: claim task
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
@@ -37,7 +49,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/claim \
   -d '{"commands":["GENERATE_MASTER"],"leaseSeconds":120,"waitSeconds":10}'
 ```
 
-## Worker: submit result
+### Worker: submit result
 
 ```bash
 curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
@@ -87,42 +99,72 @@ curl -X GET http://localhost:8080/v1/codeq/admin/queue/stats \
   -H 'Authorization: Bearer <admin-token>'
 ```
 
-## CLI Examples
+## CLI examples
 
-See [CLI Reference](15-cli-reference.md) for complete documentation.
+The CLI is shipped as a separate binary in `cmd/codeq` and primarily
+calls the HTTP API. See [CLI Reference](./15-cli-reference.md) for the
+full flag list and profile configuration.
 
-### Start local server
+### Start a local server
+
+The server binary is `cmd/server`, not a `codeq` subcommand. Build and
+run it directly:
 
 ```bash
-codeq serve --port 8080 --redis-addr localhost:6666
+go build -o bin/codeq-server ./cmd/server
+./bin/codeq-server -config deploy/config/codeq.example.yml
 ```
 
-### Create task via CLI
+For a working dev setup including Pebble shards and Prometheus, see
+[Getting started](./00-getting-started.md).
+
+### Generate an install bundle
+
+```bash
+codeq install --target docker --size dev --no-prompt
+```
+
+This emits a `codeq-install/` directory with a Docker Compose stack
+and a prebuilt image tag. The Kubernetes target (`--target k8s`) emits
+a Helm chart.
+
+### Create a task
 
 ```bash
 codeq task create \
-  --command PROCESS_ORDER \
+  --event PROCESS_ORDER \
   --payload '{"orderId":"123"}' \
-  --priority 5 \
-  --token $PRODUCER_TOKEN
+  --priority 5
 ```
 
-### Claim task via CLI
+The token is sourced from `--producer-token`, `CODEQ_PRODUCER_TOKEN`,
+or the current profile in `~/.codeq/config.yaml`.
+
+### Fetch a task and its result
 
 ```bash
-codeq task claim \
-  --commands PROCESS_ORDER \
-  --lease 120 \
-  --wait 10 \
-  --token $WORKER_TOKEN
+codeq task get 01HWXYZ1234567890ABCDEFGH
+codeq task result 01HWXYZ1234567890ABCDEFGH
 ```
 
-## Go SDK Examples
+### Inspect queue state
+
+```bash
+codeq queue stats
+codeq worker inspect PROCESS_ORDER
+```
+
+## Go SDK examples
 
 The Go SDK lives inside the main module under
-[`pkg/producerclient`](../pkg/producerclient) (task creation) and
-[`pkg/workerclient`](../pkg/workerclient) (claim + result). Both use
-gRPC streams under the hood.
+[`pkg/producerclient`](../pkg/producerclient/client.go) (task creation)
+and [`pkg/workerclient`](../pkg/workerclient/client.go) (claim and
+result). Both open one long-lived bidirectional gRPC stream after a
+single Hello handshake. The producer stream listens on `:9092`, the
+worker stream on `:9091` (defaults — overridable via config).
+
+For a runnable end-to-end walkthrough that builds both halves of a
+service, see [Go SDK tutorial](./44-tutorial-go-sdk.md).
 
 **Install:**
 
@@ -130,7 +172,7 @@ gRPC streams under the hood.
 go get github.com/osvaldoandrade/codeq
 ```
 
-**Create a task (producer):**
+**Create one task (producer):**
 
 ```go
 import (
@@ -149,18 +191,50 @@ if err != nil {
 }
 defer cli.Close()
 
-sess, err := cli.Connect(ctx)
+sess, err := cli.Connect(context.Background())
 if err != nil {
     return err
 }
 defer sess.Close()
 
-taskID, err := sess.Produce(ctx, producerclient.CreateRequest{
+taskID, err := sess.Produce(context.Background(), producerclient.CreateRequest{
     Command:  "PROCESS_ORDER",
     Payload:  []byte(`{"orderId":"123","amount":99.99}`),
     Priority: 5,
 })
 ```
+
+`Produce` blocks only until the server's `CreateAck` arrives. Many
+goroutines can call `Produce` on the same `Session` concurrently — the
+client multiplexes them via sequence numbers
+(`pkg/producerclient/client.go:104-131`).
+
+**Produce a batch in one stream frame:**
+
+```go
+reqs := []producerclient.CreateRequest{
+    {Command: "PROCESS_ORDER", Payload: []byte(`{"orderId":"1"}`)},
+    {Command: "PROCESS_ORDER", Payload: []byte(`{"orderId":"2"}`)},
+    {Command: "PROCESS_ORDER", Payload: []byte(`{"orderId":"3"}`)},
+}
+results, err := sess.ProduceBatch(context.Background(), reqs)
+if err != nil {
+    return err
+}
+for i, r := range results {
+    if r.Err != nil {
+        log.Printf("task %d rejected: %v", i, r.Err)
+        continue
+    }
+    log.Printf("task %d id=%s", i, r.TaskID)
+}
+```
+
+`ProduceBatch` sends one `CreateTaskBatch` event instead of N
+`CreateTask`, and the server returns one `CreateAckBatch`. The
+per-task latency is not serialised — the server still fans out
+internally. This is the path that gets the producer harness to 136k
+creates/s (`internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath`).
 
 **Process tasks (worker):**
 
@@ -201,18 +275,35 @@ if err := w.Run(ctx, handler); err != nil {
 }
 ```
 
+**Result dispositions** (`pkg/workerclient/result.go`):
+
+```go
+workerclient.Completed(map[string]any{"ok": true})  // terminal success
+workerclient.Failed("invalid payload: " + err.Error()) // terminal failure
+workerclient.Nack(5, "downstream 503")              // retry after 5s, attempts++
+workerclient.Abandon()                              // release lease, no attempt++
+```
+
+The single-node full-cycle harness sustains 83,420 tasks/s with this
+SDK against an embedded Pebble store
+(`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+4 shards, 32 producer slots at batch=8, 128 worker slots, 12-core
+Linux). See [`docs/_STYLE.md` § 7](./_STYLE.md#7-numbers-must-come-from-measurement)
+for the canonical bench table.
+
 **See also**:
-- [Go Integration Guide](integrations/go-integration.md) — full surface
-  walk-through.
-- [Streaming API guide](34-streaming-api-guide.md) — high-throughput
-  producer/worker stream patterns.
+- [Go SDK tutorial](./44-tutorial-go-sdk.md) — full walkthrough.
+- [Producer streaming SDK](./35-producer-streaming-sdk.md) — wire
+  protocol and Hello handshake.
+- [Worker streaming SDK](./36-worker-streaming-sdk.md) — slot loop,
+  batching, lease semantics.
 
 For non-Go callers, use the HTTP API documented in
-[04-http-api.md](04-http-api.md).
+[HTTP API](./04-http-api.md).
 
-## OpenTelemetry Distributed Tracing
+## OpenTelemetry distributed tracing
 
-### Basic Configuration
+### Basic configuration
 
 Enable tracing in your configuration file or via environment variables:
 
@@ -235,7 +326,7 @@ export TRACING_OTLP_INSECURE=true
 export TRACING_SAMPLE_RATIO=1.0
 ````
 
-### Trace Context Propagation
+### Trace context propagation
 
 When creating tasks, you can propagate trace context from your application:
 
@@ -257,7 +348,7 @@ The trace context is:
 - Propagated to webhooks and result callbacks
 - Included in all spans emitted by codeQ
 
-### Example: End-to-End Tracing with Jaeger
+### End-to-end tracing with Jaeger
 
 ````bash
 # Start codeQ with observability stack
@@ -303,7 +394,7 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/$TASK_ID/result \
 open http://localhost:16686
 ````
 
-### Tracing with Custom Services
+### Tracing inside a custom worker
 
 If you're building a worker service in your application that processes codeQ tasks, ensure you:
 
@@ -341,7 +432,7 @@ func processTask(task *Task) {
 }
 ````
 
-### Sampling Configuration
+### Sampling
 
 Control what percentage of traces are sampled:
 
@@ -351,12 +442,12 @@ tracingSampleRatio: 0.1  # Sample 10% of requests
 
 Sampling is parent-based by default, so if an incoming request has a sampled trace context, codeQ will honor it.
 
-## Additional Resources
+## Additional resources
 
-- **Go SDK overview**: [sdks/README.md](../sdks/README.md)
-- **HTTP API Reference**: [04-http-api.md](04-http-api.md)
-- **CLI Reference**: [15-cli-reference.md](15-cli-reference.md)
-- **Tracing Configuration**: [14-configuration.md](14-configuration.md#tracing-opentelemetry)
-- **Operations Guide**: [10-operations.md](10-operations.md#tracing-opentelemetry)
-- **Examples directory**: [examples/](../examples/)
-- **Go Integration Guide**: [integrations/go-integration.md](integrations/go-integration.md)
+- **Go SDK tutorial**: [44-tutorial-go-sdk.md](./44-tutorial-go-sdk.md)
+- **HTTP API reference**: [04-http-api.md](./04-http-api.md)
+- **CLI reference**: [15-cli-reference.md](./15-cli-reference.md)
+- **Producer streaming SDK**: [35-producer-streaming-sdk.md](./35-producer-streaming-sdk.md)
+- **Worker streaming SDK**: [36-worker-streaming-sdk.md](./36-worker-streaming-sdk.md)
+- **Tracing configuration**: [14-configuration.md § tracing](./14-configuration.md#tracing-opentelemetry)
+- **Operations guide**: [10-operations.md § tracing](./10-operations.md#tracing-opentelemetry)

--- a/docs/44-tutorial-go-sdk.md
+++ b/docs/44-tutorial-go-sdk.md
@@ -1,0 +1,410 @@
+# Tutorial: Go SDK end-to-end
+
+A complete walkthrough that builds a small Go service in two parts:
+
+- a **producer** that enqueues tasks over the gRPC streaming SDK
+  (`pkg/producerclient`);
+- a **worker** that claims and processes them
+  (`pkg/workerclient`).
+
+By the end you have two binaries you can run against a local codeq
+server. The code compiles unchanged against the API surface in
+[`pkg/producerclient/client.go`](../pkg/producerclient/client.go) and
+[`pkg/workerclient/client.go`](../pkg/workerclient/client.go).
+
+## Table of contents
+
+- [1. What you'll build](#1-what-youll-build)
+- [2. Prerequisites](#2-prerequisites)
+- [3. Project setup](#3-project-setup)
+- [4. Producer](#4-producer)
+- [5. Worker](#5-worker)
+- [6. Result handling — when to use which](#6-result-handling--when-to-use-which)
+- [7. Concurrency, batching, lease tuning](#7-concurrency-batching-lease-tuning)
+- [8. Where the gRPC connections go](#8-where-the-grpc-connections-go)
+- [9. Real-world patterns](#9-real-world-patterns)
+- [10. Next steps](#10-next-steps)
+
+## 1. What you'll build
+
+A small Go service with two parts: a producer that creates tasks, and
+a worker that processes them. Both use gRPC streaming clients
+([`pkg/producerclient`](../pkg/producerclient/client.go) and
+[`pkg/workerclient`](../pkg/workerclient/client.go)) that open one
+bidirectional stream per process, authenticate once with a `Hello`
+event, and then pipeline `CreateTask` / `Ready` / `Result` events over
+the same TCP connection. This avoids the per-request middleware tax of
+the REST endpoint — the harness measures the streaming full-cycle at
+83,420 tasks/s on a 12-core box
+(`internal/bench/profile_full_cycle_test.go::TestProfile_FullCycle`,
+see [`_STYLE.md` § 7](./_STYLE.md#7-numbers-must-come-from-measurement)).
+
+## 2. Prerequisites
+
+- Go 1.22 or newer (the repo currently builds on 1.25).
+- A running codeq server. The fastest path is single-node Pebble per
+  [Getting started](./00-getting-started.md). For a multi-node setup
+  see [Raft replication](./40-raft-replication.md).
+- A producer token and a worker token. With the default config the
+  string `dev-token` works for both (see
+  [`deploy/config/codeq.example.yml`](../deploy/config/codeq.example.yml)).
+  In production, mint real tokens — see [Security](./09-security.md).
+- The default ports: `:9092` for the producer stream and `:9091` for
+  the worker stream. The HTTP API on `:8080` is unused in this
+  tutorial.
+
+## 3. Project setup
+
+```bash
+mkdir my-codeq-app && cd my-codeq-app
+go mod init example/codeq-app
+go get github.com/osvaldoandrade/codeq
+mkdir -p producer worker
+```
+
+You should end up with the layout:
+
+```text
+my-codeq-app/
+├── go.mod
+├── go.sum
+├── producer/
+│   └── main.go
+└── worker/
+    └── main.go
+```
+
+## 4. Producer
+
+The producer opens **one** `Client`, then **one** `Session` on that
+client, and reuses both for the lifetime of the process. Each
+`Session` is a single gRPC stream; many goroutines can call `Produce`
+concurrently on it and the client multiplexes via sequence numbers
+([`client.go:104-131`](../pkg/producerclient/client.go)).
+
+`producer/main.go`:
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "log"
+    "os"
+    "time"
+
+    "github.com/osvaldoandrade/codeq/pkg/producerclient"
+)
+
+func main() {
+    // Construct the client. Holds one gRPC connection; safe to share
+    // across goroutines.
+    cli, err := producerclient.New(producerclient.Config{
+        Addr:  os.Getenv("CODEQ_PRODUCER_ADDR"), // e.g. "localhost:9092"
+        Token: os.Getenv("CODEQ_PRODUCER_TOKEN"),
+    })
+    if err != nil {
+        log.Fatalf("producerclient.New: %v", err)
+    }
+    defer cli.Close()
+
+    // Open one bidirectional stream. Multiple goroutines can call
+    // Produce concurrently on this Session — sends are funnelled
+    // through an internal writer goroutine and acks are routed back
+    // by sequence number.
+    ctx := context.Background()
+    sess, err := cli.Connect(ctx)
+    if err != nil {
+        log.Fatalf("Connect: %v", err)
+    }
+    defer sess.Close()
+
+    // Marshal a JSON payload. codeq treats payloads as opaque bytes;
+    // any encoding works as long as your worker agrees.
+    payload, _ := json.Marshal(map[string]any{
+        "orderId": "42",
+        "amount":  99.99,
+    })
+
+    // Produce. Returns the server-assigned task id once the matching
+    // CreateAck arrives. Blocks only on that single round trip.
+    taskID, err := sess.Produce(ctx, producerclient.CreateRequest{
+        Command:  "PROCESS_ORDER",
+        Payload:  payload,
+        Priority: 5,
+        // Optional: IdempotencyKey: "order-42",
+        // Optional: DelaySeconds:   60, // visible 60s in the future
+    })
+    if err != nil {
+        log.Fatalf("Produce: %v", err)
+    }
+    log.Printf("created task %s", taskID)
+
+    // Give the worker time to consume in this demo. In a real
+    // service the producer keeps the Session alive for the lifetime
+    // of the process.
+    time.Sleep(2 * time.Second)
+}
+```
+
+Run:
+
+```bash
+CODEQ_PRODUCER_ADDR=localhost:9092 CODEQ_PRODUCER_TOKEN=dev-token go run ./producer
+```
+
+If the producer needs to enqueue many tasks at once, prefer
+`Session.ProduceBatch`. One stream frame carries N `CreateTask` and
+the server replies with one `CreateAckBatch`. Per-task work still
+parallelises on the server side
+([`client.go:355-421`](../pkg/producerclient/client.go)).
+
+## 5. Worker
+
+The worker uses `workerclient.Client.Run`, which blocks until the
+context is cancelled. Internally it opens a stream, runs the `Hello`
+handshake, then spawns `Concurrency` slot goroutines. Each slot loops:
+send `Ready` → receive `Task` (or `TaskBatch`) → invoke the handler →
+send `Result` (or coalesced `ResultBatch`).
+
+`worker/main.go`:
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "errors"
+    "log"
+    "os"
+    "os/signal"
+    "syscall"
+
+    "github.com/osvaldoandrade/codeq/pkg/workerclient"
+)
+
+func main() {
+    w, err := workerclient.New(workerclient.Config{
+        Addr:         os.Getenv("CODEQ_WORKER_ADDR"), // e.g. "localhost:9091"
+        Token:        os.Getenv("CODEQ_WORKER_TOKEN"),
+        Commands:     []string{"PROCESS_ORDER"},
+        Concurrency:  4,   // 4 in-flight tasks per process
+        LeaseSeconds: 120, // each task gets a 2-minute lease
+        // BatchSize: 8,   // optional: claim 8 at a time + batch results
+    })
+    if err != nil {
+        log.Fatalf("workerclient.New: %v", err)
+    }
+    defer w.Close()
+
+    // Cancel cleanly on SIGINT/SIGTERM. Run returns when ctx is done.
+    ctx, stop := signal.NotifyContext(context.Background(),
+        syscall.SIGINT, syscall.SIGTERM)
+    defer stop()
+
+    handler := func(ctx context.Context, t workerclient.Task) workerclient.Result {
+        var order struct {
+            OrderID string  `json:"orderId"`
+            Amount  float64 `json:"amount"`
+        }
+        if err := json.Unmarshal(t.Payload, &order); err != nil {
+            // Bad payload — not retriable. Fail terminally; counts
+            // toward MaxAttempts and (eventually) goes to the DLQ.
+            return workerclient.Failed("invalid payload: " + err.Error())
+        }
+
+        log.Printf("processing %s (orderId=%s amount=%.2f)",
+            t.ID, order.OrderID, order.Amount)
+
+        if err := process(ctx, order.OrderID, order.Amount); err != nil {
+            if errors.Is(err, context.Canceled) {
+                // Graceful shutdown — release the lease so another
+                // worker can pick up immediately (no attempt++).
+                return workerclient.Abandon()
+            }
+            // Transient failure — retry after 5s. Attempts++.
+            return workerclient.Nack(5, err.Error())
+        }
+
+        // Success. The result body is JSON-encoded and stored in
+        // KeyResult for the producer to fetch via GetResult.
+        return workerclient.Completed(map[string]any{
+            "orderId":   order.OrderID,
+            "processed": true,
+        })
+    }
+
+    if err := w.Run(ctx, handler); err != nil {
+        log.Printf("worker exited: %v", err)
+    }
+    log.Println("worker stopped")
+}
+
+func process(ctx context.Context, orderID string, amount float64) error {
+    // Your real logic here. Honor ctx so Abandon works on shutdown.
+    return nil
+}
+```
+
+Run:
+
+```bash
+CODEQ_WORKER_ADDR=localhost:9091 CODEQ_WORKER_TOKEN=dev-token go run ./worker
+```
+
+The handler signature is `func(ctx, Task) Result`. It runs on a slot
+goroutine inside the client; the client guarantees that the handler is
+invoked concurrently up to `Concurrency` times, so any shared state
+inside must be safe under that many goroutines.
+
+## 6. Result handling — when to use which
+
+The `Result` constructors live in
+[`pkg/workerclient/result.go`](../pkg/workerclient/result.go). Pick
+based on whether the failure is retriable and whether you want the
+attempt counter to advance:
+
+| Constructor | Semantics | Attempts++ | Use when |
+|---|---|---|---|
+| `Completed(body map[string]any)` | Terminal success. Body is JSON-encoded and stored in `KeyResult`. | n/a | Work is done. |
+| `Failed(reason string)` | Terminal failure. Counts toward `MaxAttempts`; past the limit the task goes to the DLQ. | yes | Bad payload, validation error, or any error you know retrying won't fix. |
+| `Nack(backoffSec int, reason string)` | Transient failure. Re-enqueued after `backoffSec`. | yes | Downstream 503, network blip, lock contention. |
+| `Abandon()` | Release the lease without success or failure. Another worker can claim it immediately. | no | Graceful shutdown mid-task — the next worker retries with the original attempt count. |
+
+The signature of `Completed` is `func Completed(body map[string]any) Result`
+— the body is encoded with sonic on send. Pass `nil` to record success
+without a payload.
+
+## 7. Concurrency, batching, lease tuning
+
+The three knobs that matter on the worker side:
+
+- **`Concurrency`** — number of in-flight tasks per worker process.
+  Each slot is a goroutine running the handler. With Go's runtime
+  scheduler a slot is cheap to keep idle, so over-provisioning is
+  fine; under-provisioning leaves throughput on the table because
+  every server-side claim has to wait for a free slot.
+- **`BatchSize > 1`** — slots send `Ready{count: BatchSize}` and the
+  server replies with up to N tasks in one `TaskBatch`. The slot then
+  invokes the handler N times sequentially and coalesces the results
+  into one `ResultBatch`. This amortises gRPC framing and Pebble
+  commit cost across the batch. It's a win for **high-throughput**
+  workloads where slots are always busy. For low-volume workloads
+  it's a loss because slots wait for the server to fill the batch
+  before returning anything (the server flushes partial batches once
+  it's drained the queue, so the floor is one task, but the upper
+  tail latency grows). `BatchSize=0` or `1` keeps the legacy
+  single-task path.
+- **`LeaseSeconds`** — must be strictly greater than your p99 handler
+  latency, with safety margin. Too short and a slow task gets
+  re-delivered to another worker while the first is still running
+  ("spurious requeue"). Too long and crash recovery is slow — the
+  server can't reclaim a dead worker's tasks until the lease expires.
+  A common starting point: `LeaseSeconds = 2 * p99_handler_seconds`,
+  then tune from there.
+
+On the producer side, `Session.Produce` is already concurrent-safe.
+The pattern is: open one `Session` at process startup, share it across
+all your HTTP/RPC handlers, and let the client's sequence-number
+multiplexer do the rest.
+
+## 8. Where the gRPC connections go
+
+```text
+┌──────────────────┐                              ┌──────────────────┐
+│ Producer process │── gRPC stream :9092 ────────▶│                  │
+│ (your Go binary) │◀──── CreateAck / Batch ──────│                  │
+└──────────────────┘                              │   codeq server   │
+                                                  │  (one process,   │
+┌──────────────────┐                              │   Pebble shards) │
+│ Worker process   │── gRPC stream :9091 ────────▶│                  │
+│ (your Go binary) │◀──── Task / TaskBatch ───────│                  │
+└──────────────────┘                              └──────────────────┘
+```
+
+The two streams are independent. Producer events never traverse the
+worker port and vice versa. The server splits them at the gRPC
+service boundary
+(`internal/producer/producerpb`, `internal/worker/workerpb`).
+
+## 9. Real-world patterns
+
+### HTTP service that enqueues tasks
+
+Open the `Session` at process startup and store it on a struct that
+your HTTP handlers can reach:
+
+```go
+type App struct {
+    Tasks *producerclient.Session
+}
+
+func (a *App) handleCreateOrder(w http.ResponseWriter, r *http.Request) {
+    payload, _ := json.Marshal(parsedOrder)
+    id, err := a.Tasks.Produce(r.Context(), producerclient.CreateRequest{
+        Command:        "PROCESS_ORDER",
+        Payload:        payload,
+        IdempotencyKey: parsedOrder.RequestID, // dedup retries
+    })
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusBadGateway)
+        return
+    }
+    fmt.Fprintln(w, id)
+}
+```
+
+The producer harness sustains 136,392 creates/s under this exact
+pattern with `ProduceBatch`
+(`internal/bench/producer_stream_vs_rest_test.go::TestProducerThroughput_StreamBatchPath`).
+
+### Background worker process
+
+Make `worker.Client.Run` the body of your `cmd/worker/main.go`. It
+blocks until the context is done, so wire it to signal handling and
+let your supervisor (systemd, Kubernetes) restart the process on
+exit:
+
+```go
+ctx, stop := signal.NotifyContext(context.Background(),
+    syscall.SIGINT, syscall.SIGTERM)
+defer stop()
+
+if err := w.Run(ctx, handler); err != nil {
+    log.Fatalf("worker: %v", err)
+}
+```
+
+### Graceful shutdown semantics
+
+When the parent context is cancelled, in-flight handler calls receive
+a cancelled `ctx`. Honor it: return `workerclient.Abandon()` to
+release the lease without incrementing attempts. The next worker
+picks the task up with no penalty. Without that, the lease lingers
+until `LeaseSeconds` expires and a slow shutdown looks like a small
+outage to the producer.
+
+## 10. Next steps
+
+- **Multi-tenant setup** — one queue server, many tenants:
+  [Multi-tenancy](./39-multi-tenancy.md).
+- **HTTP API** for non-Go callers or one-off probes:
+  [HTTP API](./04-http-api.md).
+- **Streaming SDK reference** for the wire-level protocol:
+  [Producer streaming SDK](./35-producer-streaming-sdk.md),
+  [Worker streaming SDK](./36-worker-streaming-sdk.md).
+- **Performance tuning** — shard count, batch sizes, lease policy:
+  [Performance tuning](./17-performance-tuning.md).
+- **Observability** — tracing, metrics, structured logs:
+  [Observability](./37-observability.md).
+
+## See also
+
+- [Usage examples](./13-examples.md) — short recipes by transport.
+- [Getting started](./00-getting-started.md) — single-node Pebble
+  bring-up.
+- [Domain model](./02-domain-model.md) — what a Task, lease, and DLQ
+  actually mean inside the server.
+- [`_STYLE.md` § Value proposition](./_STYLE.md#1-value-proposition).


### PR DESCRIPTION
## Summary

- Rewrites `docs/13-examples.md` to use the real CLI surface (`codeq install`, `codeq task create --event`, `codeq queue stats`, `codeq worker inspect`) and drops the bogus `codeq serve` / `codeq task claim` / `--command` references. Adds a `ProduceBatch` snippet and cites `pkg/producerclient/client.go` plus the bench harness for the throughput claim.
- Adds `docs/44-tutorial-go-sdk.md`: a full walkthrough that builds a producer + worker Go service against `pkg/producerclient` and `pkg/workerclient`. Covers result dispositions (`Completed` / `Failed` / `Nack` / `Abandon`), slot concurrency, `BatchSize` tradeoffs, lease tuning, and graceful shutdown.
- Trims the cross-link footer to the docs that actually exist (drops the dead `sdks/README.md` and `integrations/go-integration.md` links).

## Verification

- `go build ./...` clean.
- `go test -short ./...` clean (all packages pass).
- `producer/main.go` and `worker/main.go` from the tutorial compile unchanged against the live SDK in a temp module (`go build -buildvcs=false ./...` returns 0).
- Buzzword scan (`blazingly|production-ready|enterprise-grade|next-generation|cutting-edge|seamless|robust|powerful|amazing|world-class`) returns zero hits on both files.
- Positioning scan (`sdks/(java|python|nodejs)|kvrocks|legacy Redis|Redis primary`) returns zero hits.
- All cross-linked docs (`00`, `02`, `04`, `09`, `10`, `14`, `15`, `17`, `35`, `36`, `37`, `39`, `40`, `_STYLE.md`) verified to exist.

## Test plan

- [ ] Render `docs/13-examples.md` and `docs/44-tutorial-go-sdk.md` on GitHub; confirm code-fence highlighting and Mermaid (n/a here — ASCII diagram used).
- [ ] Spot-check the tutorial against the SDK source comments (`pkg/producerclient/client.go:104-131`, `pkg/producerclient/client.go:355-421`, `pkg/workerclient/result.go`).
- [ ] Run the tutorial end-to-end against a local codeq server: `go run ./producer` enqueues, `go run ./worker` claims and completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)