### PR TITLE
fix(auth): reject conflicting tenant claims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,15 @@ test: ## Run unit tests with race detector.
 	$(GO) test -race -shuffle=on -count=1 -timeout=10m \
 		-coverprofile=$(COVER_PROFILE) -covermode=atomic $(PKGS)
 
-.PHONY: test-short
+.PHONY: test-short tenant-fuzz tenant-mutation
 test-short: ## Run short unit tests (no race, faster local loop).
 	$(GO) test -short -count=1 -timeout=5m $(PKGS)
+
+tenant-fuzz: ## Fuzz canonical and legacy tenant claim resolution.
+	$(GO) test ./internal/authclaims -run '^$$' -fuzz '^FuzzResolveTenantID$$' -fuzztime=10s
+
+tenant-mutation: ## Mutation-test the tenant claim security boundary.
+	$(GO) run github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0 unleash ./internal/authclaims --workers=2 --threshold-efficacy=80 --threshold-mcover=80
 
 .PHONY: test-integration
 test-integration: ## Run integration tests (-tags=integration).

--- a/docs/adr/0002-tenant-claim-resolution.md
+++ b/docs/adr/0002-tenant-claim-resolution.md
@@ -1,0 +1,73 @@
+# ADR 0002: Resolve one canonical tenant claim
+
+## Status
+
+Accepted by the owner under the documented T4 review waiver on 2026-07-20.
+Independent security and peer-review approvals were not performed and are not
+implied by this status.
+
+## Context
+
+Authenticated HTTP, producer gRPC, and worker gRPC paths previously interpreted
+tenant claims in three different functions. HTTP preferred `tid`, the streams
+did not recognize it, and every path silently selected one alias when a token
+contained conflicting values. A correctly signed token could therefore map to
+different physical queue prefixes depending on transport.
+
+The JWKS validator already requires the configured issuer and audience and
+validates signature and expiry before tenant resolution. The static validator
+is a local/operator compatibility producer. Producer-as-worker preserves the
+validated producer raw claims. Tenant resolution must apply one rule after all
+of those producers validate a token.
+
+## Decision
+
+`tid` is the canonical tenant claim. During the compatibility window, codeQ
+also accepts `tenantId`, `tenant_id`, `organizationId`, and `organization_id`.
+Every supplied claim must be a string, trim to the same lowercase DNS-label
+value, and match `^[a-z][a-z0-9-]{1,62}$`. A blank, non-string, unsafe, or
+conflicting claim fails closed before queue access.
+
+Subject fallback remains supported only for single-tenant tokens that contain
+none of the supported tenant claim names. The subject must satisfy the same
+tenant format. The fallback never overrides a present but invalid tenant claim.
+
+The rule lives in `internal/authclaims` and is consumed by HTTP producer/worker
+middleware and both gRPC stream handshakes. Error responses do not echo claim
+values.
+
+## Compatibility matrix
+
+| Producer shape | Result |
+| --- | --- |
+| Tikti/workload token with `tid` | accepted; canonical |
+| Firebase-era token with `tenantId` | accepted during compatibility window |
+| legacy token with `tenant_id` | accepted during compatibility window |
+| organization token with `organizationId` or `organization_id` | accepted during compatibility window |
+| static local token with one supported raw claim | accepted; same resolver |
+| producer token used as worker | accepted only after producer validation; same resolver |
+| multiple aliases with one value | accepted |
+| aliases with different values | rejected |
+| no aliases and DNS-label `sub` | accepted as single-tenant fallback |
+| present blank/non-string/unsafe alias | rejected; no fallback |
+
+## Deprecation
+
+New token producers must emit `tid` immediately. Legacy aliases remain readable
+through 2027-01-31. Beginning 2026-10-31, operators should measure alias use at
+the identity provider rather than logging raw claims in codeQ. Removal requires
+a compatibility report showing 30 days with no legacy issuance, a major-release
+notice, and a separate ADR. Subject fallback follows the same removal gate.
+
+## Verification and residual risk
+
+Compatibility-table tests, alias-order properties, fuzzing, and mutation
+testing exercise the resolver. Middleware and both stream servers compile
+against the same function; JWT validator tests separately cover issuer,
+audience, signature, expiry, and claim decoding. The threat model records the
+cross-tenant abuse cases.
+
+Independent security validation was waived by the owner. The remaining risk is
+an undocumented external producer using a non-DNS tenant or relying on a
+conflicting token. The change intentionally rejects both rather than selecting
+an ambiguous tenant. It authorizes no release or production action.

