### PR TITLE
fix(build): align Docker image with Go toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Why

The module and `.go-version` require Go 1.26.5, while the Docker build stage still used Go 1.25 with local toolchain selection. As a result, every image build failed during `go mod download` before compiling the server.

## Change

- align the Docker build image with the repository toolchain at Go 1.26.5

## Validation

- `docker build --progress=plain -t codeq-topic-admin:e2e .`
- disposable QueueTopic Kind E2E through code-admin-controller-queue:
  - tenant isolation
  - create and status
  - persistence across provider restart
  - update and idempotent replay
  - provider delete
- the repository-wide local test command was started but did not complete within several minutes; no test failure was emitted, and the remote CI suite remains authoritative

## Boundaries

- no runtime behavior or provider implementation changed
- no production cluster or registry was accessed
