### PR TITLE
Support composite authentication

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	_ "github.com/osvaldoandrade/codeq/pkg/auth/jwks"   // Register default JWKS auth provider
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/multi"  // Register bounded multi-provider auth
 	_ "github.com/osvaldoandrade/codeq/pkg/auth/static" // Register static token auth provider (dev/local)
 	"github.com/osvaldoandrade/codeq/pkg/config"
 	_ "github.com/osvaldoandrade/codeq/pkg/persistence/memory" // Register memory persistence plugin (testing)

--- a/pkg/auth/multi/validator.go
+++ b/pkg/auth/multi/validator.go
@@ -1,0 +1,62 @@
+// Package multi composes a bounded list of authentication providers. It is
+// intended for migrations where short-lived JWKS tokens and one local static
+// credential must coexist without weakening either validator.
+package multi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/osvaldoandrade/codeq/pkg/auth"
+)
+
+const maxProviders = 4
+
+type config struct {
+	Providers []auth.ProviderConfig `json:"providers"`
+}
+
+type validator struct {
+	providers []auth.Validator
+}
+
+func init() {
+	auth.RegisterProvider("multi", newValidatorFromJSON)
+}
+
+func newValidatorFromJSON(raw json.RawMessage) (auth.Validator, error) {
+	var cfg config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("multi auth: invalid config: %w", err)
+	}
+	if len(cfg.Providers) < 2 || len(cfg.Providers) > maxProviders {
+		return nil, fmt.Errorf("multi auth: providers must contain between 2 and %d entries", maxProviders)
+	}
+	result := &validator{providers: make([]auth.Validator, 0, len(cfg.Providers))}
+	for index, provider := range cfg.Providers {
+		provider.Type = strings.TrimSpace(provider.Type)
+		if provider.Type == "" || provider.Type == "multi" {
+			return nil, fmt.Errorf("multi auth: provider %d has an invalid type", index)
+		}
+		nested, err := auth.NewValidator(provider)
+		if err != nil {
+			return nil, fmt.Errorf("multi auth: configure provider %d: %w", index, err)
+		}
+		result.providers = append(result.providers, nested)
+	}
+	return result, nil
+}
+
+func (v *validator) Validate(token string) (*auth.Claims, error) {
+	var validationErrors []error
+	for _, provider := range v.providers {
+		claims, err := provider.Validate(token)
+		if err == nil {
+			return claims, nil
+		}
+		validationErrors = append(validationErrors, err)
+	}
+	return nil, fmt.Errorf("multi auth: token rejected by every provider: %w", errors.Join(validationErrors...))
+}

--- a/pkg/auth/multi/validator.go
+++ b/pkg/auth/multi/validator.go
@@ -49,6 +49,7 @@ func newValidatorFromJSON(raw json.RawMessage) (auth.Validator, error) {
 	return result, nil
 }
 
+// Validate accepts a token when any configured child validator accepts it.
 func (v *validator) Validate(token string) (*auth.Claims, error) {
 	var validationErrors []error
 	for _, provider := range v.providers {

--- a/pkg/auth/multi/validator_test.go
+++ b/pkg/auth/multi/validator_test.go
@@ -1,0 +1,53 @@
+package multi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/osvaldoandrade/codeq/pkg/auth"
+	_ "github.com/osvaldoandrade/codeq/pkg/auth/static"
+)
+
+func TestMultiValidatorAcceptsAnyConfiguredProvider(t *testing.T) {
+	raw := json.RawMessage(`{"providers":[
+		{"type":"static","config":{"token":"first","subject":"one"}},
+		{"type":"static","config":{"token":"second","subject":"two"}}
+	]}`)
+	instance, err := newValidatorFromJSON(raw)
+	if err != nil {
+		t.Fatalf("newValidatorFromJSON() error = %v", err)
+	}
+	for token, subject := range map[string]string{"first": "one", "second": "two"} {
+		claims, err := instance.Validate(token)
+		if err != nil || claims.Subject != subject {
+			t.Fatalf("Validate(%q) = %#v, %v", token, claims, err)
+		}
+	}
+	if _, err := instance.Validate("unknown"); err == nil || strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("rejected token error must not echo token: %v", err)
+	}
+}
+
+func TestMultiValidatorRejectsUnsafeComposition(t *testing.T) {
+	tests := []json.RawMessage{
+		json.RawMessage(`{"providers":[]}`),
+		json.RawMessage(`{"providers":[{"type":"static","config":{"token":"one"}}]}`),
+		json.RawMessage(`{"providers":[{"type":"multi","config":{}},{"type":"static","config":{"token":"one"}}]}`),
+	}
+	for _, raw := range tests {
+		if _, err := newValidatorFromJSON(raw); err == nil {
+			t.Fatalf("newValidatorFromJSON(%s) error = nil", raw)
+		}
+	}
+}
+
+func TestProviderRegistration(t *testing.T) {
+	raw := json.RawMessage(`{"providers":[
+		{"type":"static","config":{"token":"first","subject":"one"}},
+		{"type":"static","config":{"token":"second","subject":"two"}}
+	]}`)
+	if _, err := auth.NewValidator(auth.ProviderConfig{Type: "multi", Config: raw}); err != nil {
+		t.Fatalf("registered multi provider error = %v", err)
+	}
+}


### PR DESCRIPTION
## What changed

Adds a composite authentication provider that accepts the first successful configured validator and registers it in the server.

## Why

The local broker must accept both platform workload identity tokens and the existing bootstrap credential during migration.

## Impact

CodeQ can validate multiple explicit providers without weakening any individual validator.

## Validation

- targeted auth, configuration, and command package tests pass
- full local CodeQ publish and worker claim smoke passes

## Known test-host limitation

The repository-wide throughput suite exhausts the macOS ephemeral port range and fails with `can't assign requested address`; this is isolated to the saturation/benchmark tests and is not hidden.