### PR TITLE
fix: honor the canonical tenant tid claim

### DIFF
--- a/internal/middleware/tenant.go
+++ b/internal/middleware/tenant.go
@@ -25,7 +25,9 @@ func extractTenantID(claims *auth.Claims) string {
 
 	// Try multiple common claim names for tenant ID
 	tenantID := ""
-	if v, ok := claims.Raw["tenantId"].(string); ok {
+	if v, ok := claims.Raw["tid"].(string); ok {
+		tenantID = strings.TrimSpace(v)
+	} else if v, ok := claims.Raw["tenantId"].(string); ok {
 		tenantID = strings.TrimSpace(v)
 	} else if v, ok := claims.Raw["tenant_id"].(string); ok {
 		tenantID = strings.TrimSpace(v)

--- a/internal/middleware/tenant_test.go
+++ b/internal/middleware/tenant_test.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/osvaldoandrade/codeq/pkg/auth"
+)
+
+func TestExtractTenantID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		claims *auth.Claims
+		want   string
+	}{
+		{name: "nil claims", claims: nil, want: ""},
+		{name: "canonical tid", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": " payments "}}, want: "payments"},
+		{name: "tid has precedence", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": "payments", "tenantId": "identity"}}, want: "payments"},
+		{name: "firebase tenantId", claims: &auth.Claims{Raw: map[string]interface{}{"tenantId": "identity"}}, want: "identity"},
+		{name: "snake case tenant", claims: &auth.Claims{Raw: map[string]interface{}{"tenant_id": "analytics"}}, want: "analytics"},
+		{name: "organization", claims: &auth.Claims{Raw: map[string]interface{}{"organizationId": "platform"}}, want: "platform"},
+		{name: "subject fallback", claims: &auth.Claims{Subject: "single-tenant", Raw: map[string]interface{}{}}, want: "single-tenant"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := extractTenantID(test.claims); got != test.want {
+				t.Fatalf("extractTenantID() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Resolve the canonical Tikti tid claim before legacy tenant claim aliases.
- Preserve support for tenantId, tenant_id, organization claims, and the single-tenant subject fallback.
- Cover tenant resolution and precedence with table-driven tests.

## Why

Code Admin defines token.tid as the authoritative tenant context. codeQ previously ignored that claim and could fall back to the token subject, placing tasks in the wrong tenant partition.

## Related implementation

- https://github.com/codecompany/code-admin-api/pull/42

## Validation

- go test -race ./internal/middleware
- git diff --check

The repository-wide suite was also executed. Its high-concurrency benchmark and E2E packages exhausted local ephemeral ports with connect: cant assign requested address; the middleware package and changed contract tests pass.