--- a/docs/security/tenant-claim-threat-model.md
+++ b/docs/security/tenant-claim-threat-model.md
@@ -1,0 +1,40 @@
+# Tenant claim threat model
+
+Scope: validated token to tenant-scoped HTTP/gRPC queue access. Protected assets
+are task payloads, results, subscriptions, QueueTopic policies, rate limits, and
+physical tenant prefixes. Trust changes at token producer to validator,
+validator to claim resolver, and resolved tenant to storage/provider keys.
+
+## STRIDE and abuse cases
+
+| Threat | Abuse case | Control | Evidence |
+| --- | --- | --- | --- |
+| Spoofing | attacker signs with another key, issuer, or audience | configured JWKS signature, issuer, audience, and expiry validation | JWKS validator tests |
+| Tampering | token contains `tid=payments` and a legacy alias for another tenant | all supplied aliases must agree exactly after trimming | conflict/property/fuzz tests |
+| Repudiation | transport resolves the same token differently | one resolver for HTTP, producer gRPC, and worker gRPC | compile and compatibility matrix |
+| Information disclosure | malformed tenant escapes a key prefix or selects an empty/global scope | DNS-label validation; missing/malformed values fail closed before handlers | unsafe/missing claim tests |
+| Denial of service | oversized or unexpected claim types trigger parser failure | bounded JWT parsing plus type checks; resolver never reflects raw values | fuzz tests |
+| Elevation of privilege | subject fallback overrides a bad alias | fallback only when every supported alias is absent | blank/non-string tests |
+
+Tenant resolution occurs only after the configured validator accepts the token.
+It does not weaken route scopes, worker event types, admin scope, idempotency, or
+storage-level tenant prefixes. A global administrator remains bound to the
+resolved tenant unless a separately reviewed global route says otherwise.
+
+## Token-producer verification
+
+- JWKS producer tokens expose their raw `jwt.MapClaims` to the resolver after
+  issuer, audience, signature, and expiry checks.
+- Static tokens expose only operator-configured raw claims and use the same
+  resolver; they are not a production identity substitute.
+- Producer-as-worker copies the already validated producer raw claims and then
+  re-runs the same resolver at the worker boundary.
+- HTTP and both gRPC handshakes reject invalid tenant claims before scheduling,
+  claiming, results, subscriptions, or topic administration can execute.
+
+## Review record
+
+The owner waived independent security and peer-review gates and accepted the
+documented T4 risk. That waiver is not an independent review or sign-off. No
+GCP, Kubernetes, deployment, workload, or production validation is part of this
+evidence.

--- a/internal/authclaims/tenant.go
+++ b/internal/authclaims/tenant.go
@@ -1,0 +1,64 @@
+// Package authclaims owns security-sensitive interpretation of validated token claims.
+package authclaims
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/osvaldoandrade/codeq/pkg/auth"
+)
+
+var (
+	ErrTenantMissing   = errors.New("tenant claim is missing")
+	ErrTenantMalformed = errors.New("tenant claim is malformed")
+	ErrTenantConflict  = errors.New("tenant claims conflict")
+	tenantPattern      = regexp.MustCompile(`^[a-z][a-z0-9-]{1,62}$`)
+)
+
+var tenantClaimNames = [...]string{"tid", "tenantId", "tenant_id", "organizationId", "organization_id"}
+
+// ResolveTenantID returns the one tenant asserted by a validated token.
+// tid is canonical. Legacy aliases remain compatible only when every supplied
+// alias has the same non-empty value. Subject fallback is reserved for tokens
+// that do not contain any supported tenant claim.
+func ResolveTenantID(claims *auth.Claims) (string, error) {
+	if claims == nil {
+		return "", ErrTenantMissing
+	}
+
+	selected := ""
+	for _, name := range tenantClaimNames {
+		raw, present := claims.Raw[name]
+		if !present {
+			continue
+		}
+		value, ok := raw.(string)
+		if !ok {
+			return "", ErrTenantMalformed
+		}
+		value = strings.TrimSpace(value)
+		if !tenantPattern.MatchString(value) {
+			return "", ErrTenantMalformed
+		}
+		if selected == "" {
+			selected = value
+			continue
+		}
+		if selected != value {
+			return "", ErrTenantConflict
+		}
+	}
+	if selected != "" {
+		return selected, nil
+	}
+
+	subject := strings.TrimSpace(claims.Subject)
+	if subject == "" {
+		return "", ErrTenantMissing
+	}
+	if !tenantPattern.MatchString(subject) {
+		return "", ErrTenantMalformed
+	}
+	return subject, nil
+}

--- a/internal/authclaims/tenant.go
+++ b/internal/authclaims/tenant.go
@@ -10,13 +10,24 @@ import (
 )
 
 var (
-	ErrTenantMissing   = errors.New("tenant claim is missing")
+	// ErrTenantMissing means neither a tenant claim nor a fallback subject exists.
+	ErrTenantMissing = errors.New("tenant claim is missing")
+	// ErrTenantMalformed means a supplied tenant value is not a safe tenant label.
 	ErrTenantMalformed = errors.New("tenant claim is malformed")
-	ErrTenantConflict  = errors.New("tenant claims conflict")
-	tenantPattern      = regexp.MustCompile(`^[a-z][a-z0-9-]{1,62}$`)
+	// ErrTenantConflict means two supported claim aliases identify different tenants.
+	ErrTenantConflict = errors.New("tenant claims conflict")
+	tenantPattern     = regexp.MustCompile(`^[a-z][a-z0-9-]{1,62}$`)
 )
 
