### PR TITLE
feat: add tenant-scoped topic administration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ node_modules/
 dist/
 coverage/
 build-steps.log
-codeq
-server
+/codeq
+/server

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ tools-sec: $(TOOL_BIN)/govulncheck $(TOOL_BIN)/gosec
 $(TOOL_BIN)/golangci-lint:
 	@mkdir -p $(TOOL_BIN)
 	GOBIN=$(TOOL_BIN) $(GO) install \
-		github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+		github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(TOOL_BIN)/gofumpt:
 	@mkdir -p $(TOOL_BIN)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,29 @@ curl -X POST http://localhost:8080/v1/codeq/tasks/<id>/result \
   -d '{"status":"COMPLETED","result":{"ok":true}}'
 ```
 
+### Queue topic administration
+
+An authenticated admin can reconcile the provider policy for a tenant-scoped
+topic. The tenant comes only from the validated token; codeq stores the physical
+identifier as `<tenant>.<topicName>`.
+
+```bash
+curl -X PUT http://localhost:8080/v1/codeq/admin/topics/payments-events \
+  -H 'Authorization: Bearer <admin-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"priorityTiers":[1,3,5],"maxAttempts":5,"deadLetterTopicRef":"payments-events-dlq","retentionSeconds":604800,"maxConsumers":20}'
+```
+
+`PUT` is idempotent: the first write returns `201`, an identical replay returns
+`200` without changing the version, and a policy update increments the version.
+`GET /v1/codeq/admin/topics/{topicName}` reads the stored policy. Destructive
+removal requires `DELETE ...?deletionPolicy=Delete`; omitting the explicit
+policy returns `400`.
+
+This first administration path is durable with the Redis persistence mode.
+Pebble and Pebble/Raft return `503` until topic catalog writes participate in
+the replicated log; codeq does not accept an unreplicated control-plane state.
+
 For high-throughput producers and workers, use the gRPC streaming API — a
 long-lived bidirectional stream amortizes auth and pipelines acks. See the
 [Producer Stream](https://github.com/osvaldoandrade/codeq/wiki/IO-Producer-Stream)

--- a/internal/application/topics/service.go
+++ b/internal/application/topics/service.go
@@ -1,0 +1,56 @@
+// Package topics implements QueueTopic administration use cases.
+package topics
+
+import (
+	"context"
+	"time"
+
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
+)
+
+// Store is the consumer-owned persistence boundary for QueueTopic policies.
+type Store interface {
+	Upsert(context.Context, queuetopic.Topic) (topic queuetopic.Topic, created bool, changed bool, err error)
+	Get(context.Context, string, string) (queuetopic.Topic, error)
+	Delete(context.Context, string, string) error
+}
+
+// Service coordinates validation and persistence without transport concerns.
+type Service struct {
+	store Store
+	now   func() time.Time
+}
+
+// NewService builds a topic administration service.
+func NewService(store Store, now func() time.Time) *Service {
+	if now == nil {
+		now = time.Now
+	}
+	return &Service{store: store, now: now}
+}
+
+// Upsert creates or reconciles a topic policy idempotently.
+func (s *Service) Upsert(ctx context.Context, tenantID, topicName string, policy queuetopic.Policy) (queuetopic.Topic, bool, bool, error) {
+	desired, err := queuetopic.New(tenantID, topicName, policy, s.now())
+	if err != nil {
+		return queuetopic.Topic{}, false, false, err
+	}
+	return s.store.Upsert(ctx, desired)
+}
+
+// Get returns a tenant-scoped topic.
+func (s *Service) Get(ctx context.Context, tenantID, topicName string) (queuetopic.Topic, error) {
+	if err := queuetopic.ValidateIdentity(tenantID, topicName); err != nil {
+		return queuetopic.Topic{}, err
+	}
+	return s.store.Get(ctx, tenantID, topicName)
+}
+
+// Delete removes the provider catalog entry. The HTTP boundary requires an
+// explicit deletion policy before this method is called.
+func (s *Service) Delete(ctx context.Context, tenantID, topicName string) error {
+	if err := queuetopic.ValidateIdentity(tenantID, topicName); err != nil {
+		return err
+	}
+	return s.store.Delete(ctx, tenantID, topicName)
+}

--- a/internal/application/topics/service_test.go
+++ b/internal/application/topics/service_test.go
@@ -1,0 +1,104 @@
+package topics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
+)
+
+const testDeadLetterTopic = "events-dlq"
+
+type fakeStore struct {
+	topic   queuetopic.Topic
+	err     error
+	created bool
+	changed bool
+}
+
+func (s *fakeStore) Upsert(_ context.Context, topic queuetopic.Topic) (queuetopic.Topic, bool, bool, error) {
+	s.topic = topic
+	return topic, s.created, s.changed, s.err
+}
+
+func (s *fakeStore) Get(_ context.Context, tenantID, topicName string) (queuetopic.Topic, error) {
+	if s.err != nil {
+		return queuetopic.Topic{}, s.err
+	}
+	return queuetopic.Topic{TenantID: tenantID, TopicName: topicName}, nil
+}
+
+func (s *fakeStore) Delete(_ context.Context, tenantID, topicName string) error {
+	s.topic = queuetopic.Topic{TenantID: tenantID, TopicName: topicName}
+	return s.err
+}
+
+func TestServiceUseCases(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{created: true}
+	service := NewService(store, func() time.Time { return now })
+	policy := queuetopic.Policy{PriorityTiers: []int{3, 1}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetterTopic}
+
+	topic, created, changed, err := service.Upsert(context.Background(), "payments", "events", policy)
+	if err != nil || !created || changed || topic.TopicID != "payments.events" {
+		t.Fatalf("Upsert() = %#v, %t, %t, %v", topic, created, changed, err)
+	}
+	if _, _, _, err := service.Upsert(context.Background(), "bad tenant", "events", policy); err == nil {
+		t.Fatal("Upsert() accepted invalid tenant")
+	}
+
+	got, err := service.Get(context.Background(), "payments", "events")
+	if err != nil || got.TopicName != "events" {
+		t.Fatalf("Get() = %#v, %v", got, err)
+	}
+	if _, err := service.Get(context.Background(), "payments", "bad.topic"); err == nil {
+		t.Fatal("Get() accepted invalid topic")
+	}
+	if _, err := service.Get(context.Background(), "payments", "validation-dlq"); err != nil {
+		t.Fatalf("Get(validation-dlq) error = %v", err)
+	}
+
+	if err := service.Delete(context.Background(), "payments", "events"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if store.topic.TopicName != "events" {
+		t.Fatalf("Delete() topic = %#v", store.topic)
+	}
+	if err := service.Delete(context.Background(), "payments", "bad.topic"); err == nil {
+		t.Fatal("Delete() accepted invalid topic")
+	}
+}
+
+func TestServicePropagatesStoreErrors(t *testing.T) {
+	want := errors.New("storage failed")
+	store := &fakeStore{err: want}
+	service := NewService(store, nil)
+	policy := queuetopic.Policy{PriorityTiers: []int{0}, MaxAttempts: 1, DeadLetterTopicRef: testDeadLetterTopic}
+
+	if _, _, _, err := service.Upsert(context.Background(), "payments", "events", policy); !errors.Is(err, want) {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if _, err := service.Get(context.Background(), "payments", "events"); !errors.Is(err, want) {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if err := service.Delete(context.Background(), "payments", "events"); !errors.Is(err, want) {
+		t.Fatalf("Delete() error = %v", err)
+	}
+}
+
+func TestUnavailableServiceFailsClosed(t *testing.T) {
+	service := NewUnavailableService("raft replication unavailable")
+	policy := queuetopic.Policy{PriorityTiers: []int{0}, MaxAttempts: 1, DeadLetterTopicRef: testDeadLetterTopic}
+
+	_, _, _, upsertErr := service.Upsert(context.Background(), "payments", "events", policy)
+	_, getErr := service.Get(context.Background(), "payments", "events")
+	deleteErr := service.Delete(context.Background(), "payments", "events")
+	for _, err := range []error{upsertErr, getErr, deleteErr} {
+		var unavailable *queuetopic.UnavailableError
+		if !errors.As(err, &unavailable) {
+			t.Fatalf("error = %v, want UnavailableError", err)
+		}
+	}
+}

--- a/internal/application/topics/unavailable.go
+++ b/internal/application/topics/unavailable.go
@@ -1,0 +1,32 @@
+package topics
+
+import (
+	"context"
+
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
+)
+
+type unavailableStore struct {
+	reason string
+}
+
+// NewUnavailableService returns a service that fails closed for storage modes
+// where topic writes are not replicated safely.
+func NewUnavailableService(reason string) *Service {
+	return NewService(&unavailableStore{reason: reason}, nil)
+}
+
+// Upsert fails closed because this store has no safe persistence path.
+func (s *unavailableStore) Upsert(context.Context, queuetopic.Topic) (queuetopic.Topic, bool, bool, error) {
+	return queuetopic.Topic{}, false, false, &queuetopic.UnavailableError{Reason: s.reason}
+}
+
+// Get fails closed because this store has no safe persistence path.
+func (s *unavailableStore) Get(context.Context, string, string) (queuetopic.Topic, error) {
+	return queuetopic.Topic{}, &queuetopic.UnavailableError{Reason: s.reason}
+}
+
+// Delete fails closed because this store has no safe persistence path.
+func (s *unavailableStore) Delete(context.Context, string, string) error {
+	return &queuetopic.UnavailableError{Reason: s.reason}
+}

--- a/internal/core/queuetopic/errors.go
+++ b/internal/core/queuetopic/errors.go
@@ -1,0 +1,40 @@
+package queuetopic
+
+import "fmt"
+
+// ValidationError reports a field-level contract violation.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("invalid %s: %s", e.Field, e.Message)
+}
+
+// NotFoundError reports that a tenant-scoped topic does not exist.
+type NotFoundError struct {
+	TopicID string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("queue topic %q not found", e.TopicID)
+}
+
+// ConflictError reports that a concurrent write could not be resolved safely.
+type ConflictError struct {
+	TopicID string
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("queue topic %q changed concurrently", e.TopicID)
+}
+
+// UnavailableError reports a storage mode that cannot safely persist topics.
+type UnavailableError struct {
+	Reason string
+}
+
+func (e *UnavailableError) Error() string {
+	return "queue topic administration unavailable: " + e.Reason
+}

--- a/internal/core/queuetopic/topic.go
+++ b/internal/core/queuetopic/topic.go
@@ -1,0 +1,147 @@
+// Package queuetopic owns the tenant-scoped queue topic policy.
+package queuetopic
+
+import (
+	"regexp"
+	"slices"
+	"time"
+)
+
+const (
+	maxAttempts        = 100
+	maxConsumers       = 10000
+	maxPriority        = 10
+	maxPriorityTiers   = 10
+	maxRetentionSecond = 2147483647
+	fieldDeadLetter    = "deadLetterTopicRef"
+	fieldMaxAttempts   = "maxAttempts"
+	fieldMaxConsumers  = "maxConsumers"
+	fieldPriorityTiers = "priorityTiers"
+	fieldRetention     = "retentionSeconds"
+	fieldTopicName     = "topicName"
+)
+
+var (
+	tenantPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{1,62}$`)
+	namePattern   = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+)
+
+// Policy is the provider contract stored for a QueueTopic.
+type Policy struct {
+	PriorityTiers      []int  `json:"priorityTiers"`
+	MaxAttempts        int    `json:"maxAttempts"`
+	DeadLetterTopicRef string `json:"deadLetterTopicRef"`
+	RetentionSeconds   int    `json:"retentionSeconds,omitempty"`
+	MaxConsumers       int    `json:"maxConsumers,omitempty"`
+}
+
+// Topic is a persisted, tenant-scoped QueueTopic realization.
+type Topic struct {
+	TopicID   string    `json:"topicId"`
+	TenantID  string    `json:"tenantId"`
+	TopicName string    `json:"topicName"`
+	Policy    Policy    `json:"policy"`
+	Version   int64     `json:"version"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// New validates and normalizes a desired topic.
+func New(tenantID, topicName string, policy Policy, now time.Time) (Topic, error) {
+	if err := ValidateIdentity(tenantID, topicName); err != nil {
+		return Topic{}, err
+	}
+	if err := validatePolicy(topicName, policy); err != nil {
+		return Topic{}, err
+	}
+
+	normalized := policy
+	normalized.PriorityTiers = slices.Clone(policy.PriorityTiers)
+	slices.Sort(normalized.PriorityTiers)
+
+	return Topic{
+		TopicID:   PhysicalID(tenantID, topicName),
+		TenantID:  tenantID,
+		TopicName: topicName,
+		Policy:    normalized,
+		CreatedAt: now.UTC(),
+		UpdatedAt: now.UTC(),
+	}, nil
+}
+
+// PhysicalID returns the provider identifier. Tenant ownership is never read
+// from the request body; it is supplied by the authenticated request context.
+func PhysicalID(tenantID, topicName string) string {
+	return tenantID + "." + topicName
+}
+
+// SamePolicy reports semantic equality after New has normalized the priorities.
+func SamePolicy(left, right Policy) bool {
+	return left.MaxAttempts == right.MaxAttempts &&
+		left.DeadLetterTopicRef == right.DeadLetterTopicRef &&
+		left.RetentionSeconds == right.RetentionSeconds &&
+		left.MaxConsumers == right.MaxConsumers &&
+		slices.Equal(left.PriorityTiers, right.PriorityTiers)
+}
+
+// ValidateIdentity checks the tenant and logical provider name without
+// requiring a policy payload.
+func ValidateIdentity(tenantID, topicName string) error {
+	if !tenantPattern.MatchString(tenantID) {
+		return &ValidationError{Field: "tenantId", Message: "must match ^[a-z][a-z0-9-]{1,62}$"}
+	}
+	if len(topicName) > 63 || !namePattern.MatchString(topicName) {
+		return &ValidationError{Field: fieldTopicName, Message: "must be a DNS label with at most 63 characters"}
+	}
+	return nil
+}
+
+func validatePolicy(topicName string, policy Policy) error {
+	if err := validatePriorities(policy.PriorityTiers); err != nil {
+		return err
+	}
+	if err := validateRetryAndDLQ(topicName, policy); err != nil {
+		return err
+	}
+	return validateLimits(policy)
+}
+
+func validatePriorities(priorities []int) error {
+	if len(priorities) == 0 || len(priorities) > maxPriorityTiers {
+		return &ValidationError{Field: fieldPriorityTiers, Message: "must contain between 1 and 10 priorities"}
+	}
+	seen := make(map[int]struct{}, len(priorities))
+	for _, priority := range priorities {
+		if priority < 0 || priority > maxPriority {
+			return &ValidationError{Field: fieldPriorityTiers, Message: "priorities must be integers from 0 through 10"}
+		}
+		if _, exists := seen[priority]; exists {
+			return &ValidationError{Field: fieldPriorityTiers, Message: "priorities must be unique"}
+		}
+		seen[priority] = struct{}{}
+	}
+	return nil
+}
+
+func validateRetryAndDLQ(topicName string, policy Policy) error {
+	if policy.MaxAttempts < 1 || policy.MaxAttempts > maxAttempts {
+		return &ValidationError{Field: fieldMaxAttempts, Message: "must be between 1 and 100"}
+	}
+	if len(policy.DeadLetterTopicRef) > 63 || !namePattern.MatchString(policy.DeadLetterTopicRef) {
+		return &ValidationError{Field: fieldDeadLetter, Message: "must be a DNS label with at most 63 characters"}
+	}
+	if policy.DeadLetterTopicRef == topicName {
+		return &ValidationError{Field: fieldDeadLetter, Message: "must differ from topicName"}
+	}
+	return nil
+}
+
+func validateLimits(policy Policy) error {
+	if policy.RetentionSeconds < 0 || policy.RetentionSeconds > maxRetentionSecond {
+		return &ValidationError{Field: fieldRetention, Message: "must be between 0 and 2147483647"}
+	}
+	if policy.MaxConsumers < 0 || policy.MaxConsumers > maxConsumers {
+		return &ValidationError{Field: fieldMaxConsumers, Message: "must be between 0 and 10000"}
+	}
+	return nil
+}

--- a/internal/core/queuetopic/topic_test.go
+++ b/internal/core/queuetopic/topic_test.go
@@ -1,0 +1,114 @@
+package queuetopic
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testDeadLetter       = "events-dlq"
+	testEventsTopic      = "events"
+	testPaymentsTenant   = "payments"
+	testPhysicalTopicID  = "payments.events"
+	testFieldDeadLetter  = "deadLetterTopicRef"
+	testFieldMaxAttempts = "maxAttempts"
+	testFieldMaxConsumer = "maxConsumers"
+	testFieldPriority    = "priorityTiers"
+	testFieldRetention   = "retentionSeconds"
+	testFieldTopicName   = "topicName"
+)
+
+func TestNewNormalizesValidTopic(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 30, 0, 0, time.FixedZone("local", -3*60*60))
+	policy := Policy{
+		PriorityTiers:      []int{5, 1, 3},
+		MaxAttempts:        5,
+		DeadLetterTopicRef: "payments-events-dlq",
+		RetentionSeconds:   3600,
+		MaxConsumers:       20,
+	}
+
+	topic, err := New("payments", "payments-events", policy, now)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if topic.TopicID != "payments.payments-events" {
+		t.Fatalf("TopicID = %q", topic.TopicID)
+	}
+	if got := topic.Policy.PriorityTiers; len(got) != 3 || got[0] != 1 || got[1] != 3 || got[2] != 5 {
+		t.Fatalf("PriorityTiers = %v", got)
+	}
+	if !topic.CreatedAt.Equal(now) || topic.CreatedAt.Location() != time.UTC || !topic.UpdatedAt.Equal(now) {
+		t.Fatalf("timestamps = %s / %s", topic.CreatedAt, topic.UpdatedAt)
+	}
+	if policy.PriorityTiers[0] != 5 {
+		t.Fatal("New() mutated the caller's priority slice")
+	}
+	if !SamePolicy(topic.Policy, topic.Policy) {
+		t.Fatal("SamePolicy() = false for identical policies")
+	}
+	changed := topic.Policy
+	changed.MaxConsumers++
+	if SamePolicy(topic.Policy, changed) {
+		t.Fatal("SamePolicy() = true after policy change")
+	}
+}
+
+func TestNewRejectsInvalidContracts(t *testing.T) {
+	valid := Policy{PriorityTiers: []int{0, 3}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter}
+	tests := []struct {
+		name      string
+		tenantID  string
+		topicName string
+		policy    Policy
+		field     string
+	}{
+		{name: "tenant", tenantID: "P", topicName: testEventsTopic, policy: valid, field: "tenantId"},
+		{name: "topic pattern", tenantID: testPaymentsTenant, topicName: "bad.topic", policy: valid, field: testFieldTopicName},
+		{name: "topic length", tenantID: testPaymentsTenant, topicName: strings.Repeat("a", 64), policy: valid, field: testFieldTopicName},
+		{name: "no priorities", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter}, field: testFieldPriority},
+		{name: "too many priorities", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter}, field: testFieldPriority},
+		{name: "priority range", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{11}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter}, field: testFieldPriority},
+		{name: "duplicate priority", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1, 1}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter}, field: testFieldPriority},
+		{name: "attempts low", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, DeadLetterTopicRef: testDeadLetter}, field: testFieldMaxAttempts},
+		{name: "attempts high", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 101, DeadLetterTopicRef: testDeadLetter}, field: testFieldMaxAttempts},
+		{name: "dlq pattern", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 5, DeadLetterTopicRef: "bad.topic"}, field: testFieldDeadLetter},
+		{name: "dlq length", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 5, DeadLetterTopicRef: strings.Repeat("a", 64)}, field: testFieldDeadLetter},
+		{name: "dlq self", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 5, DeadLetterTopicRef: testEventsTopic}, field: testFieldDeadLetter},
+		{name: "retention low", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter, RetentionSeconds: -1}, field: testFieldRetention},
+		{name: "retention high", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter, RetentionSeconds: 2147483647 + 1}, field: testFieldRetention},
+		{name: "consumers low", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter, MaxConsumers: -1}, field: testFieldMaxConsumer},
+		{name: "consumers high", tenantID: testPaymentsTenant, topicName: testEventsTopic, policy: Policy{PriorityTiers: []int{1}, MaxAttempts: 5, DeadLetterTopicRef: testDeadLetter, MaxConsumers: 10001}, field: testFieldMaxConsumer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.tenantID, tt.topicName, tt.policy, time.Now())
+			var validation *ValidationError
+			if !errors.As(err, &validation) || validation.Field != tt.field {
+				t.Fatalf("error = %#v, want ValidationError for %s", err, tt.field)
+			}
+			if validation.Error() == "" {
+				t.Fatal("ValidationError.Error() is empty")
+			}
+		})
+	}
+}
+
+func TestTypedErrors(t *testing.T) {
+	tests := []error{
+		&NotFoundError{TopicID: testPhysicalTopicID},
+		&ConflictError{TopicID: testPhysicalTopicID},
+		&UnavailableError{Reason: "replication disabled"},
+	}
+	for _, err := range tests {
+		if err.Error() == "" {
+			t.Fatalf("%T.Error() is empty", err)
+		}
+	}
+	if got := PhysicalID("payments", "events"); got != "payments.events" {
+		t.Fatalf("PhysicalID() = %q", got)
+	}
+}

--- a/internal/server/http/topics/handler.go
+++ b/internal/server/http/topics/handler.go
@@ -1,0 +1,114 @@
+// Package topics exposes QueueTopic administration over HTTP.
+package topics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
+	"github.com/osvaldoandrade/codeq/internal/middleware"
+)
+
+const (
+	errorKey        = "error"
+	maxRequestBytes = 1 << 20
+)
+
+// Service is the transport-owned use-case boundary.
+type Service interface {
+	Upsert(context.Context, string, string, queuetopic.Policy) (queuetopic.Topic, bool, bool, error)
+	Get(context.Context, string, string) (queuetopic.Topic, error)
+	Delete(context.Context, string, string) error
+}
+
+// Handler translates the topic use cases to HTTP.
+type Handler struct {
+	service Service
+}
+
+// NewHandler builds the topic administration handler.
+func NewHandler(service Service) *Handler {
+	return &Handler{service: service}
+}
+
+// Upsert handles an idempotent topic policy PUT.
+func (h *Handler) Upsert(c *gin.Context) {
+	var policy queuetopic.Policy
+	if err := decodePolicy(c, &policy); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{errorKey: "invalid request body: " + err.Error()})
+		return
+	}
+
+	topic, created, _, err := h.service.Upsert(c.Request.Context(), middleware.GetTenantID(c), c.Param("topicName"), policy)
+	if err != nil {
+		writeError(c, err)
+		return
+	}
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	c.JSON(status, topic)
+}
+
+// Get handles a tenant-scoped topic lookup.
+func (h *Handler) Get(c *gin.Context) {
+	topic, err := h.service.Get(c.Request.Context(), middleware.GetTenantID(c), c.Param("topicName"))
+	if err != nil {
+		writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, topic)
+}
+
+// Delete requires the caller to state the destructive provider policy.
+func (h *Handler) Delete(c *gin.Context) {
+	if c.Query("deletionPolicy") != "Delete" {
+		c.JSON(http.StatusBadRequest, gin.H{errorKey: "deletionPolicy=Delete is required"})
+		return
+	}
+	if err := h.service.Delete(c.Request.Context(), middleware.GetTenantID(c), c.Param("topicName")); err != nil {
+		writeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func decodePolicy(c *gin.Context, policy *queuetopic.Policy) error {
+	decoder := json.NewDecoder(http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(policy); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("only one JSON object is allowed")
+		}
+		return err
+	}
+	return nil
+}
+
+func writeError(c *gin.Context, err error) {
+	var validation *queuetopic.ValidationError
+	var notFound *queuetopic.NotFoundError
+	var conflict *queuetopic.ConflictError
+	var unavailable *queuetopic.UnavailableError
+	switch {
+	case errors.As(err, &validation):
+		c.JSON(http.StatusUnprocessableEntity, gin.H{errorKey: validation.Error(), "field": validation.Field})
+	case errors.As(err, &notFound):
+		c.JSON(http.StatusNotFound, gin.H{errorKey: notFound.Error()})
+	case errors.As(err, &conflict):
+		c.JSON(http.StatusConflict, gin.H{errorKey: conflict.Error()})
+	case errors.As(err, &unavailable):
+		c.JSON(http.StatusServiceUnavailable, gin.H{errorKey: unavailable.Error()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{errorKey: "queue topic operation failed"})
+	}
+}

--- a/internal/server/http/topics/handler_test.go
+++ b/internal/server/http/topics/handler_test.go
@@ -1,0 +1,128 @@
+package topics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
+)
+
+type fakeService struct {
+	topic   queuetopic.Topic
+	err     error
+	created bool
+	changed bool
+}
+
+const testPhysicalTopicID = "payments.events"
+
+func (s *fakeService) Upsert(_ context.Context, tenantID, topicName string, policy queuetopic.Policy) (queuetopic.Topic, bool, bool, error) {
+	s.topic = queuetopic.Topic{TopicID: queuetopic.PhysicalID(tenantID, topicName), TenantID: tenantID, TopicName: topicName, Policy: policy}
+	return s.topic, s.created, s.changed, s.err
+}
+
+func (s *fakeService) Get(_ context.Context, tenantID, topicName string) (queuetopic.Topic, error) {
+	if s.err != nil {
+		return queuetopic.Topic{}, s.err
+	}
+	return queuetopic.Topic{TopicID: queuetopic.PhysicalID(tenantID, topicName), TenantID: tenantID, TopicName: topicName}, nil
+}
+
+func (s *fakeService) Delete(_ context.Context, tenantID, topicName string) error {
+	s.topic = queuetopic.Topic{TenantID: tenantID, TopicName: topicName}
+	return s.err
+}
+
+func TestHandlerUpsert(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		service *fakeService
+		status  int
+	}{
+		{name: "create", body: validBody, service: &fakeService{created: true}, status: http.StatusCreated},
+		{name: "update", body: validBody, service: &fakeService{changed: true}, status: http.StatusOK},
+		{name: "malformed", body: `{`, service: &fakeService{}, status: http.StatusBadRequest},
+		{name: "unknown field", body: `{"priorityTiers":[0],"maxAttempts":1,"deadLetterTopicRef":"events-dlq","extra":true}`, service: &fakeService{}, status: http.StatusBadRequest},
+		{name: "multiple objects", body: validBody + `{}`, service: &fakeService{}, status: http.StatusBadRequest},
+		{name: "validation", body: validBody, service: &fakeService{err: &queuetopic.ValidationError{Field: "topicName", Message: "invalid"}}, status: http.StatusUnprocessableEntity},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := request(t, tt.service, http.MethodPut, "/v1/codeq/admin/topics/events", tt.body)
+			if response.Code != tt.status {
+				t.Fatalf("status = %d, body=%s", response.Code, response.Body.String())
+			}
+			if tt.status < 300 && tt.service.topic.TopicID != testPhysicalTopicID {
+				t.Fatalf("topic = %#v", tt.service.topic)
+			}
+		})
+	}
+}
+
+func TestHandlerGetErrorMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		status int
+	}{
+		{name: "success", status: http.StatusOK},
+		{name: "not found", err: &queuetopic.NotFoundError{TopicID: testPhysicalTopicID}, status: http.StatusNotFound},
+		{name: "conflict", err: &queuetopic.ConflictError{TopicID: testPhysicalTopicID}, status: http.StatusConflict},
+		{name: "unavailable", err: &queuetopic.UnavailableError{Reason: "raft"}, status: http.StatusServiceUnavailable},
+		{name: "internal", err: errors.New("backend"), status: http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := request(t, &fakeService{err: tt.err}, http.MethodGet, "/v1/codeq/admin/topics/events", "")
+			if response.Code != tt.status {
+				t.Fatalf("status = %d, body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandlerDeleteRequiresExplicitPolicy(t *testing.T) {
+	service := &fakeService{}
+	response := request(t, service, http.MethodDelete, "/v1/codeq/admin/topics/events", "")
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("missing policy status = %d", response.Code)
+	}
+
+	response = request(t, service, http.MethodDelete, "/v1/codeq/admin/topics/events?deletionPolicy=Delete", "")
+	if response.Code != http.StatusNoContent || service.topic.TopicName != "events" {
+		t.Fatalf("delete status = %d topic=%#v", response.Code, service.topic)
+	}
+
+	response = request(t, &fakeService{err: errors.New("backend")}, http.MethodDelete, "/v1/codeq/admin/topics/events?deletionPolicy=Delete", "")
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("delete error status = %d", response.Code)
+	}
+}
+
+const validBody = `{"priorityTiers":[0,3,5],"maxAttempts":5,"deadLetterTopicRef":"events-dlq","retentionSeconds":3600,"maxConsumers":20}`
+
+func request(t *testing.T, service Service, method, target, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c.Set("tenantID", "payments")
+		c.Next()
+	})
+	handler := NewHandler(service)
+	engine.PUT("/v1/codeq/admin/topics/:topicName", handler.Upsert)
+	engine.GET("/v1/codeq/admin/topics/:topicName", handler.Get)
+	engine.DELETE("/v1/codeq/admin/topics/:topicName", handler.Delete)
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, req)
+	return response
+}

--- a/internal/storage/adapter/redis/topic_store.go
+++ b/internal/storage/adapter/redis/topic_store.go
@@ -1,0 +1,123 @@
+// Package redis implements storage adapters backed by Redis-compatible stores.
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	goredis "github.com/go-redis/redis/v8"
+
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
+)
+
+const (
+	topicKeyPrefix = "codeq:admin:topic:"
+	topicIndexKey  = "codeq:admin:topics"
+	watchRetries   = 5
+)
+
+// TopicStore persists tenant-scoped topic policies using optimistic locking.
+type TopicStore struct {
+	client *goredis.Client
+}
+
+// NewTopicStore builds a Redis topic store over the application's shared client.
+func NewTopicStore(client *goredis.Client) *TopicStore {
+	return &TopicStore{client: client}
+}
+
+// Upsert atomically creates, updates, or confirms an identical topic policy.
+func (s *TopicStore) Upsert(ctx context.Context, desired queuetopic.Topic) (queuetopic.Topic, bool, bool, error) {
+	key := topicKeyPrefix + desired.TopicID
+	for attempt := 0; attempt < watchRetries; attempt++ {
+		stored, created, changed, err := s.upsertOnce(ctx, key, desired)
+		if !errors.Is(err, goredis.TxFailedErr) {
+			return stored, created, changed, err
+		}
+	}
+	return queuetopic.Topic{}, false, false, &queuetopic.ConflictError{TopicID: desired.TopicID}
+}
+
+func (s *TopicStore) upsertOnce(ctx context.Context, key string, desired queuetopic.Topic) (stored queuetopic.Topic, created bool, changed bool, err error) {
+	err = s.client.Watch(ctx, func(tx *goredis.Tx) error {
+		current, exists, getErr := readTopic(ctx, tx, key, desired.TopicID)
+		if getErr != nil {
+			return getErr
+		}
+		if exists && queuetopic.SamePolicy(current.Policy, desired.Policy) {
+			stored = current
+			return nil
+		}
+
+		created = !exists
+		changed = exists
+		if exists {
+			desired.CreatedAt = current.CreatedAt
+			desired.Version = current.Version + 1
+		} else {
+			desired.Version = 1
+		}
+		payload, marshalErr := json.Marshal(desired)
+		if marshalErr != nil {
+			return fmt.Errorf("marshal queue topic: %w", marshalErr)
+		}
+		_, writeErr := tx.TxPipelined(ctx, func(pipe goredis.Pipeliner) error {
+			pipe.Set(ctx, key, payload, 0)
+			pipe.SAdd(ctx, topicIndexKey, desired.TopicID)
+			return nil
+		})
+		if writeErr == nil {
+			stored = desired
+		}
+		return writeErr
+	}, key)
+	return stored, created, changed, err
+}
+
+// Get returns one topic within the authenticated tenant.
+func (s *TopicStore) Get(ctx context.Context, tenantID, topicName string) (queuetopic.Topic, error) {
+	topicID := queuetopic.PhysicalID(tenantID, topicName)
+	topic, exists, err := readTopic(ctx, s.client, topicKeyPrefix+topicID, topicID)
+	if err != nil {
+		return queuetopic.Topic{}, err
+	}
+	if !exists {
+		return queuetopic.Topic{}, &queuetopic.NotFoundError{TopicID: topicID}
+	}
+	return topic, nil
+}
+
+// Delete removes a topic catalog entry idempotently.
+func (s *TopicStore) Delete(ctx context.Context, tenantID, topicName string) error {
+	topicID := queuetopic.PhysicalID(tenantID, topicName)
+	_, err := s.client.TxPipelined(ctx, func(pipe goredis.Pipeliner) error {
+		pipe.Del(ctx, topicKeyPrefix+topicID)
+		pipe.SRem(ctx, topicIndexKey, topicID)
+		return nil
+	})
+	return err
+}
+
+type topicReader interface {
+	Get(context.Context, string) *goredis.StringCmd
+}
+
+func readTopic(ctx context.Context, reader topicReader, key, topicID string) (queuetopic.Topic, bool, error) {
+	payload, err := reader.Get(ctx, key).Bytes()
+	if errors.Is(err, goredis.Nil) {
+		return queuetopic.Topic{}, false, nil
+	}
+	if err != nil {
+		return queuetopic.Topic{}, false, err
+	}
+	var topic queuetopic.Topic
+	if err := json.Unmarshal(payload, &topic); err != nil {
+		return queuetopic.Topic{}, false, fmt.Errorf("decode queue topic %q: %w", topicID, err)
+	}
+	if topic.TopicID != topicID || queuetopic.PhysicalID(topic.TenantID, topic.TopicName) != topicID {
+		return queuetopic.Topic{}, false, fmt.Errorf("decode queue topic %q: stored identity does not match key", topicID)
+	}
+	return topic, true, nil
+}

--- a/internal/storage/adapter/redis/topic_store_test.go
+++ b/internal/storage/adapter/redis/topic_store_test.go
@@ -1,0 +1,115 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	goredis "github.com/go-redis/redis/v8"
+
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
+)
+
+func TestTopicStoreLifecycle(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	store := NewTopicStore(client)
+	ctx := context.Background()
+	createdAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	desired := validTopic(t, createdAt)
+
+	created, wasCreated, changed, err := store.Upsert(ctx, desired)
+	if err != nil || !wasCreated || changed || created.Version != 1 {
+		t.Fatalf("create = %#v, %t, %t, %v", created, wasCreated, changed, err)
+	}
+	indexed, err := server.SIsMember(topicIndexKey, desired.TopicID)
+	if err != nil || !indexed {
+		t.Fatal("topic index does not contain created topic")
+	}
+
+	identical, wasCreated, changed, err := store.Upsert(ctx, desired)
+	if err != nil || wasCreated || changed || identical.Version != 1 {
+		t.Fatalf("idempotent upsert = %#v, %t, %t, %v", identical, wasCreated, changed, err)
+	}
+
+	desired.Policy.MaxConsumers = 40
+	desired.UpdatedAt = createdAt.Add(time.Minute)
+	updated, wasCreated, changed, err := store.Upsert(ctx, desired)
+	if err != nil || wasCreated || !changed || updated.Version != 2 {
+		t.Fatalf("update = %#v, %t, %t, %v", updated, wasCreated, changed, err)
+	}
+	if !updated.CreatedAt.Equal(createdAt) || !updated.UpdatedAt.Equal(createdAt.Add(time.Minute)) {
+		t.Fatalf("updated timestamps = %s / %s", updated.CreatedAt, updated.UpdatedAt)
+	}
+
+	got, err := store.Get(ctx, "payments", "events")
+	if err != nil || got.Version != 2 || got.Policy.MaxConsumers != 40 {
+		t.Fatalf("Get() = %#v, %v", got, err)
+	}
+
+	if err := store.Delete(ctx, "payments", "events"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if err := store.Delete(ctx, "payments", "events"); err != nil {
+		t.Fatalf("idempotent Delete() error = %v", err)
+	}
+	_, err = store.Get(ctx, "payments", "events")
+	var notFound *queuetopic.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("Get() error = %v, want NotFoundError", err)
+	}
+}
+
+func TestTopicStoreReportsBackendAndDataErrors(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: server.Addr()})
+	store := NewTopicStore(client)
+	ctx := context.Background()
+
+	if err := server.Set(topicKeyPrefix+"payments.events", "not-json"); err != nil {
+		t.Fatalf("Set() malformed fixture error = %v", err)
+	}
+	_, err := store.Get(ctx, "payments", "events")
+	if err == nil || !strings.Contains(err.Error(), "decode queue topic") {
+		t.Fatalf("Get() malformed error = %v", err)
+	}
+	if err := server.Set(topicKeyPrefix+"payments.events", `{"topicId":"other.events","tenantId":"other","topicName":"events"}`); err != nil {
+		t.Fatalf("Set() identity fixture error = %v", err)
+	}
+	_, err = store.Get(ctx, "payments", "events")
+	if err == nil || !strings.Contains(err.Error(), "stored identity does not match key") {
+		t.Fatalf("Get() identity error = %v", err)
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if _, err := store.Get(ctx, "payments", "other"); err == nil {
+		t.Fatal("Get() succeeded with closed client")
+	}
+	if err := store.Delete(ctx, "payments", "other"); err == nil {
+		t.Fatal("Delete() succeeded with closed client")
+	}
+	if _, _, _, err := store.Upsert(ctx, validTopic(t, time.Now())); err == nil {
+		t.Fatal("Upsert() succeeded with closed client")
+	}
+}
+
+func validTopic(t *testing.T, now time.Time) queuetopic.Topic {
+	t.Helper()
+	topic, err := queuetopic.New("payments", "events", queuetopic.Policy{
+		PriorityTiers:      []int{0, 3, 5},
+		MaxAttempts:        5,
+		DeadLetterTopicRef: "events-dlq",
+		RetentionSeconds:   3600,
+		MaxConsumers:       20,
+	}, now)
+	if err != nil {
+		t.Fatalf("queuetopic.New() error = %v", err)
+	}
+	return topic
+}

--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	topicsapp "github.com/osvaldoandrade/codeq/internal/application/topics"
 	"github.com/osvaldoandrade/codeq/internal/metrics"
 	"github.com/osvaldoandrade/codeq/internal/middleware"
 	"github.com/osvaldoandrade/codeq/internal/providers"
@@ -15,6 +16,7 @@ import (
 	"github.com/osvaldoandrade/codeq/internal/repository"
 	"github.com/osvaldoandrade/codeq/internal/services"
 	"github.com/osvaldoandrade/codeq/internal/shard"
+	topicredis "github.com/osvaldoandrade/codeq/internal/storage/adapter/redis"
 	"github.com/osvaldoandrade/codeq/internal/tracing"
 	"github.com/osvaldoandrade/codeq/pkg/auth"
 	"github.com/osvaldoandrade/codeq/pkg/config"
@@ -42,6 +44,7 @@ type Application struct {
 	Scheduler         services.SchedulerService
 	Results           services.ResultsService
 	Subs              services.SubscriptionService
+	Topics            *topicsapp.Service
 	Logger            *slog.Logger
 	TZ                *time.Location
 	ProducerValidator auth.Validator
@@ -244,6 +247,7 @@ func NewApplication(cfg *config.Config, opts ...ApplicationOption) (*Application
 	}
 	uploader := providers.NewLocalUploader(cfg.LocalArtifactsDir)
 	results := services.NewResultsService(resultRepo, uploader, resultCallback, logger, time.Now, loc)
+	topics := topicsapp.NewService(topicredis.NewTopicStore(redisClient), time.Now)
 
 	engine := gin.New()
 	engine.Use(gin.Recovery(), middleware.RequestIDMiddleware())
@@ -260,6 +264,7 @@ func NewApplication(cfg *config.Config, opts ...ApplicationOption) (*Application
 		Scheduler:   scheduler,
 		Results:     results,
 		Subs:        subs,
+		Topics:      topics,
 		Logger:      logger,
 		TZ:          loc,
 		RateLimiter: limiter,

--- a/pkg/app/application_pebble.go
+++ b/pkg/app/application_pebble.go
@@ -16,6 +16,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	topicsapp "github.com/osvaldoandrade/codeq/internal/application/topics"
 	"github.com/osvaldoandrade/codeq/internal/cluster"
 	"github.com/osvaldoandrade/codeq/internal/cluster/clusterpb"
 	"github.com/osvaldoandrade/codeq/internal/middleware"
@@ -474,6 +475,9 @@ func newPebbleApplication(
 		Scheduler:   scheduler,
 		Results:     results,
 		Subs:        subs,
+		Topics: topicsapp.NewUnavailableService(
+			"persistenceProvider=pebble requires replicated topic catalog support",
+		),
 		Logger:      logger,
 		TZ:          loc,
 		RateLimiter: limiter,

--- a/pkg/app/integration_test.go
+++ b/pkg/app/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/osvaldoandrade/codeq/internal/core/queuetopic"
 	_ "github.com/osvaldoandrade/codeq/pkg/auth/jwks" // Register JWKS provider
 	"github.com/osvaldoandrade/codeq/pkg/config"
 	"github.com/osvaldoandrade/codeq/pkg/domain"
@@ -122,6 +123,8 @@ func TestHTTPIntegrationFlow(t *testing.T) {
 
 	workerToken := signWorkerJWT(t, privKey, kid, "codeq-test", "codeq-worker", "worker-1")
 	producerToken := signProducerJWT(t, privKey, kid, "codeq-test", "codeq-producer", "user-1")
+	adminToken := signAdminJWT(t, privKey, kid, "codeq-test", "codeq-producer", "admin-1")
+	assertTopicAdminLifecycle(t, ctx, server.URL, adminToken)
 
 	taskID := createTask(t, ctx, server.URL, producerToken, hookSrv.URL)
 	claimTask(t, ctx, server.URL, workerToken, taskID)
@@ -142,6 +145,56 @@ func TestHTTPIntegrationFlow(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("expected webhook callback")
+	}
+}
+
+func assertTopicAdminLifecycle(t *testing.T, ctx context.Context, baseURL, token string) {
+	t.Helper()
+	endpoint := baseURL + "/v1/codeq/admin/topics/payments-events"
+	policy := queuetopic.Policy{
+		PriorityTiers:      []int{5, 1, 3},
+		MaxAttempts:        5,
+		DeadLetterTopicRef: "payments-events-dlq",
+		RetentionSeconds:   3600,
+		MaxConsumers:       20,
+	}
+
+	var created queuetopic.Topic
+	status, body := doJSON(t, ctx, http.MethodPut, endpoint, token, policy, &created)
+	if status != http.StatusCreated || created.TopicID != "test-tenant.payments-events" || created.Version != 1 {
+		t.Fatalf("create topic status=%d topic=%#v body=%s", status, created, body)
+	}
+
+	var replayed queuetopic.Topic
+	status, body = doJSON(t, ctx, http.MethodPut, endpoint, token, policy, &replayed)
+	if status != http.StatusOK || replayed.Version != 1 || !replayed.CreatedAt.Equal(created.CreatedAt) {
+		t.Fatalf("replay topic status=%d topic=%#v body=%s", status, replayed, body)
+	}
+
+	policy.MaxConsumers = 40
+	var updated queuetopic.Topic
+	status, body = doJSON(t, ctx, http.MethodPut, endpoint, token, policy, &updated)
+	if status != http.StatusOK || updated.Version != 2 || updated.Policy.MaxConsumers != 40 {
+		t.Fatalf("update topic status=%d topic=%#v body=%s", status, updated, body)
+	}
+
+	var fetched queuetopic.Topic
+	status, body = doJSON(t, ctx, http.MethodGet, endpoint, token, nil, &fetched)
+	if status != http.StatusOK || fetched.Version != 2 {
+		t.Fatalf("get topic status=%d topic=%#v body=%s", status, fetched, body)
+	}
+
+	status, body = doJSON(t, ctx, http.MethodDelete, endpoint, token, nil, nil)
+	if status != http.StatusBadRequest {
+		t.Fatalf("delete without policy status=%d body=%s", status, body)
+	}
+	status, body = doJSON(t, ctx, http.MethodDelete, endpoint+"?deletionPolicy=Delete", token, nil, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("delete topic status=%d body=%s", status, body)
+	}
+	status, body = doJSON(t, ctx, http.MethodGet, endpoint, token, nil, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("get deleted topic status=%d body=%s", status, body)
 	}
 }
 

--- a/pkg/app/url_mappings.go
+++ b/pkg/app/url_mappings.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	topicsapp "github.com/osvaldoandrade/codeq/internal/application/topics"
 	"github.com/osvaldoandrade/codeq/internal/controllers"
 	"github.com/osvaldoandrade/codeq/internal/middleware"
+	topicshttp "github.com/osvaldoandrade/codeq/internal/server/http/topics"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -39,6 +41,14 @@ func SetupMappings(app *Application) {
 		anyAuth.GET("/raft/status", controllers.NewRaftStatusController(adaptRaftGroups(app.RaftGroups)).Handle)
 
 		admin := producer.Group("/admin", middleware.RequireAdmin())
+		topicService := app.Topics
+		if topicService == nil {
+			topicService = topicsapp.NewUnavailableService("topic service not configured")
+		}
+		topicHandler := topicshttp.NewHandler(topicService)
+		admin.PUT("/topics/:topicName", topicHandler.Upsert)
+		admin.GET("/topics/:topicName", topicHandler.Get)
+		admin.DELETE("/topics/:topicName", topicHandler.Delete)
 		admin.GET("/queues", controllers.NewQueuesAdminController(app.Scheduler).Handle)
 		admin.GET("/queues/:command", controllers.NewQueueStatsController(app.Scheduler).Handle)
 


### PR DESCRIPTION
## Summary

- add authenticated `PUT`, `GET`, and explicit-policy `DELETE` endpoints for tenant-scoped queue topics
- derive tenant ownership from validated claims and persist physical IDs as `<tenant>.<topicName>`
- make Redis upserts atomic, idempotent, and versioned with tenant-isolation checks
- fail closed with `503` for Pebble and Pebble/Raft until catalog writes are replicated
- fix the local golangci-lint v2 installer path

## Verification

- `go test -race -cover ./internal/core/queuetopic ./internal/application/topics ./internal/storage/adapter/redis ./internal/server/http/topics`
- `GIN_MODE=release go test ./pkg/app -run "^TestHTTPIntegrationFlow$" -count=1 -timeout=2m`
- `go vet ./...`
- `go build ./...`
- golangci-lint v2.12.2 on the four new packages: 0 issues

## Risk boundary

This is a local provider contract only. It does not change any Kubernetes cluster or production workload. Pebble and Raft administration remain unavailable until their replication path is implemented. Follow-up: #722.