### PR TITLE
feat(install): default to GHCR images + binary install mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,18 +172,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.vars.outputs.version }}
 
-      - name: Ensure package is public (best-effort)
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GHCR_ADMIN_TOKEN }}
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "Skipping: secret GHCR_ADMIN_TOKEN is not set."
-            echo "To auto-publish ghcr.io/${IMAGE_NAME,,} as public, create a PAT with admin:packages and store it as GHCR_ADMIN_TOKEN."
-            exit 0
-          fi
-          gh api -X PATCH \
-            "/user/packages/container/codeq-service" \
-            -f visibility=public
+      # Package visibility is a one-time setting per package, not per release.
+      # After the first push, set it via:
+      #   https://github.com/users/<owner>/packages/container/codeq-service/settings
+      # → "Danger Zone" → "Change package visibility" → Public.
+      # The setting persists across all subsequent pushes.

--- a/deploy/docker-compose/cluster/compose.yaml
+++ b/deploy/docker-compose/cluster/compose.yaml
@@ -17,7 +17,7 @@ name: codeq-cluster
 
 services:
   node-a:
-    image: ${CODEQ_IMAGE:-codeq-service:cluster}
+    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:latest}
     container_name: codeq-cluster-node-a
     hostname: node-a
     restart: unless-stopped
@@ -58,7 +58,7 @@ services:
       - cluster
 
   node-b:
-    image: ${CODEQ_IMAGE:-codeq-service:cluster}
+    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:latest}
     container_name: codeq-cluster-node-b
     hostname: node-b
     restart: unless-stopped
@@ -99,7 +99,7 @@ services:
       - cluster
 
   node-c:
-    image: ${CODEQ_IMAGE:-codeq-service:cluster}
+    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:latest}
     container_name: codeq-cluster-node-c
     hostname: node-c
     restart: unless-stopped

--- a/deploy/docker-compose/production/compose.yaml
+++ b/deploy/docker-compose/production/compose.yaml
@@ -2,7 +2,7 @@ name: codeq
 
 services:
   codeq:
-    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:0.1.0}
+    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:latest}
     ports:
       - "${CODEQ_PORT:-8080}:8080"
     environment:

--- a/deploy/docker-compose/raft-cluster/README.md
+++ b/deploy/docker-compose/raft-cluster/README.md
@@ -21,12 +21,15 @@ limitations.
 ## Quick start
 
 ```bash
-# Build the image once (any image with codeq compiled in works).
-docker build -f deploy/docker-compose/cluster/Dockerfile -t codeq-service:cluster .
-
-# Bring the cluster up. node-a bootstraps; node-b and node-c join via
-# raft replication of the initial configuration.
+# Bring the cluster up. The compose file defaults to
+# ghcr.io/osvaldoandrade/codeq-service:latest, pulled automatically.
+# node-a bootstraps; node-b and node-c join via raft replication of
+# the initial configuration.
 docker compose -f deploy/docker-compose/raft-cluster/compose.yaml up -d
+
+# To run against a locally-built image instead:
+#   docker build -f deploy/docker-compose/cluster/Dockerfile -t codeq-service:local .
+#   CODEQ_IMAGE=codeq-service:local docker compose -f ... up -d
 
 # All three nodes are reachable:
 curl -s http://localhost:8080/v1/codeq/raft/status | jq .   # node-a

--- a/deploy/docker-compose/raft-cluster/README.md
+++ b/deploy/docker-compose/raft-cluster/README.md
@@ -31,6 +31,13 @@ docker compose -f deploy/docker-compose/raft-cluster/compose.yaml up -d
 #   docker build -f deploy/docker-compose/cluster/Dockerfile -t codeq-service:local .
 #   CODEQ_IMAGE=codeq-service:local docker compose -f ... up -d
 
+# If the pull fails with "denied" or "manifest unknown", the GHCR
+# package is still private. Either authenticate first:
+#   echo "$GHCR_TOKEN" | docker login ghcr.io -u <user> --password-stdin
+# Or flip the package to public (one-time, persists across releases):
+#   https://github.com/users/osvaldoandrade/packages/container/codeq-service/settings
+#   → "Danger Zone" → "Change package visibility" → Public.
+
 # All three nodes are reachable:
 curl -s http://localhost:8080/v1/codeq/raft/status | jq .   # node-a
 curl -s http://localhost:8081/v1/codeq/raft/status | jq .   # node-b

--- a/deploy/docker-compose/raft-cluster/compose.yaml
+++ b/deploy/docker-compose/raft-cluster/compose.yaml
@@ -24,7 +24,7 @@ name: codeq-raft
 
 services:
   node-a:
-    image: ${CODEQ_IMAGE:-codeq-service:cluster}
+    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:latest}
     container_name: codeq-raft-node-a
     hostname: node-a
     restart: unless-stopped
@@ -80,7 +80,7 @@ services:
       - raft
 
   node-b:
-    image: ${CODEQ_IMAGE:-codeq-service:cluster}
+    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:latest}
     container_name: codeq-raft-node-b
     hostname: node-b
     restart: unless-stopped
@@ -103,7 +103,7 @@ services:
         condition: service_started
 
   node-c:
-    image: ${CODEQ_IMAGE:-codeq-service:cluster}
+    image: ${CODEQ_IMAGE:-ghcr.io/osvaldoandrade/codeq-service:latest}
     container_name: codeq-raft-node-c
     hostname: node-c
     restart: unless-stopped

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env sh
 set -eu
 
-# codeq install script (builds from git and installs into a PATH directory)
+# codeq install script
+#
+# Default behavior: download a pre-built binary from GitHub Releases.
+# Fallback: clone the repository and `go build`.
 #
 # Usage (typical):
-#   curl -fsSL https://<host>/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/osvaldoandrade/codeq/main/install.sh | sh
 #
 # Overrides:
-#   CODEQ_INSTALL_REPO=https://github.com/osvaldoandrade/codeq.git
-#   CODEQ_INSTALL_REF=main|vX.Y.Z|<sha>
-#   CODEQ_INSTALL_DIR=/custom/bin
+#   CODEQ_INSTALL_MODE=auto|binary|source   # default: auto (binary, fall back to source)
+#   CODEQ_INSTALL_REPO=osvaldoandrade/codeq # owner/repo on github.com
+#   CODEQ_INSTALL_REF=vX.Y.Z|latest         # release tag (binary mode) or git ref (source mode)
+#   CODEQ_INSTALL_DIR=/custom/bin           # destination directory
+#   CODEQ_GITHUB_TOKEN=<pat>                # optional, raises GitHub API rate limit
+#   CODEQ_INSTALL_NO_PROFILE=1              # skip shell-profile PATH updates
+
+repo="${CODEQ_INSTALL_REPO:-osvaldoandrade/codeq}"
+ref="${CODEQ_INSTALL_REF:-latest}"
+mode="${CODEQ_INSTALL_MODE:-auto}"
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -18,8 +28,12 @@ need_cmd() {
   fi
 }
 
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
 mktemp_dir() {
-  if command -v mktemp >/dev/null 2>&1; then
+  if have_cmd mktemp; then
     mktemp -d 2>/dev/null && return 0
     mktemp -d -t codeq-install 2>/dev/null && return 0
     mktemp -d "${TMPDIR:-/tmp}/codeq-install.XXXXXX" 2>/dev/null && return 0
@@ -29,12 +43,29 @@ mktemp_dir() {
   echo "$dir"
 }
 
-detect_exe_suffix() {
-  os="$(uname -s 2>/dev/null || echo unknown)"
-  case "$os" in
-    MINGW*|MSYS*|CYGWIN*) echo ".exe" ;;
+detect_os() {
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux*)   echo "linux" ;;
+    Darwin*)  echo "darwin" ;;
+    MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+    *)        echo "" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m 2>/dev/null || echo unknown)" in
+    x86_64|amd64) echo "amd64" ;;
+    aarch64|arm64) echo "arm64" ;;
     *) echo "" ;;
   esac
+}
+
+detect_exe_suffix() {
+  if [ "$(detect_os)" = "windows" ]; then
+    echo ".exe"
+  else
+    echo ""
+  fi
 }
 
 detect_install_dir() {
@@ -43,7 +74,7 @@ detect_install_dir() {
     return 0
   fi
 
-  # Prefer a writable directory that is already in PATH.
+  # Prefer a writable directory already in PATH.
   old_ifs="$IFS"
   IFS=":"
   for d in $PATH; do
@@ -55,7 +86,6 @@ detect_install_dir() {
   done
   IFS="$old_ifs"
 
-  # Fallback to standard user-local bin dirs.
   if [ -n "${HOME:-}" ]; then
     if [ -d "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
       if [ -w "$HOME/.local/bin" ]; then
@@ -71,7 +101,6 @@ detect_install_dir() {
     fi
   fi
 
-  # Fallback for macOS/Linux when user-local dirs aren't writable.
   if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
     echo "/usr/local/bin"
     return 0
@@ -84,14 +113,11 @@ append_path_line() {
   file="$1"
   dir="$2"
   line="export PATH=\"$dir:\$PATH\""
-
-  # If grep isn't available, just append.
-  if command -v grep >/dev/null 2>&1; then
+  if have_cmd grep; then
     if [ -f "$file" ] && grep -F "$dir" "$file" >/dev/null 2>&1; then
       return 0
     fi
   fi
-
   mkdir -p "$(dirname "$file")" >/dev/null 2>&1 || true
   {
     echo ""
@@ -100,67 +126,202 @@ append_path_line() {
   } >>"$file"
 }
 
-need_cmd git
-need_cmd go
+# Download a URL to a file. Uses curl if available, otherwise wget.
+# Adds GitHub bearer auth when CODEQ_GITHUB_TOKEN or GITHUB_TOKEN is set.
+http_download() {
+  url="$1"
+  dest="$2"
+  accept="${3:-}"
 
-repo="${CODEQ_INSTALL_REPO:-https://github.com/osvaldoandrade/codeq.git}"
-ref="${CODEQ_INSTALL_REF:-}"
-exe_suffix="$(detect_exe_suffix)"
+  tok="${CODEQ_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
 
-tmp="$(mktemp_dir)"
-cleanup() {
-  rm -rf "$tmp" >/dev/null 2>&1 || true
+  if have_cmd curl; then
+    set -- curl -fsSL -o "$dest" \
+      -H "User-Agent: codeq-install-sh"
+    if [ -n "$accept" ]; then
+      set -- "$@" -H "Accept: $accept"
+    fi
+    if [ -n "$tok" ]; then
+      set -- "$@" -H "Authorization: Bearer $tok"
+    fi
+    set -- "$@" "$url"
+    "$@"
+    return $?
+  fi
+
+  if have_cmd wget; then
+    set -- wget -q -O "$dest" \
+      --header="User-Agent: codeq-install-sh"
+    if [ -n "$accept" ]; then
+      set -- "$@" --header="Accept: $accept"
+    fi
+    if [ -n "$tok" ]; then
+      set -- "$@" --header="Authorization: Bearer $tok"
+    fi
+    set -- "$@" "$url"
+    "$@"
+    return $?
+  fi
+
+  echo "[codeq] error: neither curl nor wget is available" >&2
+  return 1
 }
-trap cleanup EXIT INT TERM
 
-echo "[codeq] cloning: $repo"
-git clone --quiet --depth 1 "$repo" "$tmp/repo"
+# Resolve a release tag from "latest" (or pass through a pinned tag).
+resolve_release_tag() {
+  given="$1"
+  if [ "$given" != "latest" ] && [ -n "$given" ]; then
+    echo "$given"
+    return 0
+  fi
 
-if [ -n "$ref" ]; then
-  echo "[codeq] checking out: $ref"
-  (
-    cd "$tmp/repo"
-    # For tags/branches this works with a shallow clone; for SHAs it may require a fetch.
-    git fetch --quiet --depth 1 origin "$ref" 2>/dev/null || true
-    git checkout --quiet "$ref"
-  )
-fi
+  tmpjson="$(mktemp_dir)/release.json"
+  if ! http_download \
+      "https://api.github.com/repos/${repo}/releases/latest" \
+      "$tmpjson" \
+      "application/vnd.github+json"; then
+    return 1
+  fi
 
-echo "[codeq] building"
-out="$tmp/codeq${exe_suffix}"
-(cd "$tmp/repo" && go build -o "$out" ./cmd/codeq)
+  # Extract tag_name without requiring jq. Match the first occurrence.
+  if have_cmd sed; then
+    tag="$(sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' "$tmpjson" | head -n 1)"
+    if [ -n "$tag" ]; then
+      echo "$tag"
+      return 0
+    fi
+  fi
+  return 1
+}
 
-install_dir="$(detect_install_dir)"
-mkdir -p "$install_dir"
-dest="$install_dir/codeq${exe_suffix}"
+install_from_binary() {
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  exe="$(detect_exe_suffix)"
 
-echo "[codeq] installing to: $dest"
-if command -v install >/dev/null 2>&1; then
-  install -m 0755 "$out" "$dest"
-else
-  cp "$out" "$dest"
-  chmod 0755 "$dest" >/dev/null 2>&1 || true
-fi
+  if [ -z "$os" ] || [ -z "$arch" ]; then
+    echo "[codeq] binary mode: unsupported platform (os='$os' arch='$arch')" >&2
+    return 1
+  fi
+
+  echo "[codeq] resolving release: ${ref}"
+  tag="$(resolve_release_tag "$ref")" || {
+    echo "[codeq] could not resolve release tag '$ref'" >&2
+    return 1
+  }
+  echo "[codeq] release: ${tag}"
+
+  asset="codeq-${os}-${arch}${exe}"
+  url="https://github.com/${repo}/releases/download/${tag}/${asset}"
+
+  tmp="$(mktemp_dir)"
+  tmpfile="$tmp/${asset}"
+  echo "[codeq] downloading: ${url}"
+  if ! http_download "$url" "$tmpfile" "application/octet-stream"; then
+    rm -rf "$tmp" >/dev/null 2>&1 || true
+    echo "[codeq] binary download failed" >&2
+    return 1
+  fi
+
+  install_dir="$(detect_install_dir)"
+  mkdir -p "$install_dir"
+  dest="$install_dir/codeq${exe}"
+  echo "[codeq] installing to: $dest"
+  if have_cmd install; then
+    install -m 0755 "$tmpfile" "$dest"
+  else
+    cp "$tmpfile" "$dest"
+    chmod 0755 "$dest" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp" >/dev/null 2>&1 || true
+  CODEQ_INSTALL_FINAL_DIR="$install_dir"
+  return 0
+}
+
+install_from_source() {
+  need_cmd git
+  need_cmd go
+
+  exe="$(detect_exe_suffix)"
+  tmp="$(mktemp_dir)"
+  trap_cleanup_tmp="$tmp"
+
+  clone_url="https://github.com/${repo}.git"
+  echo "[codeq] cloning: $clone_url"
+  git clone --quiet --depth 1 "$clone_url" "$tmp/repo"
+
+  if [ -n "$ref" ] && [ "$ref" != "latest" ]; then
+    echo "[codeq] checking out: $ref"
+    (
+      cd "$tmp/repo"
+      git fetch --quiet --depth 1 origin "$ref" 2>/dev/null || true
+      git checkout --quiet "$ref"
+    )
+  fi
+
+  echo "[codeq] building"
+  out="$tmp/codeq${exe}"
+  (cd "$tmp/repo" && go build -o "$out" ./cmd/codeq)
+
+  install_dir="$(detect_install_dir)"
+  mkdir -p "$install_dir"
+  dest="$install_dir/codeq${exe}"
+
+  echo "[codeq] installing to: $dest"
+  if have_cmd install; then
+    install -m 0755 "$out" "$dest"
+  else
+    cp "$out" "$dest"
+    chmod 0755 "$dest" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp" >/dev/null 2>&1 || true
+  CODEQ_INSTALL_FINAL_DIR="$install_dir"
+  return 0
+}
+
+case "$mode" in
+  auto)
+    if install_from_binary; then
+      :
+    else
+      echo "[codeq] falling back to source build"
+      install_from_source
+    fi
+    ;;
+  binary)
+    install_from_binary || exit 1
+    ;;
+  source)
+    install_from_source
+    ;;
+  *)
+    echo "[codeq] error: CODEQ_INSTALL_MODE must be one of: auto, binary, source (got '$mode')" >&2
+    exit 1
+    ;;
+esac
+
+install_dir="${CODEQ_INSTALL_FINAL_DIR:-}"
 
 case ":$PATH:" in
   *":$install_dir:"*) : ;;
   *)
-    echo "[codeq] note: '$install_dir' is not in PATH for this shell."
-    if [ "${CODEQ_INSTALL_NO_PROFILE:-}" != "1" ] && [ -n "${HOME:-}" ]; then
-      shell_name="$(basename "${SHELL:-}")"
-      # Ensure new shells pick it up.
-      append_path_line "$HOME/.profile" "$install_dir"
-      if [ "$shell_name" = "zsh" ]; then
-        append_path_line "$HOME/.zprofile" "$install_dir"
+    if [ -n "$install_dir" ]; then
+      echo "[codeq] note: '$install_dir' is not in PATH for this shell."
+      if [ "${CODEQ_INSTALL_NO_PROFILE:-}" != "1" ] && [ -n "${HOME:-}" ]; then
+        shell_name="$(basename "${SHELL:-}")"
+        append_path_line "$HOME/.profile" "$install_dir"
+        if [ "$shell_name" = "zsh" ]; then
+          append_path_line "$HOME/.zprofile" "$install_dir"
+        fi
+        if [ "$shell_name" = "bash" ]; then
+          append_path_line "$HOME/.bashrc" "$install_dir"
+          append_path_line "$HOME/.bash_profile" "$install_dir"
+        fi
+        echo "[codeq] updated your shell profile(s). Open a new terminal or run:"
+        echo "  export PATH=\"$install_dir:\$PATH\""
+      else
+        echo "[codeq] add it (bash/zsh): export PATH=\"$install_dir:\$PATH\""
       fi
-      if [ "$shell_name" = "bash" ]; then
-        append_path_line "$HOME/.bashrc" "$install_dir"
-        append_path_line "$HOME/.bash_profile" "$install_dir"
-      fi
-      echo "[codeq] updated your shell profile(s). Open a new terminal or run:"
-      echo "  export PATH=\"$install_dir:\$PATH\""
-    else
-      echo "[codeq] add it (bash/zsh): export PATH=\"$install_dir:\$PATH\""
     fi
     ;;
 esac


### PR DESCRIPTION
## Summary

- Compose templates (`cluster`, `raft-cluster`, `production`) default to `ghcr.io/osvaldoandrade/codeq-service:latest`. `docker compose up -d` pulls automatically.
- `install.sh` gains a binary install mode that downloads pre-built artifacts from GitHub Releases. New `CODEQ_INSTALL_MODE=auto|binary|source` env var; default `auto` (binary, source fallback).
- Release workflow's dead-code "ensure package is public" step removed (it required `admin:packages` PAT, unavailable on many Enterprise setups). Replaced with a comment pointing to the one-time UI flip.

## Why

Before: only `npm install -g @osvaldoandrade/codeq` worked end-to-end. `curl install.sh | sh` required `git` + `go` on host. Compose templates demanded a local `docker build`. The GHCR image was being published but nothing consumed it.

After: three install paths and zero local-build requirements.

## One-time manual step

GHCR package starts private. To enable anonymous `docker pull`:

```
https://github.com/users/osvaldoandrade/packages/container/codeq-service/settings
→ Danger Zone → Change package visibility → Public
```

This is **per-package, not per-version** — flip once, all future releases inherit. No PAT or workflow secret needed.

If you'd rather keep it private and authenticate: `docker login ghcr.io` before `docker compose up` (compose README documents this).

## Test plan

- [x] `sh -n install.sh` passes
- [x] All four compose templates parse as valid YAML
- [x] `release.yml` parses cleanly after the step removal
- [x] `go build ./...` clean
- [ ] Manual e2e after the visibility flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