-var tenantClaimNames = [...]string{"tid", "tenantId", "tenant_id", "organizationId", "organization_id"}
+const (
+	claimTID                 = "tid"
+	claimTenantID            = "tenantId"
+	claimTenantIDSnake       = "tenant_id"
+	claimOrganizationID      = "organizationId"
+	claimOrganizationIDSnake = "organization_id"
+)
+
+var tenantClaimNames = [...]string{claimTID, claimTenantID, claimTenantIDSnake, claimOrganizationID, claimOrganizationIDSnake}
 
 // ResolveTenantID returns the one tenant asserted by a validated token.
 // tid is canonical. Legacy aliases remain compatible only when every supplied
@@ -26,34 +37,43 @@ func ResolveTenantID(claims *auth.Claims) (string, error) {
 	if claims == nil {
 		return "", ErrTenantMissing
 	}
+	if selected, found, err := resolveAliases(claims.Raw); found || err != nil {
+		return selected, err
+	}
+	return validateFallbackSubject(claims.Subject)
+}
 
+func resolveAliases(raw map[string]interface{}) (string, bool, error) {
 	selected := ""
 	for _, name := range tenantClaimNames {
-		raw, present := claims.Raw[name]
+		value, present := raw[name]
 		if !present {
 			continue
 		}
-		value, ok := raw.(string)
+		text, ok := value.(string)
 		if !ok {
-			return "", ErrTenantMalformed
+			return "", true, ErrTenantMalformed
 		}
-		value = strings.TrimSpace(value)
-		if !tenantPattern.MatchString(value) {
-			return "", ErrTenantMalformed
+		text = strings.TrimSpace(text)
+		if !tenantPattern.MatchString(text) {
+			return "", true, ErrTenantMalformed
 		}
 		if selected == "" {
-			selected = value
+			selected = text
 			continue
 		}
-		if selected != value {
-			return "", ErrTenantConflict
+		if selected != text {
+			return "", true, ErrTenantConflict
 		}
 	}
 	if selected != "" {
-		return selected, nil
+		return selected, true, nil
 	}
+	return "", false, nil
+}
 
-	subject := strings.TrimSpace(claims.Subject)
+func validateFallbackSubject(value string) (string, error) {
+	subject := strings.TrimSpace(value)
 	if subject == "" {
 		return "", ErrTenantMissing
 	}

--- a/internal/authclaims/tenant_test.go
+++ b/internal/authclaims/tenant_test.go
@@ -1,0 +1,92 @@
+package authclaims
+
+import (
+	"errors"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/osvaldoandrade/codeq/pkg/auth"
+)
+
+func TestResolveTenantIDCompatibilityMatrix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		claims  *auth.Claims
+		want    string
+		wantErr error
+	}{
+		{name: "nil claims", wantErr: ErrTenantMissing},
+		{name: "canonical tid", claims: claims(map[string]any{"tid": " payments "}, "ignored"), want: "payments"},
+		{name: "firebase camel case", claims: claims(map[string]any{"tenantId": "identity"}, ""), want: "identity"},
+		{name: "snake case tenant", claims: claims(map[string]any{"tenant_id": "analytics"}, ""), want: "analytics"},
+		{name: "organization camel case", claims: claims(map[string]any{"organizationId": "platform"}, ""), want: "platform"},
+		{name: "organization snake case", claims: claims(map[string]any{"organization_id": "platform"}, ""), want: "platform"},
+		{name: "matching aliases", claims: claims(map[string]any{"tid": "payments", "tenantId": "payments", "organization_id": "payments"}, "other"), want: "payments"},
+		{name: "subject fallback", claims: claims(map[string]any{}, "single-tenant"), want: "single-tenant"},
+		{name: "canonical conflict", claims: claims(map[string]any{"tid": "payments", "tenantId": "analytics"}, "payments"), wantErr: ErrTenantConflict},
+		{name: "legacy conflict", claims: claims(map[string]any{"tenant_id": "payments", "organizationId": "analytics"}, "payments"), wantErr: ErrTenantConflict},
+		{name: "blank claim does not fall back", claims: claims(map[string]any{"tid": " "}, "payments"), wantErr: ErrTenantMalformed},
+		{name: "non-string claim", claims: claims(map[string]any{"tid": 7}, "payments"), wantErr: ErrTenantMalformed},
+		{name: "unsafe tenant", claims: claims(map[string]any{"tid": "../payments"}, "payments"), wantErr: ErrTenantMalformed},
+		{name: "missing subject and claims", claims: claims(nil, ""), wantErr: ErrTenantMissing},
+		{name: "unsafe subject fallback", claims: claims(nil, "user@example.com"), wantErr: ErrTenantMalformed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveTenantID(test.claims)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("ResolveTenantID() error = %v, want %v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Fatalf("ResolveTenantID() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveTenantIDAliasOrderDoesNotChangeResult(t *testing.T) {
+	t.Parallel()
+	aliases := []string{"tid", "tenantId", "tenant_id", "organizationId", "organization_id"}
+	for seed := int64(0); seed < 100; seed++ {
+		rand.New(rand.NewSource(seed)).Shuffle(len(aliases), func(left, right int) {
+			aliases[left], aliases[right] = aliases[right], aliases[left]
+		})
+		raw := make(map[string]any, len(aliases))
+		for _, alias := range aliases {
+			raw[alias] = "payments"
+		}
+		got, err := ResolveTenantID(claims(raw, "fallback"))
+		if err != nil || got != "payments" {
+			t.Fatalf("seed %d: got tenant=%q err=%v", seed, got, err)
+		}
+	}
+}
+
+func FuzzResolveTenantID(f *testing.F) {
+	f.Add("payments", "payments", "payments")
+	f.Add("payments", "analytics", "fallback")
+	f.Add("", "", "single-tenant")
+	f.Fuzz(func(t *testing.T, canonical, legacy, subject string) {
+		raw := map[string]any{}
+		if canonical != "" {
+			raw["tid"] = canonical
+		}
+		if legacy != "" {
+			raw["tenantId"] = legacy
+		}
+		resolved, err := ResolveTenantID(claims(raw, subject))
+		if err == nil && !tenantPattern.MatchString(resolved) {
+			t.Fatalf("accepted unsafe tenant %q", resolved)
+		}
+		if err == nil && canonical != "" && legacy != "" && strings.TrimSpace(canonical) != strings.TrimSpace(legacy) {
+			t.Fatalf("accepted conflicting claims canonical=%q legacy=%q", canonical, legacy)
+		}
+	})
+}
+
+func claims(raw map[string]any, subject string) *auth.Claims {
+	return &auth.Claims{Raw: raw, Subject: subject}
+}

--- a/internal/authclaims/tenant_test.go
+++ b/internal/authclaims/tenant_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/osvaldoandrade/codeq/pkg/auth"
 )
 
+const (
+	testPayments              = "payments"
+	testIdentity              = "identity"
+	testAnalytics             = "analytics"
+	testPlatform              = "platform"
+	testClaimTenantID         = "tenantId"
+	testClaimOrganizationID   = "organizationId"
+	testClaimOrganizationPath = "organization_id"
+)
+
 func TestResolveTenantIDCompatibilityMatrix(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -18,18 +28,18 @@ func TestResolveTenantIDCompatibilityMatrix(t *testing.T) {
 		wantErr error
 	}{
 		{name: "nil claims", wantErr: ErrTenantMissing},
-		{name: "canonical tid", claims: claims(map[string]any{"tid": " payments "}, "ignored"), want: "payments"},
-		{name: "firebase camel case", claims: claims(map[string]any{"tenantId": "identity"}, ""), want: "identity"},
-		{name: "snake case tenant", claims: claims(map[string]any{"tenant_id": "analytics"}, ""), want: "analytics"},
-		{name: "organization camel case", claims: claims(map[string]any{"organizationId": "platform"}, ""), want: "platform"},
-		{name: "organization snake case", claims: claims(map[string]any{"organization_id": "platform"}, ""), want: "platform"},
-		{name: "matching aliases", claims: claims(map[string]any{"tid": "payments", "tenantId": "payments", "organization_id": "payments"}, "other"), want: "payments"},
+		{name: "canonical tid", claims: claims(map[string]any{claimTID: " payments "}, "ignored"), want: testPayments},
+		{name: "firebase camel case", claims: claims(map[string]any{testClaimTenantID: testIdentity}, ""), want: testIdentity},
+		{name: "snake case tenant", claims: claims(map[string]any{claimTenantIDSnake: testAnalytics}, ""), want: testAnalytics},
+		{name: "organization camel case", claims: claims(map[string]any{testClaimOrganizationID: testPlatform}, ""), want: testPlatform},
+		{name: "organization snake case", claims: claims(map[string]any{testClaimOrganizationPath: testPlatform}, ""), want: testPlatform},
+		{name: "matching aliases", claims: claims(map[string]any{claimTID: testPayments, testClaimTenantID: testPayments, testClaimOrganizationPath: testPayments}, "other"), want: testPayments},
 		{name: "subject fallback", claims: claims(map[string]any{}, "single-tenant"), want: "single-tenant"},
-		{name: "canonical conflict", claims: claims(map[string]any{"tid": "payments", "tenantId": "analytics"}, "payments"), wantErr: ErrTenantConflict},
-		{name: "legacy conflict", claims: claims(map[string]any{"tenant_id": "payments", "organizationId": "analytics"}, "payments"), wantErr: ErrTenantConflict},
-		{name: "blank claim does not fall back", claims: claims(map[string]any{"tid": " "}, "payments"), wantErr: ErrTenantMalformed},
-		{name: "non-string claim", claims: claims(map[string]any{"tid": 7}, "payments"), wantErr: ErrTenantMalformed},
-		{name: "unsafe tenant", claims: claims(map[string]any{"tid": "../payments"}, "payments"), wantErr: ErrTenantMalformed},
+		{name: "canonical conflict", claims: claims(map[string]any{claimTID: testPayments, testClaimTenantID: testAnalytics}, testPayments), wantErr: ErrTenantConflict},
+		{name: "legacy conflict", claims: claims(map[string]any{claimTenantIDSnake: testPayments, testClaimOrganizationID: testAnalytics}, testPayments), wantErr: ErrTenantConflict},
+		{name: "blank claim does not fall back", claims: claims(map[string]any{claimTID: " "}, testPayments), wantErr: ErrTenantMalformed},
+		{name: "non-string claim", claims: claims(map[string]any{claimTID: 7}, testPayments), wantErr: ErrTenantMalformed},
+		{name: "unsafe tenant", claims: claims(map[string]any{claimTID: "../payments"}, testPayments), wantErr: ErrTenantMalformed},
 		{name: "missing subject and claims", claims: claims(nil, ""), wantErr: ErrTenantMissing},
 		{name: "unsafe subject fallback", claims: claims(nil, "user@example.com"), wantErr: ErrTenantMalformed},
 	}
@@ -49,17 +59,17 @@ func TestResolveTenantIDCompatibilityMatrix(t *testing.T) {
 
 func TestResolveTenantIDAliasOrderDoesNotChangeResult(t *testing.T) {
 	t.Parallel()
-	aliases := []string{"tid", "tenantId", "tenant_id", "organizationId", "organization_id"}
+	aliases := []string{claimTID, testClaimTenantID, claimTenantIDSnake, testClaimOrganizationID, testClaimOrganizationPath}
 	for seed := int64(0); seed < 100; seed++ {
 		rand.New(rand.NewSource(seed)).Shuffle(len(aliases), func(left, right int) {
 			aliases[left], aliases[right] = aliases[right], aliases[left]
 		})
 		raw := make(map[string]any, len(aliases))
 		for _, alias := range aliases {
-			raw[alias] = "payments"
+			raw[alias] = testPayments
 		}
 		got, err := ResolveTenantID(claims(raw, "fallback"))
-		if err != nil || got != "payments" {
+		if err != nil || got != testPayments {
 			t.Fatalf("seed %d: got tenant=%q err=%v", seed, got, err)
 		}
 	}
@@ -72,7 +82,7 @@ func FuzzResolveTenantID(f *testing.F) {
 	f.Fuzz(func(t *testing.T, canonical, legacy, subject string) {
 		raw := map[string]any{}
 		if canonical != "" {
-			raw["tid"] = canonical
+			raw[claimTID] = canonical
 		}
 		if legacy != "" {
 			raw["tenantId"] = legacy

--- a/internal/middleware/any_auth.go
+++ b/internal/middleware/any_auth.go
@@ -17,7 +17,7 @@ func AnyAuthMiddleware(workerValidator, producerValidator auth.Validator, cfg *c
 			if err == nil && len(claims.EventTypes) > 0 {
 				tenantID, tenantErr := extractTenantID(claims)
 				if tenantErr != nil {
-					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{tenantClaimsErrorKey: tenantClaimsErrorMessage})
 					return
 				}
 				c.Set("workerClaims", claims)
@@ -33,7 +33,7 @@ func AnyAuthMiddleware(workerValidator, producerValidator auth.Validator, cfg *c
 			if err == nil {
 				tenantID, tenantErr := extractTenantID(claims)
 				if tenantErr != nil {
-					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{tenantClaimsErrorKey: tenantClaimsErrorMessage})
 					return
 				}
 				setProducerContext(c, cfg, claims, tenantID)

--- a/internal/middleware/any_auth.go
+++ b/internal/middleware/any_auth.go
@@ -15,7 +15,13 @@ func AnyAuthMiddleware(workerValidator, producerValidator auth.Validator, cfg *c
 		if workerValidator != nil {
 			claims, err := validateBearer(workerValidator, c.GetHeader("Authorization"))
 			if err == nil && len(claims.EventTypes) > 0 {
+				tenantID, tenantErr := extractTenantID(claims)
+				if tenantErr != nil {
+					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+					return
+				}
 				c.Set("workerClaims", claims)
+				c.Set("tenantID", tenantID)
 				c.Set("authType", "worker")
 				c.Next()
 				return
@@ -25,7 +31,12 @@ func AnyAuthMiddleware(workerValidator, producerValidator auth.Validator, cfg *c
 		if producerValidator != nil {
 			claims, err := validateBearer(producerValidator, c.GetHeader("Authorization"))
 			if err == nil {
-				setProducerContext(c, cfg, claims)
+				tenantID, tenantErr := extractTenantID(claims)
+				if tenantErr != nil {
+					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+					return
+				}
+				setProducerContext(c, cfg, claims, tenantID)
 				c.Set("authType", "producer")
 				c.Next()
 				return

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -26,7 +26,12 @@ func AuthMiddleware(validator auth.Validator, cfg *config.Config) gin.HandlerFun
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 			return
 		}
-		setProducerContext(c, cfg, claims)
+		tenantID, err := extractTenantID(claims)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+			return
+		}
+		setProducerContext(c, cfg, claims, tenantID)
 		c.Next()
 	}
 }
@@ -42,7 +47,7 @@ func validateBearer(validator auth.Validator, authHeader string) (*auth.Claims, 
 	return validator.Validate(parts[1])
 }
 
-func setProducerContext(c *gin.Context, cfg *config.Config, claims *auth.Claims) {
+func setProducerContext(c *gin.Context, cfg *config.Config, claims *auth.Claims, tenantID string) {
 	c.Set("userClaims", claims)
 	email := strings.TrimSpace(claims.Email)
 	if email == "" {
@@ -62,7 +67,5 @@ func setProducerContext(c *gin.Context, cfg *config.Config, claims *auth.Claims)
 	}
 	c.Set("userRole", role)
 
-	// Extract tenant ID from JWT claims
-	tenantID := extractTenantID(claims)
 	c.Set("tenantID", tenantID)
 }

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -28,7 +28,7 @@ func AuthMiddleware(validator auth.Validator, cfg *config.Config) gin.HandlerFun
 		}
 		tenantID, err := extractTenantID(claims)
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{tenantClaimsErrorKey: tenantClaimsErrorMessage})
 			return
 		}
 		setProducerContext(c, cfg, claims, tenantID)

--- a/internal/middleware/tenant.go
+++ b/internal/middleware/tenant.go
@@ -6,6 +6,11 @@ import (
 	"github.com/osvaldoandrade/codeq/pkg/auth"
 )
 
+const (
+	tenantClaimsErrorKey     = "error"
+	tenantClaimsErrorMessage = "invalid tenant claims"
+)
+
 // GetTenantID extracts tenant ID from the request context
 func GetTenantID(c *gin.Context) string {
 	if v, ok := c.Get("tenantID"); ok {

--- a/internal/middleware/tenant.go
+++ b/internal/middleware/tenant.go
@@ -1,9 +1,8 @@
 package middleware
 
 import (
-	"strings"
-
 	"github.com/gin-gonic/gin"
+	"github.com/osvaldoandrade/codeq/internal/authclaims"
 	"github.com/osvaldoandrade/codeq/pkg/auth"
 )
 
@@ -17,30 +16,8 @@ func GetTenantID(c *gin.Context) string {
 	return ""
 }
 
-// extractTenantID extracts tenant ID from JWT claims
-func extractTenantID(claims *auth.Claims) string {
-	if claims == nil || claims.Raw == nil {
-		return ""
-	}
-
-	// Try multiple common claim names for tenant ID
-	tenantID := ""
-	if v, ok := claims.Raw["tid"].(string); ok {
-		tenantID = strings.TrimSpace(v)
-	} else if v, ok := claims.Raw["tenantId"].(string); ok {
-		tenantID = strings.TrimSpace(v)
-	} else if v, ok := claims.Raw["tenant_id"].(string); ok {
-		tenantID = strings.TrimSpace(v)
-	} else if v, ok := claims.Raw["organizationId"].(string); ok {
-		tenantID = strings.TrimSpace(v)
-	} else if v, ok := claims.Raw["organization_id"].(string); ok {
-		tenantID = strings.TrimSpace(v)
-	}
-
-	// Fall back to using subject as tenant for single-tenant scenarios
-	if tenantID == "" {
-		tenantID = strings.TrimSpace(claims.Subject)
-	}
-
-	return tenantID
+// extractTenantID keeps the middleware call site narrow while delegating the
+// canonical security policy to authclaims.
+func extractTenantID(claims *auth.Claims) (string, error) {
+	return authclaims.ResolveTenantID(claims)
 }

--- a/internal/middleware/tenant_test.go
+++ b/internal/middleware/tenant_test.go
@@ -1,21 +1,25 @@
 package middleware
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/osvaldoandrade/codeq/internal/authclaims"
 	"github.com/osvaldoandrade/codeq/pkg/auth"
 )
 
 func TestExtractTenantID(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name   string
-		claims *auth.Claims
-		want   string
+		name    string
+		claims  *auth.Claims
+		want    string
+		wantErr error
 	}{
-		{name: "nil claims", claims: nil, want: ""},
+		{name: "nil claims", claims: nil, wantErr: authclaims.ErrTenantMissing},
 		{name: "canonical tid", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": " payments "}}, want: "payments"},
-		{name: "tid has precedence", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": "payments", "tenantId": "identity"}}, want: "payments"},
+		{name: "matching aliases", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": "payments", "tenantId": "payments"}}, want: "payments"},
+		{name: "conflicting alias", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": "payments", "tenantId": "identity"}}, wantErr: authclaims.ErrTenantConflict},
 		{name: "firebase tenantId", claims: &auth.Claims{Raw: map[string]interface{}{"tenantId": "identity"}}, want: "identity"},
 		{name: "snake case tenant", claims: &auth.Claims{Raw: map[string]interface{}{"tenant_id": "analytics"}}, want: "analytics"},
 		{name: "organization", claims: &auth.Claims{Raw: map[string]interface{}{"organizationId": "platform"}}, want: "platform"},
@@ -24,7 +28,11 @@ func TestExtractTenantID(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			if got := extractTenantID(test.claims); got != test.want {
+			got, err := extractTenantID(test.claims)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("extractTenantID() error = %v, want %v", err, test.wantErr)
+			}
+			if got != test.want {
 				t.Fatalf("extractTenantID() = %q, want %q", got, test.want)
 			}
 		})

--- a/internal/middleware/tenant_test.go
+++ b/internal/middleware/tenant_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/osvaldoandrade/codeq/pkg/auth"
 )
 
+const (
+	testTenantPayments = "payments"
+	testClaimTID       = "tid"
+	testClaimTenantID  = "tenantId"
+	testTenantIdentity = "identity"
+	testSubject        = "user-1"
+)
+
 func TestExtractTenantID(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -17,10 +25,10 @@ func TestExtractTenantID(t *testing.T) {
 		wantErr error
 	}{
 		{name: "nil claims", claims: nil, wantErr: authclaims.ErrTenantMissing},
-		{name: "canonical tid", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": " payments "}}, want: "payments"},
-		{name: "matching aliases", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": "payments", "tenantId": "payments"}}, want: "payments"},
-		{name: "conflicting alias", claims: &auth.Claims{Subject: "user-1", Raw: map[string]interface{}{"tid": "payments", "tenantId": "identity"}}, wantErr: authclaims.ErrTenantConflict},
-		{name: "firebase tenantId", claims: &auth.Claims{Raw: map[string]interface{}{"tenantId": "identity"}}, want: "identity"},
+		{name: "canonical tid", claims: &auth.Claims{Subject: testSubject, Raw: map[string]interface{}{testClaimTID: " payments "}}, want: testTenantPayments},
+		{name: "matching aliases", claims: &auth.Claims{Subject: testSubject, Raw: map[string]interface{}{testClaimTID: testTenantPayments, testClaimTenantID: testTenantPayments}}, want: testTenantPayments},
+		{name: "conflicting alias", claims: &auth.Claims{Subject: testSubject, Raw: map[string]interface{}{testClaimTID: testTenantPayments, testClaimTenantID: testTenantIdentity}}, wantErr: authclaims.ErrTenantConflict},
+		{name: "firebase tenantId", claims: &auth.Claims{Raw: map[string]interface{}{testClaimTenantID: testTenantIdentity}}, want: testTenantIdentity},
 		{name: "snake case tenant", claims: &auth.Claims{Raw: map[string]interface{}{"tenant_id": "analytics"}}, want: "analytics"},
 		{name: "organization", claims: &auth.Claims{Raw: map[string]interface{}{"organizationId": "platform"}}, want: "platform"},
 		{name: "subject fallback", claims: &auth.Claims{Subject: "single-tenant", Raw: map[string]interface{}{}}, want: "single-tenant"},

--- a/internal/middleware/worker_auth.go
+++ b/internal/middleware/worker_auth.go
@@ -55,7 +55,7 @@ func WorkerAuthMiddleware(workerValidator, producerValidator auth.Validator, cfg
 
 		tenantID, err := extractTenantID(claims)
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{tenantClaimsErrorKey: tenantClaimsErrorMessage})
 			return
 		}
 		c.Set("tenantID", tenantID)

--- a/internal/middleware/worker_auth.go
+++ b/internal/middleware/worker_auth.go
@@ -53,8 +53,11 @@ func WorkerAuthMiddleware(workerValidator, producerValidator auth.Validator, cfg
 		}
 		c.Set("workerClaims", claims)
 
-		// Extract tenant ID from worker JWT claims
-		tenantID := extractTenantID(claims)
+		tenantID, err := extractTenantID(claims)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "invalid tenant claims"})
+			return
+		}
 		c.Set("tenantID", tenantID)
 
 		c.Next()

--- a/internal/producer/server.go
+++ b/internal/producer/server.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/osvaldoandrade/codeq/internal/authclaims"
 	"github.com/osvaldoandrade/codeq/internal/producer/producerpb"
 	"github.com/osvaldoandrade/codeq/internal/services"
 	"github.com/osvaldoandrade/codeq/pkg/auth"
@@ -110,7 +111,6 @@ func (s *streamSession) send(ev *producerpb.ServerEvent) error {
 	}
 }
 
-
 // Stream is the bidirectional rpc. First message MUST be Hello; the
 // server validates the token and replies with HelloAck. Subsequent
 // CreateTask events fan out to per-event goroutines so a slow Pebble
@@ -191,8 +191,12 @@ func (s *Server) handleHello(stream producerpb.ProducerStream_StreamServer) (*st
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "auth failed: %v", err)
 	}
+	tenantID, err := authclaims.ResolveTenantID(claims)
+	if err != nil {
+		return nil, status.Error(codes.PermissionDenied, "invalid tenant claims")
+	}
 	sess := newStreamSession(stream.Context(), stream)
-	sess.tenantID = tenantIDFromClaims(claims)
+	sess.tenantID = tenantID
 	sess.subject = claims.Subject
 	if err := sess.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_HelloAck{
 		HelloAck: &producerpb.HelloAck{TenantId: sess.tenantID, Subject: sess.subject},
@@ -273,25 +277,6 @@ func (s *Server) handleCreateBatch(ctx context.Context, sess *streamSession, req
 	_ = sess.send(&producerpb.ServerEvent{Event: &producerpb.ServerEvent_CreateAckBatch{
 		CreateAckBatch: &producerpb.CreateAckBatch{Acks: acks},
 	}})
-}
-
-// tenantIDFromClaims mirrors middleware/tenant.go's extractTenantID but
-// is duplicated here to avoid pulling the middleware (and its Gin deps)
-// into the gRPC server. Falls back to JWT subject for single-tenant.
-func tenantIDFromClaims(claims *auth.Claims) string {
-	if claims == nil {
-		return ""
-	}
-	if claims.Raw != nil {
-		for _, key := range []string{"tenantId", "tenant_id", "organizationId", "organization_id"} {
-			if v, ok := claims.Raw[key].(string); ok {
-				if t := strings.TrimSpace(v); t != "" {
-					return t
-				}
-			}
-		}
-	}
-	return strings.TrimSpace(claims.Subject)
 }
 
 // pre-flight check that the gRPC server interface is satisfied.

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/osvaldoandrade/codeq/internal/authclaims"
 	"github.com/osvaldoandrade/codeq/internal/services"
 	"github.com/osvaldoandrade/codeq/internal/worker/workerpb"
 	"github.com/osvaldoandrade/codeq/pkg/auth"
@@ -253,7 +254,10 @@ func (s *Server) handleHello(stream workerpb.WorkerStream_StreamServer) (*stream
 	if workerID == "" {
 		workerID = claims.Subject
 	}
-	tenantID := tenantIDFromClaims(claims)
+	tenantID, err := authclaims.ResolveTenantID(claims)
+	if err != nil {
+		return nil, status.Error(codes.PermissionDenied, "invalid tenant claims")
+	}
 
 	sess := newStreamSession(stream.Context(), stream)
 	sess.workerID = workerID
@@ -558,22 +562,6 @@ func validateWorkerClaims(claims *auth.Claims) error {
 		return errors.New("missing scope")
 	}
 	return nil
-}
-
-func tenantIDFromClaims(claims *auth.Claims) string {
-	if claims == nil {
-		return ""
-	}
-	if claims.Raw != nil {
-		for _, key := range []string{"tenantId", "tenant_id", "organizationId", "organization_id"} {
-			if v, ok := claims.Raw[key].(string); ok {
-				if tenantID := strings.TrimSpace(v); tenantID != "" {
-					return tenantID
-				}
-			}
-		}
-	}
-	return strings.TrimSpace(claims.Subject)
 }
 
 // resolveCommands intersects the worker's requested commands with the


### PR DESCRIPTION
## Summary

- make `tid` the canonical tenant claim while retaining documented legacy aliases
- reject missing, blank, non-string, unsafe, or conflicting tenant claims before queue access
- centralize tenant resolution across producer HTTP, worker HTTP, AnyAuth, producer gRPC, and worker gRPC
- restrict subject fallback to tokens with no tenant aliases and a safe DNS-label subject
- publish the compatibility ADR, deprecation plan, STRIDE threat model, and owner waiver record
- add compatibility, property, fuzz, and mutation evidence

## Validation

- `make test-short`
- targeted race tests for authclaims, middleware, producer, and worker
- `go vet ./...`
- tenant fuzz: 8.7 million executions in 10 seconds
- tenant mutation: 5 killed, 0 lived, 100% efficacy, 100% mutant coverage
- Gosec v2.28.0 on the new authclaims boundary: 0 findings

The repository-wide Gosec baseline still reports four existing integer-conversion findings in the worker server. Those findings are unchanged by this PR and remain tracked by #720; they are not suppressed here.

## Waiver and safety

The owner authorized merge without independent security and reviewer sign-offs and accepted the documented T4 residual risk. The ADR records the waiver without claiming independent approval.

No release, deployment, GCP resource, Kubernetes cluster, pod, or production workload was accessed or changed.

Fixes #719